### PR TITLE
Include version number in release artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
         archive_ext: [tar.gz]
-        archive_cmd: ["tar cf"]
+        archive_cmd: ["tar cfz"]
         include:
           - os: ubuntu-latest
             osname: linux

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,9 +57,9 @@ jobs:
         if: ${{ github.event_name == 'release' }}
         run: |
           cd muse2
-          ${{ matrix.archive_cmd }} ../muse2_${{ matrix.osname }}.${{ matrix.archive_ext }} *
+          ${{ matrix.archive_cmd }} ../muse2_${{ matrix.osname }}_${{ github.ref_name }}.${{ matrix.archive_ext }} *
       - name: Upload release artifacts
         if: ${{ github.event_name == 'release' }}
         uses: softprops/action-gh-release@v3
         with:
-          files: muse2_${{ matrix.osname }}.${{ matrix.archive_ext }}
+          files: muse2_${{ matrix.osname }}_${{ github.ref_name }}.${{ matrix.archive_ext }}


### PR DESCRIPTION
# Description

We currently call the release artifacts something like `muse2_linux.tar.gz` -- so we include the OS name, but not the version number. It's helpful to have the version number in there so you can see which version you have if you stumble across the file or want to download multiple different versions. This is common practice.

Update the release workflow accordingly. I'll also open a PR for the `muse2_data_analysis` repo as we'll need to update [this CI action](https://github.com/EnergySystemsModellingLab/muse2_data_analysis/blob/main/.github/actions/setup-muse2-release/action.yml) too (opened in draft here: https://github.com/EnergySystemsModellingLab/muse2_data_analysis/pull/64).

Once this is merged I'll rename the files for the existing releases for consistency.

Closes #1232.

## Type of change

- [ ] Bug fix (non-breaking change to fix an issue)
- [ ] New feature (non-breaking change to add functionality)
- [ ] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [ ] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`
- [ ] Update release notes for the latest release if this PR adds a new feature or fixes a bug
      present in the previous release

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
