### PR TITLE
Fix warning about assets commissioned before simulation start

### DIFF
--- a/docs/release_notes/upcoming.md
+++ b/docs/release_notes/upcoming.md
@@ -13,3 +13,15 @@ ready to be released, carry out the following steps:
   version
 
 -->
+
+## New features
+
+<!-- TODO -->
+
+## Breaking changes
+
+<!-- TODO -->
+
+## Bug fixes
+
+<!-- TODO -->

--- a/docs/release_notes/upcoming.md
+++ b/docs/release_notes/upcoming.md
@@ -24,4 +24,6 @@ ready to be released, carry out the following steps:
 
 ## Bug fixes
 
-<!-- TODO -->
+- Fix misleading warning message for assets decommissioned before simulation start ([#1259])
+
+[#1259]: https://github.com/EnergySystemsModellingLab/MUSE2/pull/1259

--- a/src/asset.rs
+++ b/src/asset.rs
@@ -340,8 +340,8 @@ impl Asset {
         let max_decommission_year =
             max_decommission_year.unwrap_or(commission_year + process_parameter.lifetime);
         ensure!(
-            max_decommission_year >= commission_year,
-            "Max decommission year must be after/same as commission year"
+            max_decommission_year > commission_year,
+            "Max decommission year must be greater than commission year"
         );
 
         Ok(Self {

--- a/src/asset/pool.rs
+++ b/src/asset/pool.rs
@@ -35,8 +35,8 @@ impl AssetPool {
             // Ignore assets that have already been decommissioned
             if asset.max_decommission_year() <= year {
                 warn!(
-                    "User asset '{}' with commission year {} was decommissioned in {}, before \
-                    the start of the simulation",
+                    "User asset '{}' with commission year {} with maximum decommission year {} \
+                    was decommissioned before start of the simulation",
                     asset.process_id(),
                     asset.commission_year,
                     asset.max_decommission_year

--- a/src/asset/pool.rs
+++ b/src/asset/pool.rs
@@ -35,11 +35,11 @@ impl AssetPool {
             // Ignore assets that have already been decommissioned
             if asset.max_decommission_year() <= year {
                 warn!(
-                    "Asset '{}' with commission year {} and lifetime {} was decommissioned before \
+                    "User asset '{}' with commission year {} was decommissioned in {}, before \
                     the start of the simulation",
                     asset.process_id(),
                     asset.commission_year,
-                    asset.process_parameter.lifetime
+                    asset.max_decommission_year
                 );
                 continue;
             }


### PR DESCRIPTION
# Description

Users are permitted to define assets in `assets.csv` that are decommissioned before the simulation starts. If this happens, users are warned, in case it was a mistake, but the warning message reports the process lifetime, which is misleading as `max_decommission_year` may be set to more or less than this value.

Instead of correcting the lifetime stated in the warning, I thought it was clearer to rewrite the message to include the decommission year directly.

(I just went through this issue with @mjademitchell and @AdrianDAlessandro as a demo.)

Fixes #1220.

## Type of change

- [x] Bug fix (non-breaking change to fix an issue)
- [ ] New feature (non-breaking change to add functionality)
- [ ] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [x] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`
- [ ] Update release notes for the latest release if this PR adds a new feature or fixes a bug
      present in the previous release

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
