### PR TITLE
Show release notes for all versions of MUSE2 in old versions of docs

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -20,8 +20,10 @@
   - [Architecture and coding style](developer_guide/architecture_quickstart.md)
   - [Developing the documentation](developer_guide/docs.md)
 - [API documentation](./api/muse2/README.md)
+<!-- ANCHOR: release_notes -->
 - [Release notes](release_notes/README.md)
   - [MUSE2 v2.0.0 (October 14, 2025)](release_notes/v2.0.0.md)
   - [MUSE2 v2.1.0 (March 31, 2026)](release_notes/v2.1.0.md)
   - [Next unreleased version](release_notes/upcoming.md)
+<!-- ANCHOR_END: release_notes -->
 - [Other versions of documentation](versions.md)

--- a/docs/build_old_docs.py
+++ b/docs/build_old_docs.py
@@ -16,19 +16,43 @@ DOCS_DIR = REPO_ROOT / "docs"
 
 
 def clone_repo_to(dest: Path):
-    """Clone this repo somewhere else."""
+    """Make a bare clone of this repo somewhere else."""
     print(f"Making a copy of repo in {dest}")
-    sp.run(("git", "clone", REPO_ROOT, dest), check=True, capture_output=True)
+    sp.run(("git", "clone", "--bare", REPO_ROOT, dest), check=True, capture_output=True)
+
+
+def add_worktree_for_release(repo_path: Path, release: str) -> Path:
+    """Add a worktree for the current release.
+
+    Also tries to symlink to the cargo cache dir to speed up build times, if possible.
+    """
+    # Add new worktree
+    release_path = repo_path.parent / release
+    sp.run(
+        (
+            "git",
+            "-C",
+            str(repo_path),
+            "worktree",
+            "add",
+            release_path,
+            release,
+        ),
+        check=True,
+        capture_output=True,
+    )
 
     # Add a symlink to cargo cache dir
     try:
-        os.symlink(REPO_ROOT / "target", dest / "target")
+        os.symlink(REPO_ROOT / "target", release_path / "target")
     except (NotImplementedError, OSError):
         # Only newer versions of Windows support symlinks and these require the user to have
         # additional privileges (or to be in developer mode)
         print(
             "WARN: Could not create symlink to cache directory; cache will not be stored"
         )
+
+    return release_path
 
 
 def apply_patches_for_release(release: str, repo_path: Path) -> None:
@@ -41,22 +65,16 @@ def apply_patches_for_release(release: str, repo_path: Path) -> None:
 def build_docs_for_release(release: str, repo_path: Path, outdir: Path) -> None:
     """Build documentation for a given release."""
     print(f"Building docs for {release}")
-
-    # Check out release
-    sp.run(
-        ("git", "-C", str(repo_path), "checkout", release),
-        check=True,
-        capture_output=True,
-    )
+    release_path = add_worktree_for_release(repo_path, release)
 
     # Apply patches, if any
-    apply_patches_for_release(release, repo_path)
+    apply_patches_for_release(release, release_path)
 
     # Build docs
-    sp.run(("just", f"{repo_path!s}/build-docs"), check=True)
+    sp.run(("just", f"{release_path!s}/build-docs"), check=True)
 
     # Patch versions.html to redirect to main versions page
-    with (repo_path / "book" / "versions.html").open("w", encoding="utf-8") as f:
+    with (release_path / "book" / "versions.html").open("w", encoding="utf-8") as f:
         f.write(f"""<head>
     <meta http-equiv="Refresh" content="0; URL={DOCS_SITE_ROOT}/versions.html" />
 </head>""")
@@ -64,7 +82,7 @@ def build_docs_for_release(release: str, repo_path: Path, outdir: Path) -> None:
     # Move to output directory
     release_outdir = outdir / release
     print(f"Copying to {release_outdir}")
-    shutil.move((repo_path / "book"), release_outdir)
+    shutil.move((release_path / "book"), release_outdir)
 
 
 def build_old_docs() -> None:
@@ -74,7 +92,7 @@ def build_old_docs() -> None:
 
     # Clone this repo to a temporary directory
     with TemporaryDirectory() as tmpdir:
-        repo_path = Path(tmpdir)
+        repo_path = Path(tmpdir) / "MUSE2.git"
         clone_repo_to(repo_path)
 
         # Generate documentation for each previous release

