### PR TITLE
Add region key to `FlowMap`

### DIFF
--- a/src/output.rs
+++ b/src/output.rs
@@ -628,7 +628,7 @@ impl DataWriter {
 
     /// Write commodity flows to a CSV file
     pub fn write_flows(&mut self, milestone_year: u32, flow_map: &FlowMap) -> Result<()> {
-        for ((asset, commodity_id, time_slice), flow) in flow_map {
+        for ((asset, commodity_id, _region_id, time_slice), flow) in flow_map {
             let row = CommodityFlowRow {
                 milestone_year,
                 asset_id: asset.id().unwrap(),
@@ -720,11 +720,16 @@ mod tests {
     }
 
     #[rstest]
-    fn write_flows(assets: AssetPool, commodity_id: CommodityID, time_slice: TimeSliceID) {
+    fn write_flows(
+        assets: AssetPool,
+        commodity_id: CommodityID,
+        region_id: RegionID,
+        time_slice: TimeSliceID,
+    ) {
         let milestone_year = 2020;
         let asset = assets.iter().next().unwrap();
         let flow_map = indexmap! {
-            (asset.clone(), commodity_id.clone(), time_slice.clone()) => Flow(42.0)
+            (asset.clone(), commodity_id.clone(), region_id.clone(), time_slice.clone()) => Flow(42.0)
         };
 
         // Write a flow

--- a/src/simulation/investment.rs
+++ b/src/simulation/investment.rs
@@ -498,13 +498,9 @@ fn flatten_preset_demands_for_year(
 /// TODO: this is a very flawed approach. The proper solution might be for agents to consider
 /// multiple commodities simultaneously, but that would require substantial work to implement.
 fn update_net_demand_map(demand: &mut AllDemandMap, flows: &FlowMap, assets: &[AssetRef]) {
-    for ((asset, commodity_id, time_slice), flow) in flows {
+    for ((asset, commodity_id, region_id, time_slice), flow) in flows {
         if assets.contains(asset) {
-            let key = (
-                commodity_id.clone(),
-                asset.region_id().clone(),
-                time_slice.clone(),
-            );
+            let key = (commodity_id.clone(), region_id.clone(), time_slice.clone());
 
             // Only consider input flows and output flows from the primary output commodity
             // (excluding secondary outputs)

--- a/src/simulation/optimisation.rs
+++ b/src/simulation/optimisation.rs
@@ -28,7 +28,7 @@ mod constraints;
 use constraints::{ConstraintKeys, add_model_constraints};
 
 /// A map of commodity flows calculated during the optimisation
-pub type FlowMap = IndexMap<(AssetRef, CommodityID, TimeSliceID), Flow>;
+pub type FlowMap = IndexMap<(AssetRef, CommodityID, RegionID, TimeSliceID), Flow>;
 
 /// A decision variable in the optimisation
 ///
@@ -193,7 +193,12 @@ fn create_flow_map<'a>(
     for (asset, time_slice, activity) in activity {
         let n_units = Dimensionless(asset.num_children().unwrap_or(1) as f64);
         for flow in asset.iter_flows() {
-            let flow_key = (asset.clone(), flow.commodity.id.clone(), time_slice.clone());
+            let flow_key = (
+                asset.clone(),
+                flow.commodity.id.clone(),
+                asset.region_id().clone(),
+                time_slice.clone(),
+            );
             let flow_value = activity * flow.coeff / n_units;
             flows.insert(flow_key, flow_value);
         }
@@ -204,9 +209,19 @@ fn create_flow_map<'a>(
         if let Some(parent) = asset.parent() {
             for commodity_id in asset.iter_flows().map(|flow| &flow.commodity.id) {
                 for time_slice in time_slice_info.iter_ids() {
-                    let flow = flows[&(parent.clone(), commodity_id.clone(), time_slice.clone())];
+                    let flow = flows[&(
+                        parent.clone(),
+                        commodity_id.clone(),
+                        parent.region_id().clone(),
+                        time_slice.clone(),
+                    )];
                     flows.insert(
-                        (asset.clone(), commodity_id.clone(), time_slice.clone()),
+                        (
+                            asset.clone(),
+                            commodity_id.clone(),
+                            asset.region_id().clone(),
+                            time_slice.clone(),
+                        ),
                         flow,
                     );
                 }
@@ -215,7 +230,7 @@ fn create_flow_map<'a>(
     }
 
     // Remove all the parent assets
-    flows.retain(|(asset, _, _), _| !asset.is_parent());
+    flows.retain(|(asset, _, _, _), _| !asset.is_parent());
 
     flows
 }


### PR DESCRIPTION
# Description

Adds a region field to `FlowMap` to allow for the possibility of flow regions differing from the region of the asset. This will be necessary for trade as we'll probably want to store trade flows in this map as well. (Or will we... this map needs an asset key, so if we wanted trade processes to exist without assets, then trade flows would need to be stored in a different map. Not sure!)

Fixes #1309

## Type of change

- [ ] Bug fix (non-breaking change to fix an issue)
- [ ] New feature (non-breaking change to add functionality)
- [ ] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [ ] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`
- [ ] Update release notes for the latest release if this PR adds a new feature or fixes a bug
      present in the previous release

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
