### PR TITLE
Allow passing custom options to HiGHS via `model.toml`

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,3 +15,5 @@ For Rust code:
 - Test function names should not be prefixed with `test_`
 - Prefer using parameterised tests (using `rstest`) over separate ones where testing similar
   functionality
+- While this crate is a library, no one is using it as a library, so don't warn about breaking
+  changes to the external API

--- a/clippy.toml
+++ b/clippy.toml
@@ -4,3 +4,5 @@
 # The AssetRef type uses Rc<Asset> internally for shared ownership, but the hash
 # implementation is carefully designed to be consistent regardless of interior mutability
 ignore-interior-mutability = ["muse2::asset::AssetRef"]
+# Things that should not be treated as identifiers. The ".." represents the default options.
+doc-valid-idents = ["HiGHS", ".."]

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -18,6 +18,7 @@
   - [Setting up your development environment](developer_guide/setup.md)
   - [Building and developing MUSE2](developer_guide/coding.md)
   - [Architecture and coding style](developer_guide/architecture_quickstart.md)
+  - [Applying custom HiGHS options](developer_guide/custom_highs_options.md)
   - [Developing the documentation](developer_guide/docs.md)
 - [API documentation](./api/muse2/README.md)
 - [Release notes](release_notes/README.md)

--- a/docs/developer_guide/custom_highs_options.md
+++ b/docs/developer_guide/custom_highs_options.md
@@ -1,0 +1,35 @@
+# Applying custom HiGHS options
+
+As part of development, you may wish to directly set custom options for the HiGHS solver. Note that
+while some of these options will not affect results of simulations (e.g. to enable console logging
+for HiGHS), as we cannot guarantee this for all options, in order to use this feature, you have to
+set `please_give_me_broken_results = true` in your [`model.toml` file][model.toml].
+
+You can change any of the options exposed by the HiGHS solver; for more information, see [the HiGHS
+documentation][highs-opts].
+
+You can set options to be applied to all optimisations, just dispatch or just appraisal.
+
+Here is an example:
+
+```toml
+milestone_years = [2020, 2030, 2040]
+
+# These options are applied to all optimisations
+[highs.global_options]
+# These two options are required to be enabled to log to console
+log_to_console = true
+output_flag = true
+
+# These ones are just applied to dispatch
+[highs.dispatch_options]
+# Increase to higher than default
+primal_feasibility_tolerance = 10e-6
+
+# These ones are just applied to appraisal
+[highs.appraisal_options]
+optimality_tolerance = 10e-6
+```
+
+[model.toml]: https://energysystemsmodellinglab.github.io/MUSE2/file_formats/input_files.html#model-parameters-modeltoml
+[highs-opts]: https://ergo-code.github.io/HiGHS/stable/options/definitions/

