### PR TITLE
Fix: Extend timeout for docs deployment to 30 mins

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -19,7 +19,7 @@ jobs:
   build:
     name: Build docs
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 30
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6


### PR DESCRIPTION
# Description

It's currently timing out while trying to build all the old versions of the docs. This isn't normally an issue as much of this work is cached, but without the cache it apparently takes longer than the 10 mins limit we currently have. Extend it to 30 mins.

I've left the timeout for the link-checker workflow at 10 mins for now, even though that also involves building the docs, because it only builds the latest version of the docs, so shouldn't be as time consuming. We can always revise this.

Fixes #1265.

## Type of change

- [x] Bug fix (non-breaking change to fix an issue)
- [ ] New feature (non-breaking change to add functionality)
- [ ] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [x] Documentation (improve or add documentation)

## Key checklist

- [ ] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`
- [ ] Update release notes for the latest release if this PR adds a new feature or fixes a bug
      present in the previous release

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