--- a/docs/build_old_docs.py
+++ b/docs/build_old_docs.py
@@ -17,7 +17,7 @@ DOCS_DIR = REPO_ROOT / "docs"
 
 def clone_repo_to(dest: Path):
     """Clone this repo somewhere else."""
-    print("Making a copy of repo")
+    print(f"Making a copy of repo in {dest}")
     sp.run(("git", "clone", REPO_ROOT, dest), check=True, capture_output=True)
 
     # Add a symlink to cargo cache dir

--- a/docs/build_old_docs.py
+++ b/docs/build_old_docs.py
@@ -13,6 +13,8 @@ from release import get_releases
 DOCS_SITE_ROOT = "https://energysystemsmodellinglab.github.io/MUSE2"
 REPO_ROOT = Path(__file__).parent.parent.absolute()
 DOCS_DIR = REPO_ROOT / "docs"
+RELEASE_NOTES_START_ANCHOR = "ANCHOR: release_notes"
+RELEASE_NOTES_END_ANCHOR = "ANCHOR_END: release_notes"
 
 
 def clone_repo_to(dest: Path):
@@ -62,13 +64,66 @@ def apply_patches_for_release(release: str, repo_path: Path) -> None:
         sp.run(("git", "-C", str(repo_path), "am", str(patch_path)), check=True)
 
 
-def build_docs_for_release(release: str, repo_path: Path, outdir: Path) -> None:
+def patch_release_notes(release_path: Path, release_notes_toc: str) -> None:
+    """Use the latest version of release notes everywhere.
+
+    This means we can have release notes for newer versions linked to from old versions of the
+    documentation.
+    """
+    # Patch in the contents of release_notes_toc between the anchors
+    new_summary = ""
+    found_start_anchor = False
+    summary_path = release_path / "docs" / "SUMMARY.md"
+    with summary_path.open(encoding="utf-8") as f:
+        lines = iter(f.readlines())
+
+        for line in lines:
+            if RELEASE_NOTES_START_ANCHOR in line:
+                assert not found_start_anchor
+                found_start_anchor = True
+                new_summary += release_notes_toc
+
+                # Skip ahead until we find end anchor
+                try:
+                    next(line for line in lines if RELEASE_NOTES_END_ANCHOR in line)
+                except StopIteration:
+                    raise RuntimeError(
+                        "End anchor for release notes not found in SUMMARY.md"
+                    )
+            else:
+                new_summary += line
+        if not found_start_anchor:
+            raise RuntimeError("Start anchor for release notes not found in SUMMARY.md")
+    with summary_path.open("w", encoding="utf-8") as f:
+        f.write(new_summary)
+
+    # Replace release_notes dir with symlink/copy of version in main repo
+    release_notes_path = release_path / "docs" / "release_notes"
+    if release_notes_path.exists():
+        shutil.rmtree(release_notes_path)
+    try:
+        os.symlink(
+            DOCS_DIR / "release_notes", release_notes_path, target_is_directory=True
+        )
+    except (NotImplementedError, OSError):
+        # Only newer versions of Windows support symlinks and these require the user to have
+        # additional privileges (or to be in developer mode)
+        print("WARN: Could not create symlink to release notes. Falling back on copy.")
+        shutil.copytree(DOCS_DIR / "release_notes", release_notes_path)
+
+
+def build_docs_for_release(
+    release: str, release_notes_toc: str, repo_path: Path, outdir: Path
+) -> None:
     """Build documentation for a given release."""
     print(f"Building docs for {release}")
     release_path = add_worktree_for_release(repo_path, release)
 
     # Apply patches, if any
     apply_patches_for_release(release, release_path)
+
+    # Use release notes from main version of docs
+    patch_release_notes(release_path, release_notes_toc)
 
     # Build docs
     sp.run(("just", f"{release_path!s}/build-docs"), check=True)
@@ -85,8 +140,31 @@ def build_docs_for_release(release: str, repo_path: Path, outdir: Path) -> None:
     shutil.move((release_path / "book"), release_outdir)
 
 
