### PR TITLE
Allow patches to be based on any example model

### DIFF
--- a/src/cli/example.rs
+++ b/src/cli/example.rs
@@ -100,7 +100,12 @@ fn handle_example_extract_command(name: &str, dest: Option<&Path>, patch: bool) 
 /// If `patch` is `true`, then the corresponding patched example will be extracted.
 fn extract_example(name: &str, patch: bool, dest: &Path) -> Result<()> {
     if patch {
-        let (base_example, file_patches, toml_patch) = get_patches(name)?;
+        let patch_info = get_patches(name)?;
+        let (base_example, file_patches, toml_patch) = (
+            &patch_info.base_example,
+            &patch_info.file_patches,
+            &patch_info.toml_patch,
+        );
         let example = Example::from_name(base_example)?;
 
         // First extract the example to a temp dir

--- a/src/cli/example.rs
+++ b/src/cli/example.rs
@@ -100,10 +100,8 @@ fn handle_example_extract_command(name: &str, dest: Option<&Path>, patch: bool) 
 /// If `patch` is `true`, then the corresponding patched example will be extracted.
 fn extract_example(name: &str, patch: bool, dest: &Path) -> Result<()> {
     if patch {
-        let (file_patches, toml_patch) = get_patches(name)?;
-
-        // NB: All patched models are based on `simple`, for now
-        let example = Example::from_name("simple").unwrap();
+        let (base_example, file_patches, toml_patch) = get_patches(name)?;
+        let example = Example::from_name(base_example)?;
 
         // First extract the example to a temp dir
         let example_tmp = TempDir::new().context("Failed to create temporary directory")?;

--- a/src/example/patches.rs
+++ b/src/example/patches.rs
@@ -6,7 +6,7 @@ use anyhow::{Context, Result};
 use std::{collections::BTreeMap, sync::LazyLock};
 
 /// Map of patches keyed by name, with the file patches and an optional TOML patch
-type PatchMap = BTreeMap<&'static str, (Vec<FilePatch>, Option<&'static str>)>;
+type PatchMap = BTreeMap<&'static str, (&'static str, Vec<FilePatch>, Option<&'static str>)>;
 
 /// The patches, keyed by name
 static PATCHES: LazyLock<PatchMap> = LazyLock::new(get_all_patches);
@@ -18,6 +18,7 @@ fn get_all_patches() -> PatchMap {
         (
             "simple_divisible",
             (
+                "simple",
                 vec![
                     FilePatch::new("processes.csv")
                         .with_deletion("RGASBR,Gas boiler,all,RSHEAT,2020,2040,1.0,")
@@ -30,6 +31,7 @@ fn get_all_patches() -> PatchMap {
         (
             "simple_npv",
             (
+                "simple",
                 vec![
                     FilePatch::new("agent_objectives.csv")
                         .with_deletion("A0_RES,all,lcox,,")
@@ -42,6 +44,7 @@ fn get_all_patches() -> PatchMap {
             // The simple example with electricity priced using marginal costs
             "simple_marginal",
             (
+                "simple",
                 vec![FilePatch::new("commodities.csv").with_replacement(&[
                     "id,description,type,time_slice_level,pricing_strategy,units",
                     "GASPRD,Gas produced,sed,season,shadow,PJ",
@@ -57,6 +60,7 @@ fn get_all_patches() -> PatchMap {
             // The simple example with gas commodities priced using full costs
             "simple_full",
             (
+                "simple",
                 vec![FilePatch::new("commodities.csv").with_replacement(&[
                     "id,description,type,time_slice_level,pricing_strategy,units",
                     "GASPRD,Gas produced,sed,season,full,PJ",
@@ -72,6 +76,7 @@ fn get_all_patches() -> PatchMap {
             // The simple example with electricity priced using average marginal costs
             "simple_marginal_average",
             (
+                "simple",
                 vec![FilePatch::new("commodities.csv").with_replacement(&[
                     "id,description,type,time_slice_level,pricing_strategy,units",
                     "GASPRD,Gas produced,sed,season,shadow,PJ",
@@ -87,6 +92,7 @@ fn get_all_patches() -> PatchMap {
             // The simple example with gas commodities priced using average full costs
             "simple_full_average",
             (
+                "simple",
                 vec![FilePatch::new("commodities.csv").with_replacement(&[
                     "id,description,type,time_slice_level,pricing_strategy,units",
                     "GASPRD,Gas produced,sed,season,full_average,PJ",
@@ -101,7 +107,7 @@ fn get_all_patches() -> PatchMap {
         // The simple example with the ironing-out loop turned on
         (
             "simple_ironing_out",
-            (vec![], Some("max_ironing_out_iterations = 10")),
+            ("simple", vec![], Some("max_ironing_out_iterations = 10")),
         ),
     ]
     .into_iter()
@@ -114,7 +120,9 @@ pub fn get_patch_names() -> impl Iterator<Item = &'static str> {
 }
 
 /// Get patches for the named patched example
-pub fn get_patches(name: &str) -> Result<&'static (Vec<FilePatch>, Option<&'static str>)> {
+pub fn get_patches(
+    name: &str,
+) -> Result<&'static (&'static str, Vec<FilePatch>, Option<&'static str>)> {
     PATCHES
         .get(name)
         .with_context(|| format!("Patched example '{name}' not found"))

--- a/src/example/patches.rs
+++ b/src/example/patches.rs
@@ -4,9 +4,44 @@
 use crate::patch::FilePatch;
 use anyhow::{Context, Result};
 use std::{collections::BTreeMap, sync::LazyLock};
+/// Holds patch information for a patched example model
+pub struct PatchInfo {
+    /// The base example to patch
+    pub base_example: &'static str,
+    /// File patches to apply to the base example
+    pub file_patches: Vec<FilePatch>,
+    /// An optional TOML patch to apply to the base example
+    pub toml_patch: Option<&'static str>,
+}
 
+impl PatchInfo {
+    /// Create a new `PatchInfo` with the specified base example, file patches, and optional TOML patch
+    pub fn new(
+        base_example: &'static str,
+        file_patches: Vec<FilePatch>,
+        toml_patch: Option<&'static str>,
+    ) -> Self {
+        Self {
+            base_example,
+            file_patches,
+            toml_patch,
+        }
+    }
+    /// Create a new `PatchInfo` with the specified base example, file patches, and TOML patch
+    pub fn new_with_toml_patch(
+        base_example: &'static str,
+        file_patches: Vec<FilePatch>,
+        toml_patch: &'static str,
+    ) -> Self {
+        Self {
+            base_example,
+            file_patches,
+            toml_patch: Some(toml_patch),
+        }
+    }
+}
 /// Map of patches keyed by name, with the file patches and an optional TOML patch
-type PatchMap = BTreeMap<&'static str, (&'static str, Vec<FilePatch>, Option<&'static str>)>;
+type PatchMap = BTreeMap<&'static str, PatchInfo>;
 
 /// The patches, keyed by name
 static PATCHES: LazyLock<PatchMap> = LazyLock::new(get_all_patches);
@@ -17,7 +52,7 @@ fn get_all_patches() -> PatchMap {
         // The simple example with gas boiler process made divisible
         (
             "simple_divisible",
-            (
+            PatchInfo::new(
                 "simple",
                 vec![
                     FilePatch::new("processes.csv")
@@ -30,7 +65,7 @@ fn get_all_patches() -> PatchMap {
         // The simple example with objective type set to NPV for one agent
         (
             "simple_npv",
-            (
+            PatchInfo::new(
                 "simple",
                 vec![
                     FilePatch::new("agent_objectives.csv")
@@ -43,7 +78,7 @@ fn get_all_patches() -> PatchMap {
         (
             // The simple example with electricity priced using marginal costs
             "simple_marginal",
-            (
+            PatchInfo::new(
                 "simple",
                 vec![FilePatch::new("commodities.csv").with_replacement(&[
                     "id,description,type,time_slice_level,pricing_strategy,units",
@@ -59,7 +94,7 @@ fn get_all_patches() -> PatchMap {
         (
             // The simple example with gas commodities priced using full costs
             "simple_full",
-            (
+            PatchInfo::new(
                 "simple",
                 vec![FilePatch::new("commodities.csv").with_replacement(&[
                     "id,description,type,time_slice_level,pricing_strategy,units",
@@ -75,7 +110,7 @@ fn get_all_patches() -> PatchMap {
         (
             // The simple example with electricity priced using average marginal costs
             "simple_marginal_average",
-            (
+            PatchInfo::new(
                 "simple",
                 vec![FilePatch::new("commodities.csv").with_replacement(&[
                     "id,description,type,time_slice_level,pricing_strategy,units",
@@ -91,7 +126,7 @@ fn get_all_patches() -> PatchMap {
         (
             // The simple example with gas commodities priced using average full costs
             "simple_full_average",
-            (
+            PatchInfo::new(
                 "simple",
                 vec![FilePatch::new("commodities.csv").with_replacement(&[
                     "id,description,type,time_slice_level,pricing_strategy,units",
@@ -107,7 +142,7 @@ fn get_all_patches() -> PatchMap {
         // The simple example with the ironing-out loop turned on
         (
             "simple_ironing_out",
-            ("simple", vec![], Some("max_ironing_out_iterations = 10")),
+            PatchInfo::new("simple", vec![], Some("max_ironing_out_iterations = 10")),
         ),
     ]
     .into_iter()
@@ -120,9 +155,7 @@ pub fn get_patch_names() -> impl Iterator<Item = &'static str> {
 }
 
 /// Get patches for the named patched example
-pub fn get_patches(
-    name: &str,
-) -> Result<&'static (&'static str, Vec<FilePatch>, Option<&'static str>)> {
+pub fn get_patches(name: &str) -> Result<&'static PatchInfo> {
     PATCHES
         .get(name)
         .with_context(|| format!("Patched example '{name}' not found"))

--- a/src/fixture.rs
+++ b/src/fixture.rs
@@ -47,7 +47,14 @@ pub(crate) use assert_error;
 ///
 /// If the patched model cannot be built, for whatever reason, this function will panic.
 pub(crate) fn build_patched_simple_tempdir(file_patches: Vec<FilePatch>) -> tempfile::TempDir {
-    ModelPatch::from_example("simple")
+    build_patched_tempdir("simple", file_patches)
+}
+
+pub(crate) fn build_patched_tempdir(
+    base_example: &str,
+    file_patches: Vec<FilePatch>,
+) -> tempfile::TempDir {
+    ModelPatch::from_example(base_example)
         .with_file_patches(file_patches)
         .build_to_tempdir()
         .unwrap()


### PR DESCRIPTION
# Description

Added a base example name field to the patch map so each patch can specify its own base model. Also added a generic `build_patched_tempdir` helper in fixture.rs so tests can patch any example, not just `simple`

Fixes #1080 

## Type of change

- [ ] Bug fix (non-breaking change to fix an issue)
- [ ] New feature (non-breaking change to add functionality)
- [ ] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [ ] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`
- [ ] Update release notes for the latest release if this PR adds a new feature or fixes a bug
      present in the previous release

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
