### PR TITLE
Link checker: Ignore doi.org and zenodo.org

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -10,8 +10,10 @@
 ^http://www.adobe.com
 
 # Often times out
+^https://doi.org
 ^https://iea-etsap.org
 ^https://www.contributor-covenant.org
+^https://zenodo.org
 
 # Server often rejects connection (at least on GitHub runners)
 ^https://allcontributors.org

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -17,3 +17,6 @@
 
 # Server often rejects connection (at least on GitHub runners)
 ^https://allcontributors.org
+
+# UKRI gateway tracker is unreliable
+^https://gtr.ukri.org

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -4,19 +4,19 @@
 ^file://.+/MUSE2/docs/index\.html$
 
 # Some of these links give a 404, even though they're generated in the API docs. No idea why.
-^https://docs.rs/erased-serde/
+^https://docs\.rs/erased-serde/
 
 # Times out on GitHub runner
-^http://www.adobe.com
+^http://www\.adobe\.com/
 
 # Often times out
-^https://doi.org
-^https://iea-etsap.org
-^https://www.contributor-covenant.org
-^https://zenodo.org
+^https://doi\.org/
+^https://iea-etsap\.org/
+^https://www\.contributor-covenant\.org/
+^https://zenodo\.org/
 
 # Server often rejects connection (at least on GitHub runners)
-^https://allcontributors.org
+^https://allcontributors\.org/
 
 # UKRI gateway tracker is unreliable
-^https://gtr.ukri.org
+^https://gtr\.ukri\.org/


### PR DESCRIPTION
# Description

These often time out both locally and on CI and are currently causing CI jobs to fail.

I often can't access these domains even from my web browser. Not sure what the deal is. Let's just ignore them.

## Type of change

- [x] Bug fix (non-breaking change to fix an issue)
- [ ] New feature (non-breaking change to add functionality)
- [ ] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [ ] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`
- [ ] Update release notes for the latest release if this PR adds a new feature or fixes a bug
      present in the previous release

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
