### PR TITLE
point current dev version at index.html

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,6 +1,7 @@
 # For some reason these spurious links appear in some cargo doc-generated files
 ^file://.+/MUSE2/book/api/index\.html$
 ^file://.+/MUSE2/book/README\.html$
+^file://.+/MUSE2/docs/index\.html$
 
 # Some of these links give a 404, even though they're generated in the API docs. No idea why.
 ^https://docs.rs/erased-serde/

--- a/docs/templates/versions.md.jinja
+++ b/docs/templates/versions.md.jinja
@@ -2,7 +2,7 @@
 
 The MUSE2 documentation for different releases is available below.
 
-- [Current development version](./README.md)
+- [Current development version](index.html)
 {%- for release in releases %}
 - [{{ release }}](release/{{ release }}/index.html)
 {%- endfor %}


### PR DESCRIPTION
# Description

This works for me locally, although not sure how to test in production without merging, couple of thoughts I had along the way:
- In our current docs v2.1.0 is missing, do we need to set up the python scripts (`generate_versions_docs.py` and friends) to run in our release CI or something?
- Now that we are making releases, do we want `Making a release` section to our developer guide? Like a list of steps to follow when making a release.

Fixes #1254

## Type of change

- [X] Bug fix (non-breaking change to fix an issue)
- [ ] New feature (non-breaking change to add functionality)
- [ ] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [X] All tests pass: `$ cargo test`
- [X] The documentation builds and looks OK: `$ cargo doc`
- [ ] Update release notes for the latest release if this PR adds a new feature or fixes a bug
      present in the previous release

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