--- a/docs/developer_guide/custom_highs_options.md
+++ b/docs/developer_guide/custom_highs_options.md
@@ -13,6 +13,7 @@ You can set options to be applied to all optimisations, just dispatch or just ap
 Here is an example:
 
 ```toml
+please_give_me_broken_results = true
 milestone_years = [2020, 2030, 2040]
 
 # These options are applied to all optimisations

--- a/docs/release_notes/upcoming.md
+++ b/docs/release_notes/upcoming.md
@@ -16,7 +16,7 @@ ready to be released, carry out the following steps:
 
 ## New features
 
-- Users can now optionally pass [custom options][highs-options] to the HiGHS solver [#1276]
+- Users can now optionally pass [custom options][highs-opts-docs] to the HiGHS solver [#1276]
 
 ## Breaking changes
 
@@ -26,6 +26,6 @@ ready to be released, carry out the following steps:
 
 - Fix misleading warning message for assets decommissioned before simulation start ([#1259])
 
-[highs-options]: https://ergo-code.github.io/HiGHS/stable/options/definitions/
+[highs-opts-docs]: https://energysystemsmodellinglab.github.io/MUSE2/developer_guide/custom_highs_options.html
 [#1259]: https://github.com/EnergySystemsModellingLab/MUSE2/pull/1259
 [#1276]: https://github.com/EnergySystemsModellingLab/MUSE2/pull/1276

--- a/docs/release_notes/upcoming.md
+++ b/docs/release_notes/upcoming.md
@@ -16,7 +16,7 @@ ready to be released, carry out the following steps:
 
 ## New features
 
-<!-- TODO -->
+- Users can now optionally pass [custom options][highs-options] to the HiGHS solver [#1276]
 
 ## Breaking changes
 
@@ -26,4 +26,6 @@ ready to be released, carry out the following steps:
 
 - Fix misleading warning message for assets decommissioned before simulation start ([#1259])
 
+[highs-options]: https://ergo-code.github.io/HiGHS/stable/options/definitions/
 [#1259]: https://github.com/EnergySystemsModellingLab/MUSE2/pull/1259
+[#1276]: https://github.com/EnergySystemsModellingLab/MUSE2/pull/1276

--- a/schemas/input/model.yaml
+++ b/schemas/input/model.yaml
@@ -59,5 +59,26 @@ properties:
       investment cycle. Changing the value of this parameter is potentially dangerous,
       so it requires setting `please_give_me_broken_results` to true.
     default: 1e-12
+  highs:
+    type: object
+    description: |
+      Used for setting custom HiGHS options. As this is unsafe, it requires setting
+      `please_give_me_broken_results` to true. For more information, see the relevant [section of
+      the developer documentation][highs-opts-docs].
+
+      [highs-opts-docs]: https://energysystemsmodellinglab.github.io/MUSE2/developer_guide/custom_highs_options.html
+    properties:
+      global_options:
+        type: object
+        description: HiGHS options applied to all optimisations
+        properties: {}
+      dispatch_options:
+        type: object
+        description: HiGHS options applied only to dispatch optimisations
+        properties: {}
+      appraisal_options:
+        type: object
+        description: HiGHS options applied only to appraisal optimisations
+        properties: {}
 
 required: [milestone_years]

--- a/src/model/parameters.rs
+++ b/src/model/parameters.rs
@@ -13,6 +13,7 @@ use log::warn;
 use serde::Deserialize;
 use std::path::Path;
 use std::sync::OnceLock;
+use toml::Table;
 
 const MODEL_PARAMETERS_FILE_NAME: &str = "model.toml";
 
@@ -98,6 +99,12 @@ pub struct ModelParameters {
     pub mothball_years: u32,
     /// Absolute tolerance when checking if remaining demand is close enough to zero
     pub remaining_demand_absolute_tolerance: Flow,
+    /// Options for the HiGHS solver.
+    ///
+    /// For a full list of options, see [the HiGHS documentation].
+    ///
+    /// [the HiGHS documentation]: https://ergo-code.github.io/HiGHS/stable/options/definitions/
+    pub highs: HighsOptions,
 }
 
 impl Default for ModelParameters {
@@ -117,7 +124,44 @@ impl Default for ModelParameters {
             capacity_margin: Dimensionless(0.2),
             mothball_years: 0,
             remaining_demand_absolute_tolerance: DEFAULT_REMAINING_DEMAND_ABSOLUTE_TOLERANCE,
+            highs: HighsOptions::default(),
         }
+    }
+}
+
+/// Defines the TOML table holding the sub-tables to define HiGHS options
+#[derive(Default, Deserialize)]
+#[serde(default)]
+pub struct HighsOptions {
+    /// HiGHS options applied to both dispatch and appraisal
+    global_options: Table,
+    /// HiGHS options applied only to dispatch
+    pub dispatch_options: Table,
+    /// HiGHS options applied only to appraisal
+    pub appraisal_options: Table,
+}
+
+impl HighsOptions {
+    /// Copy the options specified in `global_options` to `dispatch_options` and `appraisal_options`
+    fn apply_global_options(&mut self) {
+        let append_global_opts_to = |opts: &mut Table| {
+            for (option, value) in &self.global_options {
+                opts.entry(option).or_insert(value.clone());
+            }
+        };
+
+        append_global_opts_to(&mut self.dispatch_options);
+        append_global_opts_to(&mut self.appraisal_options);
+
+        // Now that we're finished with global options we can discard
+        self.global_options.clear();
+    }
+
+    /// Check whether any options have been set
+    pub fn is_empty(&self) -> bool {
+        self.global_options.is_empty()
+            && self.dispatch_options.is_empty()
+            && self.appraisal_options.is_empty()
     }
 }
 
@@ -195,6 +239,20 @@ fn check_capacity_margin(value: Dimensionless) -> Result<()> {
     Ok(())
 }
 
+/// Check the custom HiGHS options are valid.
+///
+/// Note that we cannot know whether the options specified exist and are of the correct type until
+/// we attempt to use them. We could check for types that are never valid (e.g. an array), but as
+/// we're checking later anyway, we don't bother.
+fn check_highs_options(dangerous_options_enabled: bool, highs: &HighsOptions) -> Result<()> {
+    ensure!(
+        dangerous_options_enabled || highs.is_empty(),
+        "Cannot set custom HiGHS options without enabling {ALLOW_DANGEROUS_OPTION_NAME}"
+    );
+
+    Ok(())
+}
+
 impl ModelParameters {
     /// Read a model file from the specified directory.
     ///
@@ -207,13 +265,16 @@ impl ModelParameters {
     /// The model file contents as a [`ModelParameters`] struct or an error if the file is invalid
     pub fn from_path<P: AsRef<Path>>(model_dir: P) -> Result<ModelParameters> {
         let file_path = model_dir.as_ref().join(MODEL_PARAMETERS_FILE_NAME);
-        let model_params: ModelParameters = read_toml(&file_path)?;
+        let mut model_params: ModelParameters = read_toml(&file_path)?;
 
         set_dangerous_model_options_flag(model_params.allow_dangerous_options);
 
         model_params
             .validate()
             .with_context(|| input_err_msg(file_path))?;
+
+        // Copy global options to other tables
+        model_params.highs.apply_global_options();
 
         Ok(model_params)
     }
@@ -255,6 +316,8 @@ impl ModelParameters {
             self.allow_dangerous_options,
             self.remaining_demand_absolute_tolerance,
         )?;
+
+        check_highs_options(self.allow_dangerous_options, &self.highs)?;
 
         Ok(())
     }

--- a/src/model/parameters.rs
+++ b/src/model/parameters.rs
@@ -63,7 +63,7 @@ fn set_dangerous_model_options_flag(enabled: bool) {
 ///
 /// NOTE: If you add or change a field in this struct, you must also update the schema in
 /// `schemas/input/model.yaml`.
-#[derive(Debug, Deserialize, PartialEq)]
+#[derive(Deserialize)]
 #[serde(default)]
 pub struct ModelParameters {
     /// Milestone years

--- a/src/model/parameters.rs
+++ b/src/model/parameters.rs
@@ -9,6 +9,7 @@ use crate::input::{
 };
 use crate::units::{Capacity, Dimensionless, Flow, MoneyPerFlow};
 use anyhow::{Context, Result, ensure};
+use itertools::Itertools;
 use log::warn;
 use serde::Deserialize;
 use std::path::Path;
@@ -157,6 +158,25 @@ impl HighsOptions {
         self.global_options.clear();
     }
 
+    /// Log custom HiGHS options set by user, if any
+    fn log_options(&self) {
+        fn log_highs_options(name: &str, options: &Table) {
+            if options.is_empty() {
+                return;
+            }
+
+            let options_str = options
+                .iter()
+                .format_with("\n  - ", |(opt, val), f| f(&format_args!("{opt} = {val}")))
+                .to_string();
+            warn!("Using custom HiGHS options for {name}:\n  - {options_str}");
+        }
+
+        log_highs_options("dispatch and appraisal", &self.global_options);
+        log_highs_options("dispatch only", &self.dispatch_options);
+        log_highs_options("appraisal only", &self.appraisal_options);
+    }
+
     /// Check whether any options have been set
     pub fn is_empty(&self) -> bool {
         self.global_options.is_empty()
@@ -272,6 +292,8 @@ impl ModelParameters {
         model_params
             .validate()
             .with_context(|| input_err_msg(file_path))?;
+
+        model_params.highs.log_options();
 
         // Copy global options to other tables
         model_params.highs.apply_global_options();

--- a/src/model/parameters.rs
+++ b/src/model/parameters.rs
@@ -11,7 +11,7 @@ use crate::units::{Capacity, Dimensionless, Flow, MoneyPerFlow};
 use anyhow::{Context, Result, ensure};
 use itertools::Itertools;
 use log::warn;
-use serde::Deserialize;
+use serde::{Deserialize, Deserializer};
 use std::path::Path;
 use std::sync::OnceLock;
 use toml::Table;
@@ -131,33 +131,52 @@ impl Default for ModelParameters {
 }
 
 /// Defines the TOML table holding the sub-tables to define HiGHS options
-#[derive(Default, Deserialize)]
-#[serde(default)]
+#[derive(Default)]
 pub struct HighsOptions {
-    /// HiGHS options applied to both dispatch and appraisal
-    global_options: Table,
-    /// HiGHS options applied only to dispatch
+    /// HiGHS options applied to dispatch optimisation
     pub dispatch_options: Table,
-    /// HiGHS options applied only to appraisal
+    /// HiGHS options applied to appraisal optimisation
     pub appraisal_options: Table,
 }
 
-impl HighsOptions {
-    /// Copy the options specified in `global_options` to `dispatch_options` and `appraisal_options`
-    fn apply_global_options(&mut self) {
-        let append_global_opts_to = |opts: &mut Table| {
-            for (option, value) in &self.global_options {
-                opts.entry(option).or_insert(value.clone());
+impl<'de> Deserialize<'de> for HighsOptions {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Default, Deserialize)]
+        #[serde(default)]
+        #[allow(clippy::struct_field_names)]
+        struct RawHighsOptions {
+            global_options: Table,
+            dispatch_options: Table,
+            appraisal_options: Table,
+        }
+
+        let RawHighsOptions {
+            global_options,
+            mut dispatch_options,
+            mut appraisal_options,
+        } = RawHighsOptions::deserialize(deserializer)?;
+
+        let append_global_options = |options: &mut Table| {
+            for (option, value) in &global_options {
+                options
+                    .entry(option.clone())
+                    .or_insert_with(|| value.clone());
             }
         };
+        append_global_options(&mut dispatch_options);
+        append_global_options(&mut appraisal_options);
 
-        append_global_opts_to(&mut self.dispatch_options);
-        append_global_opts_to(&mut self.appraisal_options);
-
-        // Now that we're finished with global options we can discard
-        self.global_options.clear();
+        Ok(Self {
+            dispatch_options,
+            appraisal_options,
+        })
     }
+}
 
+impl HighsOptions {
     /// Log custom HiGHS options set by user, if any
     fn log_options(&self) {
         fn log_highs_options(name: &str, options: &Table) {
@@ -172,16 +191,13 @@ impl HighsOptions {
             warn!("Using custom HiGHS options for {name}:\n  - {options_str}");
         }
 
-        log_highs_options("dispatch and appraisal", &self.global_options);
-        log_highs_options("dispatch only", &self.dispatch_options);
-        log_highs_options("appraisal only", &self.appraisal_options);
+        log_highs_options("dispatch", &self.dispatch_options);
+        log_highs_options("appraisal", &self.appraisal_options);
     }
 
     /// Check whether any options have been set
     pub fn is_empty(&self) -> bool {
-        self.global_options.is_empty()
-            && self.dispatch_options.is_empty()
-            && self.appraisal_options.is_empty()
+        self.dispatch_options.is_empty() && self.appraisal_options.is_empty()
     }
 }
 
@@ -285,7 +301,7 @@ impl ModelParameters {
     /// The model file contents as a [`ModelParameters`] struct or an error if the file is invalid
     pub fn from_path<P: AsRef<Path>>(model_dir: P) -> Result<ModelParameters> {
         let file_path = model_dir.as_ref().join(MODEL_PARAMETERS_FILE_NAME);
-        let mut model_params: ModelParameters = read_toml(&file_path)?;
+        let model_params: ModelParameters = read_toml(&file_path)?;
 
         set_dangerous_model_options_flag(model_params.allow_dangerous_options);
 
@@ -294,9 +310,6 @@ impl ModelParameters {
             .with_context(|| input_err_msg(file_path))?;
 
         model_params.highs.log_options();
-
-        // Copy global options to other tables
-        model_params.highs.apply_global_options();
 
         Ok(model_params)
     }
@@ -403,6 +416,105 @@ mod tests {
 
         let model_params = ModelParameters::from_path(dir.path()).unwrap();
         assert_eq!(model_params.milestone_years, [2020, 2100]);
+    }
+
+    #[test]
+    fn model_params_deserialisation_copies_highs_global_options() {
+        let model_params: ModelParameters = toml::from_str(
+            "
+            milestone_years = [2020, 2100]
+
+            [highs.global_options]
+            output_flag = true
+
+            [highs.dispatch_options]
+            log_to_console = false
+            ",
+        )
+        .unwrap();
+
+        assert_eq!(
+            model_params.highs.dispatch_options["output_flag"],
+            toml::Value::Boolean(true)
+        );
+        assert_eq!(
+            model_params.highs.dispatch_options["log_to_console"],
+            toml::Value::Boolean(false)
+        );
+        assert_eq!(
+            model_params.highs.appraisal_options["output_flag"],
+            toml::Value::Boolean(true)
+        );
+    }
+
+    #[test]
+    fn highs_options_deserialisation_copies_global_options() {
+        let highs: HighsOptions = toml::from_str(
+            "
+            [global_options]
+            output_flag = true
+            log_to_console = true
+
+            [dispatch_options]
+            primal_feasibility_tolerance = 1e-5
+
+            [appraisal_options]
+            optimality_tolerance = 1e-5
+            ",
+        )
+        .unwrap();
+
+        assert_eq!(
+            highs.dispatch_options["output_flag"],
+            toml::Value::Boolean(true)
+        );
+        assert_eq!(
+            highs.dispatch_options["log_to_console"],
+            toml::Value::Boolean(true)
+        );
+        assert_eq!(
+            highs.appraisal_options["output_flag"],
+            toml::Value::Boolean(true)
+        );
+        assert_eq!(
+            highs.appraisal_options["log_to_console"],
+            toml::Value::Boolean(true)
+        );
+    }
+
+    #[test]
+    fn highs_options_deserialisation_preserves_specific_options() {
+        let highs: HighsOptions = toml::from_str(
+            "
+            [global_options]
+            output_flag = true
+            log_to_console = true
+
+            [dispatch_options]
+            output_flag = false
+
+            [appraisal_options]
+            log_to_console = false
+            ",
+        )
+        .unwrap();
+
+        assert_eq!(
+            highs.dispatch_options["output_flag"],
+            toml::Value::Boolean(false)
+        );
+        assert_eq!(
+            highs.dispatch_options["log_to_console"],
+            toml::Value::Boolean(true)
+        );
+        assert_eq!(
+            highs.appraisal_options["output_flag"],
+            toml::Value::Boolean(true)
+        );
+        assert_eq!(
+            highs.appraisal_options["log_to_console"],
+            toml::Value::Boolean(false)
+        );
     }
 
     #[rstest]

--- a/src/simulation/investment/appraisal.rs
+++ b/src/simulation/investment/appraisal.rs
@@ -258,12 +258,12 @@ fn calculate_lcox(
     demand: &DemandMap,
 ) -> Result<AppraisalOutput> {
     let results = perform_optimisation(
+        model,
         asset,
         max_capacity,
         commodity,
         coefficients,
         demand,
-        &model.time_slice_info,
         highs::Sense::Minimise,
     )?;
 
@@ -296,12 +296,12 @@ fn calculate_npv(
     demand: &DemandMap,
 ) -> Result<AppraisalOutput> {
     let results = perform_optimisation(
+        model,
         asset,
         max_capacity,
         commodity,
         coefficients,
         demand,
-        &model.time_slice_info,
         highs::Sense::Maximise,
     )?;
 

--- a/src/simulation/investment/appraisal/optimisation.rs
+++ b/src/simulation/investment/appraisal/optimisation.rs
@@ -6,6 +6,7 @@ use super::constraints::{
 };
 use crate::asset::{AssetCapacity, AssetRef};
 use crate::commodity::Commodity;
+use crate::simulation::optimisation::ModelError;
 use crate::simulation::optimisation::solve_optimal;
 use crate::time_slice::{TimeSliceID, TimeSliceInfo};
 use crate::units::{Activity, Capacity, Flow};
@@ -150,7 +151,9 @@ pub fn perform_optimisation(
     );
 
     // Solve model
-    let solution = solve_optimal(problem.optimise(sense))?.get_solution();
+    let solution = solve_optimal(problem.optimise(sense))
+        .map_err(ModelError::into_anyhow)?
+        .get_solution();
     let solution_values = solution.columns();
     Ok(ResultsMap {
         // If the asset has a defined unit size, the capacity variable represents number of units,

--- a/src/simulation/investment/appraisal/optimisation.rs
+++ b/src/simulation/investment/appraisal/optimisation.rs
@@ -6,11 +6,13 @@ use super::constraints::{
 };
 use crate::asset::{AssetCapacity, AssetRef};
 use crate::commodity::Commodity;
+use crate::model::Model;
 use crate::simulation::optimisation::ModelError;
+use crate::simulation::optimisation::apply_highs_options_from_toml;
 use crate::simulation::optimisation::solve_optimal;
 use crate::time_slice::{TimeSliceID, TimeSliceInfo};
 use crate::units::{Activity, Capacity, Flow};
-use anyhow::Result;
+use anyhow::{Context, Result};
 use highs::{RowProblem as Problem, Sense};
 use indexmap::IndexMap;
 
@@ -127,12 +129,12 @@ fn add_constraints(
 /// The optimisation will use continuous or integer capacity variables depending on whether the
 /// asset has a defined unit size.
 pub fn perform_optimisation(
+    model: &Model,
     asset: &AssetRef,
     max_capacity: Option<AssetCapacity>,
     commodity: &Commodity,
     coefficients: &ObjectiveCoefficients,
     demand: &DemandMap,
-    time_slice_info: &TimeSliceInfo,
     sense: Sense,
 ) -> Result<ResultsMap> {
     // Create problem and add variables
@@ -147,11 +149,14 @@ pub fn perform_optimisation(
         commodity,
         &variables,
         demand,
-        time_slice_info,
+        &model.time_slice_info,
     );
 
     // Solve model
-    let solution = solve_optimal(problem.optimise(sense))
+    let mut highs_model = problem.optimise(sense);
+    apply_highs_options_from_toml(&mut highs_model, &model.parameters.highs.appraisal_options)
+        .context("Failed to apply custom HiGHS options to appraisal optimisation")?;
+    let solution = solve_optimal(highs_model)
         .map_err(ModelError::into_anyhow)?
         .get_solution();
     let solution_values = solution.columns();

--- a/src/simulation/optimisation.rs
+++ b/src/simulation/optimisation.rs
@@ -14,10 +14,11 @@ use crate::units::{
     Activity, Capacity, Dimensionless, Flow, Money, MoneyPerActivity, MoneyPerCapacity,
     MoneyPerFlow, Year,
 };
-use anyhow::{Result, anyhow, bail, ensure};
+use anyhow::{Context, Result, anyhow, bail, ensure};
 use highs::{HighsModelStatus, RowProblem as Problem, Sense};
 use indexmap::{IndexMap, IndexSet};
 use itertools::{chain, iproduct};
+use log::debug;
 use std::cell::Cell;
 use std::collections::HashMap;
 use std::error::Error;
@@ -408,6 +409,44 @@ impl fmt::Display for ModelError {
 
 impl Error for ModelError {}
 
+/// Apply the specified HiGHS options from a [`toml::Table`]
+pub fn apply_highs_options_from_toml(
+    model: &mut highs::Model,
+    options: &toml::Table,
+) -> Result<()> {
+    // Attempt to set an option, returning an error if it fails
+    macro_rules! try_set_opt {
+        ($option:expr, $value:expr) => {{
+            let option = $option.as_str();
+            let value = $value;
+
+            debug!("Setting HiGHS option \"{option}\" to \"{value}\"");
+            model
+                .try_set_option(option, value)
+                .map_err(|_| anyhow!("Invalid option name or value"))?;
+
+            Ok(())
+        }};
+    }
+
+    // Iterate through options, applying each in turn to the HiGHS model
+    for (option, value) in options {
+        match value {
+            toml::Value::String(value) => try_set_opt!(option, value.as_str()),
+            toml::Value::Integer(value) => match i32::try_from(*value) {
+                Ok(value) => try_set_opt!(option, value),
+                Err(_) => Err(anyhow!("Value out of range")),
+            },
+            toml::Value::Float(value) => try_set_opt!(option, *value),
+            toml::Value::Boolean(value) => try_set_opt!(option, *value),
+            _ => Err(anyhow!("HiGHS options cannot have this type")),
+        }
+        .with_context(|| format!("Failed to set option \"{option}\" to value \"{value}\""))?;
+    }
+
+    Ok(())
+}
+
 /// Try to solve the model, returning an error if the model is incoherent or result is non-optimal
 pub fn solve_optimal(model: highs::Model) -> Result<highs::SolvedModel, ModelError> {
     let solved = model
@@ -694,8 +733,11 @@ impl<'model, 'run> DispatchRun<'model, 'run> {
             self.year,
         );
 
-        // Solve model
-        let solution = solve_optimal(problem.optimise(Sense::Minimise))?;
+        // Create model and apply any user-supplied HiGHS options to it
+        let mut model = problem.optimise(Sense::Minimise);
+        apply_highs_options_from_toml(&mut model, &self.model.parameters.highs.dispatch_options)
+            .context("Failed to apply custom HiGHS options to dispatch optimisation")?;
+        let solution = solve_optimal(model)?;
 
         let solution = Solution {
             solution: solution.get_solution(),

--- a/src/simulation/optimisation.rs
+++ b/src/simulation/optimisation.rs
@@ -14,8 +14,8 @@ use crate::units::{
     Activity, Capacity, Dimensionless, Flow, Money, MoneyPerActivity, MoneyPerCapacity,
     MoneyPerFlow, Year,
 };
-use anyhow::{Result, bail, ensure};
-use highs::{HighsModelStatus, HighsStatus, RowProblem as Problem, Sense};
+use anyhow::{Result, anyhow, bail, ensure};
+use highs::{HighsModelStatus, RowProblem as Problem, Sense};
 use indexmap::{IndexMap, IndexSet};
 use itertools::{chain, iproduct};
 use std::cell::Cell;
@@ -371,23 +371,37 @@ impl Solution<'_> {
 }
 
 /// Defines the possible errors that can occur when running the solver
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub enum ModelError {
-    /// The model definition is incoherent.
-    ///
-    /// Users should not be able to trigger this error.
-    Incoherent(HighsStatus),
     /// An optimal solution could not be found
     NonOptimal(HighsModelStatus),
+    /// Another error occurred
+    Other(anyhow::Error),
+}
+
+impl From<anyhow::Error> for ModelError {
+    fn from(value: anyhow::Error) -> Self {
+        Self::Other(value)
+    }
+}
+
+impl ModelError {
+    /// Convert this error into an [`anyhow::Error`]
+    pub fn into_anyhow(self) -> anyhow::Error {
+        match self {
+            ModelError::NonOptimal(status) => anyhow!("Could not find optimal result: {status:?}"),
+            ModelError::Other(error) => error,
+        }
+    }
 }
 
 impl fmt::Display for ModelError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            ModelError::Incoherent(status) => write!(f, "Incoherent model: {status:?}"),
             ModelError::NonOptimal(status) => {
                 write!(f, "Could not find optimal result: {status:?}")
             }
+            ModelError::Other(error) => error.fmt(f),
         }
     }
 }
@@ -396,7 +410,9 @@ impl Error for ModelError {}
 
 /// Try to solve the model, returning an error if the model is incoherent or result is non-optimal
 pub fn solve_optimal(model: highs::Model) -> Result<highs::SolvedModel, ModelError> {
-    let solved = model.try_solve().map_err(ModelError::Incoherent)?;
+    let solved = model
+        .try_solve()
+        .map_err(|status| anyhow!("Incoherent model: {status:?}"))?;
 
     match solved.status() {
         HighsModelStatus::Optimal => Ok(solved),
@@ -603,9 +619,9 @@ impl<'model, 'run> DispatchRun<'model, 'run> {
                     the supplied assets could not meet the required demand. Demand was not met \
                     for the following markets: {}",
                     format_items_with_cap(markets)
-                )
+                );
             }
-            Err(err) => Err(err)?,
+            Err(err) => Err(err.into_anyhow()),
         }
     }
 

--- a/src/simulation/optimisation.rs
+++ b/src/simulation/optimisation.rs
@@ -461,6 +461,7 @@ fn get_parent_or_self(assets: &[AssetRef]) -> Vec<AssetRef> {
 /// For a detailed description, please see the [dispatch optimisation formulation][1].
 ///
 /// [1]: https://energysystemsmodellinglab.github.io/MUSE2/model/dispatch_optimisation.html
+#[must_use = "Must call run() method on DispatchRun struct"]
 pub struct DispatchRun<'model, 'run> {
     model: &'model Model,
     existing_assets: &'run [AssetRef],

--- a/src/simulation/optimisation.rs
+++ b/src/simulation/optimisation.rs
@@ -18,7 +18,6 @@ use anyhow::{Context, Result, anyhow, bail, ensure};
 use highs::{HighsModelStatus, RowProblem as Problem, Sense};
 use indexmap::{IndexMap, IndexSet};
 use itertools::{chain, iproduct};
-use log::debug;
 use std::cell::Cell;
 use std::collections::HashMap;
 use std::error::Error;
@@ -424,12 +423,8 @@ pub fn apply_highs_options_from_toml(
     // Attempt to set an option, returning an error if it fails
     macro_rules! try_set_opt {
         ($option:expr, $value:expr) => {{
-            let option = $option.as_str();
-            let value = $value;
-
-            debug!("Setting HiGHS option \"{option}\" to \"{value}\"");
             model
-                .try_set_option(option, value)
+                .try_set_option($option.as_str(), $value)
                 .map_err(|_| anyhow!("Invalid option name or value"))?;
 
             Ok(())

--- a/src/simulation/optimisation.rs
+++ b/src/simulation/optimisation.rs
@@ -407,7 +407,14 @@ impl fmt::Display for ModelError {
     }
 }
 
-impl Error for ModelError {}
+impl Error for ModelError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            ModelError::NonOptimal(_) => None,
+            ModelError::Other(error) => Some(error.as_ref()),
+        }
+    }
+}
 
 /// Apply the specified HiGHS options from a [`toml::Table`]
 pub fn apply_highs_options_from_toml(


### PR DESCRIPTION
# Description

The HiGHS solver provides [many options](https://ergo-code.github.io/HiGHS/stable/options/definitions/) to change its behaviour, but there is currently no mechanism for changing them within MUSE2. While we don't want ordinary users to be mucking around with things like tolerances, it's useful for development to be able to tweak them to see what happens.

Add a new optional `[highs]` section to the `model.toml` file, which lets users pass through options directly to the solver. I thought it was worth letting users change things separately for dispatch and appraisal, as these are different optimisation problems, so there are actually three subsections to `[highs]`: `[highs.global_options]`, `[highs.dispatch_options]` and `[highs.appraisal_options]`. Global options are applied to both optimisation types (for if e.g. you want to enable logging for HiGHS for both). As we can't be sure that the options changed won't do something odd, it's gated behind the `please_give_me_broken_results` setting, like we do for other potentially dangerous things.

An alternative way of implementing this would be to let users create a HiGHS config file then telling HiGHS to load this, but it seemed cleaner to just use the existing file we have for configuring models and not having to worry about another input format etc.

I've also added a short page to the docs to explain how to use this feature.

Closes #420.

## Type of change

- [ ] Bug fix (non-breaking change to fix an issue)
- [x] New feature (non-breaking change to add functionality)
- [ ] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [x] All tests pass: `$ cargo test`
- [x] The documentation builds and looks OK: `$ cargo doc`
- [ ] Update release notes for the latest release if this PR adds a new feature or fixes a bug
      present in the previous release

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