+def read_release_notes_toc() -> str:
+    """Read the release notes section from SUMMARY.md."""
+    with (DOCS_DIR / "SUMMARY.md").open(encoding="utf-8") as f:
+        lines = iter(f.readlines())
+
+        # Skip ahead until we find start anchor
+        try:
+            next(line for line in lines if RELEASE_NOTES_START_ANCHOR in line)
+        except StopIteration:
+            raise RuntimeError("Start anchor for release notes not found in SUMMARY.md")
+
+        # Append lines to output until we find end anchor
+        out = ""
+        for line in lines:
+            if RELEASE_NOTES_END_ANCHOR in line:
+                return out
+            out += line
+
+        raise RuntimeError("End anchor for release notes not found in SUMMARY.md")
+
+
 def build_old_docs() -> None:
     """Build documentation for previous releases."""
+    release_notes_toc = read_release_notes_toc()
+
     outdir = REPO_ROOT / "book" / "release"
     outdir.mkdir(parents=True, exist_ok=True)
 
@@ -97,7 +175,7 @@ def build_old_docs() -> None:
 
         # Generate documentation for each previous release
         for release in get_releases():
-            build_docs_for_release(release, repo_path, outdir)
+            build_docs_for_release(release, release_notes_toc, repo_path, outdir)
 
 
 if __name__ == "__main__":

--- a/docs/build_old_docs.py
+++ b/docs/build_old_docs.py
@@ -79,7 +79,10 @@ def patch_release_notes(release_path: Path, release_notes_toc: str) -> None:
 
         for line in lines:
             if RELEASE_NOTES_START_ANCHOR in line:
-                assert not found_start_anchor
+                if found_start_anchor:
+                    raise RuntimeError(
+                        "Multiple start anchors for release notes found in SUMMARY.md"
+                    )
                 found_start_anchor = True
                 new_summary += release_notes_toc
 

--- a/docs/build_old_docs.py
+++ b/docs/build_old_docs.py
@@ -46,7 +46,9 @@ def add_worktree_for_release(repo_path: Path, release: str) -> Path:
 
     # Add a symlink to cargo cache dir
     try:
-        os.symlink(REPO_ROOT / "target", release_path / "target")
+        os.symlink(
+            REPO_ROOT / "target", release_path / "target", target_is_directory=True
+        )
     except (NotImplementedError, OSError):
         # Only newer versions of Windows support symlinks and these require the user to have
         # additional privileges (or to be in developer mode)

--- a/docs/release/__init__.py
+++ b/docs/release/__init__.py
@@ -2,6 +2,7 @@
 
 import re
 import subprocess as sp
+from pathlib import Path
 
 
 def is_release_tag(tag: str) -> bool:
@@ -14,8 +15,10 @@ def is_release_tag(tag: str) -> bool:
 
 def get_releases() -> list[str]:
     """Get all release tags for this repo, sorted by semantic version."""
