### PR TITLE
Make semantics of asset comparisons consistent

### DIFF
--- a/src/asset.rs
+++ b/src/asset.rs
@@ -1035,12 +1035,7 @@ pub fn check_capacity_valid_for_asset(capacity: Capacity) -> Result<()> {
     Ok(())
 }
 
-/// A wrapper around [`Asset`] for storing references in maps.
-///
-/// If the asset has been commissioned, then comparison and hashing is done based on the asset ID,
-/// otherwise a combination of other parameters is used.
-///
-/// [`Ord`] is implemented for [`AssetRef`], but it will panic for non-commissioned assets.
+/// A wrapper containing a reference-counted [`Asset`]
 #[derive(Clone, Debug)]
 pub struct AssetRef(Rc<Asset>);
 
@@ -1048,6 +1043,21 @@ impl AssetRef {
     /// Make a mutable reference to the underlying [`Asset`]
     pub fn make_mut(&mut self) -> &mut Asset {
         Rc::make_mut(&mut self.0)
+    }
+
+    /// Get a representation of this [`AssetRef`] that can be used for comparisons
+    fn get_asset_cmp(&self) -> AssetCmp<'_> {
+        if let Some(id) = self.id() {
+            AssetCmp::WithID(id)
+        } else {
+            AssetCmp::WithoutID((
+                self.process_id(),
+                self.region_id(),
+                self.commission_year,
+                self.agent_id(),
+                self.group_id(),
+            ))
+        }
     }
 
     /// Apply a function to each of this asset's children, consuming the asset in the process.
@@ -1163,46 +1173,17 @@ impl Deref for AssetRef {
     }
 }
 
+impl Eq for AssetRef {}
+
 impl PartialEq for AssetRef {
     fn eq(&self, other: &Self) -> bool {
-        // For assets to be considered equal, they must have the same process, region, commission
-        // year and state
-        Rc::ptr_eq(&self.0.process, &other.0.process)
-            && self.0.region_id == other.0.region_id
-            && self.0.commission_year == other.0.commission_year
-            && self.0.state == other.0.state
+        self.get_asset_cmp() == other.get_asset_cmp()
     }
 }
 
-impl Eq for AssetRef {}
-
-impl Hash for AssetRef {
-    /// Hash an asset according to its state:
-    /// - Commissioned assets are hashed based on their ID alone
-    /// - Selected assets are hashed based on `process_id`, `region_id`, `commission_year` and
-    ///   `agent_id`
-    /// - Candidate assets are hashed based on `process_id`, `region_id` and `commission_year`
-    /// - Parent assets are hashed based on `agent_id` and `group_id`
-    /// - Future and Decommissioned assets cannot currently be hashed
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        match &self.0.state {
-            AssetState::Commissioned { id, .. } => {
-                // Hashed based on their ID alone, since this is sufficient to uniquely identify the
-                // asset
-                id.hash(state);
-            }
-            AssetState::Candidate | AssetState::Selected { .. } | AssetState::Parent { .. } => {
-                self.0.process.id.hash(state);
-                self.0.region_id.hash(state);
-                self.0.commission_year.hash(state);
-                self.0.agent_id().hash(state);
-                self.0.group_id().hash(state);
-            }
-            state => {
-                // We don't need to hash other types of asset
-                panic!("Cannot hash {state} assets");
-            }
-        }
+impl Ord for AssetRef {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.get_asset_cmp().cmp(&other.get_asset_cmp())
     }
 }
 
@@ -1212,10 +1193,29 @@ impl PartialOrd for AssetRef {
     }
 }
 
-impl Ord for AssetRef {
-    fn cmp(&self, other: &Self) -> Ordering {
-        self.id().unwrap().cmp(&other.id().unwrap())
+impl Hash for AssetRef {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.get_asset_cmp().hash(state);
     }
+}
+
+/// A data structure representing the fields of an [`Asset`] that should be used for comparisons.
+///
+/// For assets that have an ID (i.e. have been commissioned at some point), we can compare based on
+/// the ID. Otherwise, we fall back on comparing other properties. The combination of these
+/// properties should be unique within the simulation (e.g. for assets being input into dispatch).
+#[derive(PartialEq, PartialOrd, Eq, Ord, Hash)]
+enum AssetCmp<'a> {
+    WithID(AssetID),
+    WithoutID(
+        (
+            &'a ProcessID,
+            &'a RegionID,
+            u32,
+            Option<&'a AgentID>,
+            Option<AssetGroupID>,
+        ),
+    ),
 }
 
 /// Additional methods for iterating over assets

--- a/src/asset.rs
+++ b/src/asset.rs
@@ -120,7 +120,7 @@ pub enum AssetState {
 }
 
 /// An asset controlled by an agent.
-#[derive(Clone, PartialEq)]
+#[derive(Clone)]
 pub struct Asset {
     /// The status of the asset
     state: AssetState,

--- a/src/asset.rs
+++ b/src/asset.rs
@@ -1035,7 +1035,11 @@ pub fn check_capacity_valid_for_asset(capacity: Capacity) -> Result<()> {
     Ok(())
 }
 
-/// A wrapper containing a reference-counted [`Asset`]
+/// A wrapper containing a reference-counted [`Asset`].
+///
+/// [`AssetRef`] implements equality, ordering, and hashing using an [`AssetID`], if available, but
+/// otherwise using a combination of other fields which should be unique at all the relevant points
+/// in the simulation.
 #[derive(Clone, Debug)]
 pub struct AssetRef(Rc<Asset>);
 


### PR DESCRIPTION
# Description

`AssetRef` needs to implement `Ord`, `Eq` and `Hash` and we have to do this manually as opposed to deriving the traits. There are a couple of problems with the current implementations, however:

1. Under some circumstances, they panic (e.g. because the `AssetState` is one that we don't need to hash)
2. They are not consistent with one another (e.g. you can only sort commissioned assets, but you can test for equality of more types)

While this _might_ not cause problems with the code as it is, it is a fragile and bugprone setup and we may end up violating some invariant in the standard library somewhere at some point (e.g. see documentation for [`HashMap`](https://doc.rust-lang.org/std/collections/struct.HashMap.html)).

Let's make these implementations all consistent. The way I've done this is to define a separate `AssetCmp` enum, which contains just the properties we use for comparison and which derives `Ord`, `Eq`, `Hash` etc. The implementations of these traits for `AssetRef` can then just create `AssetCmp` objects as needed and then provide a thin wrapper around the derived implementation for `AssetCmp`. Another upside of this approach is it makes it easy to change the properties that are compared by just changing `AssetCmp`, rather than having to change the code in a bunch of different places.

One difference from the old code is that we are now comparing agent IDs and parent IDs (if present) for `Ord` and `Eq`, whereas before we didn't bother, but in practice, this won't change anything. Similarly, there were places where we compared assets' processes with `Rc::ptr_eq` but now use the process ID, but it shouldn't be a functional change in our code base.

Closes #1215.

## Type of change

- [x] Bug fix (non-breaking change to fix an issue)
- [ ] New feature (non-breaking change to add functionality)
- [x] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [x] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`
- [ ] Update release notes for the latest release if this PR adds a new feature or fixes a bug
      present in the previous release

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
