### PR TITLE
Add lychee exception for gtr.ukri

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -14,3 +14,6 @@
 
 # Server often rejects connection (at least on GitHub runners)
 ^https://allcontributors.org
+
+# UKRI gateway tracker is unreliable
+^https://gtr.ukri.org


### PR DESCRIPTION
There appears to be problems with the UKRI gateway website which is breaking the link checker, specifically [this link](https://gtr.ukri.org/projects?ref=EP%2FX038823%2F2) in the README. 

I believe the website is just temporarily down, so we shouldn't need to change the link, but adding to `.lycheeignore` (as we've done for a few other sites) so this doesn't derail our CI.