+
+    repo_path = Path(__file__).parent
     ret = sp.run(
-        ("git", "tag", "-l", "--sort=-version:refname"),
+        ("git", "-C", str(repo_path), "tag", "-l", "--sort=-version:refname"),
         capture_output=True,
         check=True,
         encoding="utf-8",

--- a/docs/release/patches/v2.0.0/0002-Add-placeholder-other-versions-of-docs-chapter.patch
+++ b/docs/release/patches/v2.0.0/0002-Add-placeholder-other-versions-of-docs-chapter.patch
@@ -1,0 +1,21 @@
+From e0638c6639a5ce322977cafdb4d06b656cd77cb7 Mon Sep 17 00:00:00 2001
+From: Alex Dewar <a.dewar@imperial.ac.uk>
+Date: Wed, 29 Apr 2026 14:43:12 +0100
+Subject: [PATCH] Add placeholder "other versions of docs" chapter
+
+This will redirect to the version in the main version of the docs when built.
+---
+ docs/SUMMARY.md | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/docs/SUMMARY.md b/docs/SUMMARY.md
+index 5a1d47bf..ab00b928 100644
+--- a/docs/SUMMARY.md
++++ b/docs/SUMMARY.md
+@@ -15,3 +15,4 @@
+   - [Model Diagrams](model/model_diagrams.md)
+ - [Glossary](glossary.md)
+ - [Developer Guide](developer_guide.md)
++- [Other versions of documentation](versions.md)
+--
+2.54.0

--- a/docs/release/patches/v2.0.0/0003-SUMMARY.md-Add-release-notes-anchors.patch
+++ b/docs/release/patches/v2.0.0/0003-SUMMARY.md-Add-release-notes-anchors.patch
@@ -1,0 +1,22 @@
+From 8d47c901fb3418a7e24ec3b37ba8e1c2300bcdf1 Mon Sep 17 00:00:00 2001
+From: Alex Dewar <a.dewar@imperial.ac.uk>
+Date: Wed, 29 Apr 2026 15:12:04 +0100
+Subject: [PATCH] SUMMARY.md: Add release notes anchors
+
+---
+ docs/SUMMARY.md | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/docs/SUMMARY.md b/docs/SUMMARY.md
+index ab00b928..eacb2987 100644
+--- a/docs/SUMMARY.md
++++ b/docs/SUMMARY.md
+@@ -15,4 +15,6 @@
+   - [Model Diagrams](model/model_diagrams.md)
+ - [Glossary](glossary.md)
+ - [Developer Guide](developer_guide.md)
++<!-- ANCHOR: release_notes -->
++<!-- ANCHOR_END: release_notes -->
+ - [Other versions of documentation](versions.md)
+--
+2.54.0

--- a/docs/release/patches/v2.1.0/0001-SUMMARY.md-Add-release-notes-anchors.patch
+++ b/docs/release/patches/v2.1.0/0001-SUMMARY.md-Add-release-notes-anchors.patch
@@ -1,0 +1,26 @@
+From 31ec589873fa67b152e9aa58cd3642596474930a Mon Sep 17 00:00:00 2001
+From: Alex Dewar <a.dewar@imperial.ac.uk>
+Date: Wed, 29 Apr 2026 15:13:20 +0100
+Subject: [PATCH] SUMMARY.md: Add release notes anchors
+
+---
+ docs/SUMMARY.md | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/docs/SUMMARY.md b/docs/SUMMARY.md
+index 78ff94c4..70511947 100644
+--- a/docs/SUMMARY.md
++++ b/docs/SUMMARY.md
+@@ -20,8 +20,10 @@
+   - [Architecture and coding style](developer_guide/architecture_quickstart.md)
+   - [Developing the documentation](developer_guide/docs.md)
+ - [API documentation](./api/muse2/README.md)
++<!-- ANCHOR: release_notes -->
+ - [Release notes](release_notes/README.md)
+   - [MUSE2 v2.0.0 (October 14, 2025)](release_notes/v2.0.0.md)
+   - [MUSE2 v2.1.0 (March 31, 2026)](release_notes/v2.1.0.md)
+   - [Next unreleased version](release_notes/upcoming.md)
++<!-- ANCHOR_END: release_notes -->
+ - [Other versions of documentation](versions.md)
+--
+2.54.0


### PR DESCRIPTION
# Description

When you navigate to an old version of the docs (since v2.1.0), there will be chapters for release notes for all the different versions of MUSE2 listed in the navigation bar, but it will only show the release notes that were bundled in the old version of the docs, i.e. no newer versions. For v2.0.0, there are no release notes included in the docs anyway, which is less of a problem, but only showing release notes for some versions of MUSE2 is potentially confusing. This isn't a problem now, but once we've released v2.2.0, the release notes for this won't appear in the docs for v2.1.0 etc., so we should fix it.

I've changed the `build_old_docs.py` script to substitute in the release notes from the dev version of the docs, so they should always be up to date. It does this by patching `SUMMARY.md` (which has the TOC) and symlinking/copying the `docs/release_notes` folder. I had to add a couple of patch files to the old versions of the docs to make this work, but we shouldn't need to do this going forward.

As part of this, I changed the way the git repo is used. Previously, we cloned the whole thing to a temp dir, then checked out the different versions one by one. Now that we're mucking about with the git tree by deleting files etc., it makes it messier to change between the different tags, so I switched to using a different worktree for each instead.

While I was at it, I fixed #1189.

Closes #1251. Closes #1189.

## Type of change

- [ ] Bug fix (non-breaking change to fix an issue)
- [ ] New feature (non-breaking change to add functionality)
- [ ] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [x] Documentation (improve or add documentation)

## Key checklist

- [ ] All tests pass: `$ cargo test`
- [x] The documentation builds and looks OK: `$ cargo doc`
- [ ] Update release notes for the latest release if this PR adds a new feature or fixes a bug
      present in the previous release

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
