### PR TITLE
Store process flows as a vec

### DIFF
--- a/src/asset.rs
+++ b/src/asset.rs
@@ -13,7 +13,6 @@ use crate::units::{
     MoneyPerCapacity, MoneyPerFlow, Year,
 };
 use anyhow::{Context, Result, ensure};
-use indexmap::IndexMap;
 use log::debug;
 use serde::{Deserialize, Serialize};
 use std::cell::Cell;
@@ -129,7 +128,7 @@ pub struct Asset {
     /// Activity limits for this asset
     activity_limits: Rc<ActivityLimits>,
     /// The commodity flows for this asset
-    flows: Rc<IndexMap<(CommodityID, RegionID), ProcessFlow>>,
+    flows: Rc<Vec<ProcessFlow>>,
     /// The [`ProcessParameter`] corresponding to the asset's region and commission year
     process_parameter: Rc<ProcessParameter>,
     /// The region in which the asset is located
@@ -653,17 +652,19 @@ impl Asset {
         commodity_id: &CommodityID,
         region_id: &RegionID,
     ) -> Option<&ProcessFlow> {
-        self.flows.get(&(commodity_id.clone(), region_id.clone()))
+        self.flows
+            .iter()
+            .find(|f| &f.commodity.id == commodity_id && &f.region_id == region_id)
     }
 
     /// Iterate over the asset's flows
     pub fn iter_flows(&self) -> impl Iterator<Item = &ProcessFlow> {
-        self.flows.values()
+        self.flows.iter()
     }
 
     /// Iterate over the asset's output SED/SVD flows
     pub fn iter_output_flows(&self) -> impl Iterator<Item = &ProcessFlow> {
-        self.flows.values().filter(|flow| {
+        self.flows.iter().filter(|flow| {
             flow.direction() == FlowDirection::Output
                 && matches!(
                     flow.commodity.kind,
@@ -676,7 +677,7 @@ impl Asset {
     pub fn primary_output(&self) -> Option<&ProcessFlow> {
         let commodity_id = self.process.primary_output.as_ref()?;
         self.flows
-            .values()
+            .iter()
             .find(|f| &f.commodity.id == commodity_id && f.direction() == FlowDirection::Output)
     }
 
@@ -1283,7 +1284,6 @@ mod tests {
         MoneyPerFlow,
     };
     use float_cmp::assert_approx_eq;
-    use indexmap::indexmap;
     use rstest::{fixture, rstest};
     use std::rc::Rc;
 
@@ -1303,8 +1303,7 @@ mod tests {
             kind: FlowType::Fixed,
             cost: MoneyPerFlow(0.0),
         };
-        let process_flows =
-            indexmap! { (commodity_rc.id.clone(), region_id.clone()) => process_flow.clone() };
+        let process_flows = vec![process_flow.clone()];
         let process_flows_map = process_flows_map(process.regions.clone(), Rc::new(process_flows));
         process.flows = process_flows_map;
 

--- a/src/asset.rs
+++ b/src/asset.rs
@@ -129,7 +129,7 @@ pub struct Asset {
     /// Activity limits for this asset
     activity_limits: Rc<ActivityLimits>,
     /// The commodity flows for this asset
-    flows: Rc<IndexMap<CommodityID, ProcessFlow>>,
+    flows: Rc<IndexMap<(CommodityID, RegionID), ProcessFlow>>,
     /// The [`ProcessParameter`] corresponding to the asset's region and commission year
     process_parameter: Rc<ProcessParameter>,
     /// The region in which the asset is located
@@ -647,9 +647,13 @@ impl Asset {
         self.total_capacity() * self.process.capacity_to_activity
     }
 
-    /// Get a specific process flow
-    pub fn get_flow(&self, commodity_id: &CommodityID) -> Option<&ProcessFlow> {
-        self.flows.get(commodity_id)
+    /// Get a specific process flow by commodity and flow region
+    pub fn get_flow_for_market(
+        &self,
+        commodity_id: &CommodityID,
+        region_id: &RegionID,
+    ) -> Option<&ProcessFlow> {
+        self.flows.get(&(commodity_id.clone(), region_id.clone()))
     }
 
     /// Iterate over the asset's flows
@@ -670,10 +674,10 @@ impl Asset {
 
     /// Get the primary output flow (if any) for this asset
     pub fn primary_output(&self) -> Option<&ProcessFlow> {
-        self.process
-            .primary_output
-            .as_ref()
-            .map(|commodity_id| &self.flows[commodity_id])
+        let commodity_id = self.process.primary_output.as_ref()?;
+        self.flows
+            .values()
+            .find(|f| &f.commodity.id == commodity_id && f.direction() == FlowDirection::Output)
     }
 
     /// Whether this asset has been commissioned
@@ -1249,12 +1253,13 @@ where
         self.filter(move |asset| asset.region_id == *region_id)
     }
 
-    /// Iterate over process flows affecting the given commodity
-    fn flows_for_commodity(
+    /// Iterate over process flows targeting the given market (commodity + flow region)
+    fn flows_for_market(
         self,
         commodity_id: &'a CommodityID,
+        region_id: &'a RegionID,
     ) -> impl Iterator<Item = (&'a AssetRef, &'a ProcessFlow)> + 'a {
-        self.filter_map(|asset| Some((asset, asset.get_flow(commodity_id)?)))
+        self.filter_map(|asset| Some((asset, asset.get_flow_for_market(commodity_id, region_id)?)))
     }
 }
 
@@ -1298,7 +1303,8 @@ mod tests {
             kind: FlowType::Fixed,
             cost: MoneyPerFlow(0.0),
         };
-        let process_flows = indexmap! { commodity_rc.id.clone() => process_flow.clone() };
+        let process_flows =
+            indexmap! { (commodity_rc.id.clone(), region_id.clone()) => process_flow.clone() };
         let process_flows_map = process_flows_map(process.regions.clone(), Rc::new(process_flows));
         process.flows = process_flows_map;
 

--- a/src/fixture.rs
+++ b/src/fixture.rs
@@ -24,8 +24,8 @@ use crate::units::{
     MoneyPerCapacity, MoneyPerCapacityPerYear, MoneyPerFlow, Year,
 };
 use anyhow::Result;
+use indexmap::IndexSet;
 use indexmap::indexmap;
-use indexmap::{IndexMap, IndexSet};
 use itertools::Itertools;
 use rstest::fixture;
 use std::collections::HashMap;
@@ -277,15 +277,15 @@ pub fn process_investment_constraints() -> ProcessInvestmentConstraintsMap {
 
 #[fixture]
 /// Create an empty set of `ProcessFlows` for a given region/year
-pub fn process_flows() -> Rc<IndexMap<(CommodityID, RegionID), ProcessFlow>> {
-    Rc::new(IndexMap::new())
+pub fn process_flows() -> Rc<Vec<ProcessFlow>> {
+    Rc::new(Vec::new())
 }
 
 #[fixture]
 /// Create a `ProcessFlowsMap` with the provided flows for each region/year
 pub fn process_flows_map(
     region_ids: IndexSet<RegionID>,
-    process_flows: Rc<IndexMap<(CommodityID, RegionID), ProcessFlow>>,
+    process_flows: Rc<Vec<ProcessFlow>>,
 ) -> ProcessFlowsMap {
     region_ids
         .into_iter()

--- a/src/fixture.rs
+++ b/src/fixture.rs
@@ -277,7 +277,7 @@ pub fn process_investment_constraints() -> ProcessInvestmentConstraintsMap {
 
 #[fixture]
 /// Create an empty set of `ProcessFlows` for a given region/year
-pub fn process_flows() -> Rc<IndexMap<CommodityID, ProcessFlow>> {
+pub fn process_flows() -> Rc<IndexMap<(CommodityID, RegionID), ProcessFlow>> {
     Rc::new(IndexMap::new())
 }
 
@@ -285,7 +285,7 @@ pub fn process_flows() -> Rc<IndexMap<CommodityID, ProcessFlow>> {
 /// Create a `ProcessFlowsMap` with the provided flows for each region/year
 pub fn process_flows_map(
     region_ids: IndexSet<RegionID>,
-    process_flows: Rc<IndexMap<CommodityID, ProcessFlow>>,
+    process_flows: Rc<IndexMap<(CommodityID, RegionID), ProcessFlow>>,
 ) -> ProcessFlowsMap {
     region_ids
         .into_iter()

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -74,10 +74,7 @@ impl Display for GraphEdge {
 /// returns its flows. It considers both the commission year and the process lifetime, since a
 /// process may operate for years after its commission window. If the process cannot be operating
 /// in the target region/year, `None` is returned.
-fn get_flow_for_year(
-    process: &Process,
-    target: (RegionID, u32),
-) -> Option<Rc<IndexMap<(CommodityID, RegionID), ProcessFlow>>> {
+fn get_flow_for_year(process: &Process, target: (RegionID, u32)) -> Option<Rc<Vec<ProcessFlow>>> {
     // If its already in the map, we return it
     if process.flows.contains_key(&target) {
         return process.flows.get(&target).cloned();
@@ -125,14 +122,14 @@ fn create_commodities_graph_for_region_year(
 
         // Get output nodes for the process
         let mut outputs: Vec<_> = flows
-            .values()
+            .iter()
             .filter(|flow| flow.direction() == FlowDirection::Output)
             .map(|flow| GraphNode::Commodity(flow.commodity.id.clone()))
             .collect();
 
         // Get input nodes for the process
         let mut inputs: Vec<_> = flows
-            .values()
+            .iter()
             .filter(|flow| flow.direction() == FlowDirection::Input)
             .map(|flow| GraphNode::Commodity(flow.commodity.id.clone()))
             .collect();

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -77,7 +77,7 @@ impl Display for GraphEdge {
 fn get_flow_for_year(
     process: &Process,
     target: (RegionID, u32),
-) -> Option<Rc<IndexMap<CommodityID, ProcessFlow>>> {
+) -> Option<Rc<IndexMap<(CommodityID, RegionID), ProcessFlow>>> {
     // If its already in the map, we return it
     if process.flows.contains_key(&target) {
         return process.flows.get(&target).cloned();

--- a/src/input/process/flow.rs
+++ b/src/input/process/flow.rs
@@ -199,7 +199,7 @@ where
                 .or_default();
             let existing = Rc::get_mut(flows_map)
                 .unwrap() // safe: there will only be one copy
-                .insert(commodity.id.clone(), process_flow)
+                .insert((commodity.id.clone(), region_id.clone()), process_flow)
                 .is_some();
             ensure!(
                 !existing,
@@ -276,8 +276,10 @@ fn validate_flows_and_update_primary_output(
 /// Infer the primary output.
 ///
 /// This is only possible if there is only one output flow for the process.
-fn infer_primary_output(map: &IndexMap<CommodityID, ProcessFlow>) -> Result<Option<CommodityID>> {
-    let mut iter = map.iter().filter_map(|(commodity_id, flow)| {
+fn infer_primary_output(
+    map: &IndexMap<(CommodityID, RegionID), ProcessFlow>,
+) -> Result<Option<CommodityID>> {
+    let mut iter = map.iter().filter_map(|((commodity_id, _), flow)| {
         (flow.direction() == FlowDirection::Output).then_some(commodity_id)
     });
 
@@ -296,16 +298,20 @@ fn infer_primary_output(map: &IndexMap<CommodityID, ProcessFlow>) -> Result<Opti
 
 /// Check the flows are correct for the specified primary output (or lack thereof)
 fn check_flows_primary_output(
-    flows_map: &IndexMap<CommodityID, ProcessFlow>,
+    flows_map: &IndexMap<(CommodityID, RegionID), ProcessFlow>,
     primary_output: Option<&CommodityID>,
 ) -> Result<()> {
     if let Some(primary_output) = primary_output {
-        let flow = flows_map.get(primary_output).with_context(|| {
-            format!("Primary output commodity '{primary_output}' isn't a process flow")
-        })?;
-
         ensure!(
-            flow.direction() == FlowDirection::Output,
+            flows_map
+                .keys()
+                .any(|(commodity_id, _)| commodity_id == primary_output),
+            "Primary output commodity '{primary_output}' isn't a process flow"
+        );
+        ensure!(
+            flows_map.values().any(|f| {
+                &f.commodity.id == primary_output && f.direction() == FlowDirection::Output
+            }),
             "Primary output commodity '{primary_output}' isn't an output flow",
         );
     } else {
@@ -341,16 +347,19 @@ fn validate_secondary_flows(
             .filter(|&y| process.years.contains(y))
             .collect();
 
-        // Get the non-primary io flows for all years, if any, arranged by (commodity, region)
+        // Get the non-primary io flows for all years, if any, arranged by (commodity, flow region)
         let iter = iproduct!(process.years.clone(), process.regions.iter());
         let mut flows: HashMap<(CommodityID, RegionID), Vec<&ProcessFlow>> = HashMap::new();
         let mut number_of_years: HashMap<(CommodityID, RegionID), u32> = HashMap::new();
         for (year, region_id) in iter {
             if let Some(commodity_map) = map.get(&(region_id.clone(), year)) {
-                let flow = commodity_map.iter().filter_map(|(commodity_id, flow)| {
-                    (Some(commodity_id) != process.primary_output.as_ref())
-                        .then_some(((commodity_id.clone(), region_id.clone()), flow))
-                });
+                let flow =
+                    commodity_map
+                        .iter()
+                        .filter_map(|((commodity_id, flow_region_id), flow)| {
+                            (Some(commodity_id) != process.primary_output.as_ref())
+                                .then_some(((commodity_id.clone(), flow_region_id.clone()), flow))
+                        });
 
                 for (key, value) in flow {
                     flows.entry(key.clone()).or_default().push(value);
@@ -427,7 +436,11 @@ mod tests {
         I: Clone + Iterator<Item = (CommodityID, ProcessFlow)>,
     {
         let years = years.unwrap_or(process.years.clone().collect());
-        let map: Rc<IndexMap<_, _>> = Rc::new(flows.collect());
+        let map: Rc<IndexMap<_, _>> = Rc::new(
+            flows
+                .map(|(commodity_id, flow)| ((commodity_id, flow.region_id.clone()), flow))
+                .collect(),
+        );
         let flows_inner = iproduct!(&process.regions, years)
             .map(|(region_id, year)| ((region_id.clone(), year), map.clone()))
             .collect();

--- a/src/input/process/flow.rs
+++ b/src/input/process/flow.rs
@@ -8,7 +8,7 @@ use crate::process::{
 use crate::region::{RegionID, parse_region_str};
 use crate::units::{FlowPerActivity, MoneyPerFlow};
 use anyhow::{Context, Result, bail, ensure};
-use indexmap::{IndexMap, IndexSet};
+use indexmap::IndexSet;
 use itertools::iproduct;
 use serde::Deserialize;
 use std::collections::HashMap;
@@ -94,7 +94,7 @@ fn validate_output_flows_units(flows_map: &HashMap<ProcessID, ProcessFlowsMap>) 
     for (process_id, process_flows) in flows_map {
         for ((region_id, year), flows) in process_flows {
             let sed_svd_output_units: IndexSet<&str> = flows
-                .values()
+                .iter()
                 .filter_map(|flow| {
                     let commodity = &flow.commodity;
                     (flow.coeff.value() > 0.0
@@ -194,13 +194,13 @@ where
                 kind: FlowType::Fixed,
                 cost: record.cost.unwrap_or(MoneyPerFlow(0.0)),
             };
-            let flows_map = region_year_map
+            let flows = region_year_map
                 .entry((region_id.clone(), year))
                 .or_default();
-            let existing = Rc::get_mut(flows_map)
-                .unwrap() // safe: there will only be one copy
-                .insert((commodity.id.clone(), region_id.clone()), process_flow)
-                .is_some();
+            let inner = Rc::get_mut(flows).unwrap(); // safe: there will only be one copy
+            let existing = inner
+                .iter()
+                .any(|f| f.commodity.id == commodity.id && f.region_id == *region_id);
             ensure!(
                 !existing,
                 "Duplicate process flow entry for region {}, year {} and commodity {}",
@@ -208,6 +208,7 @@ where
                 year,
                 commodity.id
             );
+            inner.push(process_flow);
         }
     }
 
@@ -276,11 +277,9 @@ fn validate_flows_and_update_primary_output(
 /// Infer the primary output.
 ///
 /// This is only possible if there is only one output flow for the process.
-fn infer_primary_output(
-    map: &IndexMap<(CommodityID, RegionID), ProcessFlow>,
-) -> Result<Option<CommodityID>> {
-    let mut iter = map.iter().filter_map(|((commodity_id, _), flow)| {
-        (flow.direction() == FlowDirection::Output).then_some(commodity_id)
+fn infer_primary_output(flows: &[ProcessFlow]) -> Result<Option<CommodityID>> {
+    let mut iter = flows.iter().filter_map(|flow| {
+        (flow.direction() == FlowDirection::Output).then_some(&flow.commodity.id)
     });
 
     let Some(first_output) = iter.next() else {
@@ -298,26 +297,24 @@ fn infer_primary_output(
 
 /// Check the flows are correct for the specified primary output (or lack thereof)
 fn check_flows_primary_output(
-    flows_map: &IndexMap<(CommodityID, RegionID), ProcessFlow>,
+    flows: &[ProcessFlow],
     primary_output: Option<&CommodityID>,
 ) -> Result<()> {
     if let Some(primary_output) = primary_output {
         ensure!(
-            flows_map
-                .keys()
-                .any(|(commodity_id, _)| commodity_id == primary_output),
+            flows.iter().any(|f| &f.commodity.id == primary_output),
             "Primary output commodity '{primary_output}' isn't a process flow"
         );
         ensure!(
-            flows_map.values().any(|f| {
+            flows.iter().any(|f| {
                 &f.commodity.id == primary_output && f.direction() == FlowDirection::Output
             }),
             "Primary output commodity '{primary_output}' isn't an output flow",
         );
     } else {
         ensure!(
-            flows_map
-                .values()
+            flows
+                .iter()
                 .all(|x| x.direction() == FlowDirection::Input
                     || x.direction() == FlowDirection::Zero),
             "First year is only inputs, but subsequent years have outputs, although no primary \
@@ -353,13 +350,10 @@ fn validate_secondary_flows(
         let mut number_of_years: HashMap<(CommodityID, RegionID), u32> = HashMap::new();
         for (year, region_id) in iter {
             if let Some(commodity_map) = map.get(&(region_id.clone(), year)) {
-                let flow =
-                    commodity_map
-                        .iter()
-                        .filter_map(|((commodity_id, flow_region_id), flow)| {
-                            (Some(commodity_id) != process.primary_output.as_ref())
-                                .then_some(((commodity_id.clone(), flow_region_id.clone()), flow))
-                        });
+                let flow = commodity_map.iter().filter_map(|flow| {
+                    (Some(&flow.commodity.id) != process.primary_output.as_ref())
+                        .then_some(((flow.commodity.id.clone(), flow.region_id.clone()), flow))
+                });
 
                 for (key, value) in flow {
                     flows.entry(key.clone()).or_default().push(value);
@@ -410,7 +404,6 @@ mod tests {
     use crate::process::{FlowType, Process, ProcessFlow, ProcessMap};
     use crate::time_slice::TimeSliceLevel;
     use crate::units::{FlowPerActivity, MoneyPerFlow};
-    use indexmap::IndexMap;
     use itertools::Itertools;
     use map_macro::hash_map;
     use rstest::{fixture, rstest};
@@ -436,11 +429,7 @@ mod tests {
         I: Clone + Iterator<Item = (CommodityID, ProcessFlow)>,
     {
         let years = years.unwrap_or(process.years.clone().collect());
-        let map: Rc<IndexMap<_, _>> = Rc::new(
-            flows
-                .map(|(commodity_id, flow)| ((commodity_id, flow.region_id.clone()), flow))
-                .collect(),
-        );
+        let map: Rc<Vec<ProcessFlow>> = Rc::new(flows.map(|(_, flow)| flow).collect());
         let flows_inner = iproduct!(&process.regions, years)
             .map(|(region_id, year)| ((region_id.clone(), year), map.clone()))
             .collect();

--- a/src/process.rs
+++ b/src/process.rs
@@ -29,8 +29,11 @@ pub type ProcessParameterMap = HashMap<(RegionID, u32), Rc<ProcessParameter>>;
 
 /// A map of process flows, keyed by region and year.
 ///
-/// The value is actually a map itself, keyed by commodity ID.
-pub type ProcessFlowsMap = HashMap<(RegionID, u32), Rc<IndexMap<CommodityID, ProcessFlow>>>;
+/// The value is a map keyed by `(CommodityID, RegionID)`, where the `RegionID` is the
+/// region in which the flow occurs (the flow's target/source region, which may differ from
+/// the asset's own region for inter-region trade).
+pub type ProcessFlowsMap =
+    HashMap<(RegionID, u32), Rc<IndexMap<(CommodityID, RegionID), ProcessFlow>>>;
 
 /// Map of process investment constraints, keyed by region and year
 pub type ProcessInvestmentConstraintsMap =

--- a/src/process.rs
+++ b/src/process.rs
@@ -29,11 +29,8 @@ pub type ProcessParameterMap = HashMap<(RegionID, u32), Rc<ProcessParameter>>;
 
 /// A map of process flows, keyed by region and year.
 ///
-/// The value is a map keyed by `(CommodityID, RegionID)`, where the `RegionID` is the
-/// region in which the flow occurs (the flow's target/source region, which may differ from
-/// the asset's own region for inter-region trade).
-pub type ProcessFlowsMap =
-    HashMap<(RegionID, u32), Rc<IndexMap<(CommodityID, RegionID), ProcessFlow>>>;
+/// The value is a `Vec` of flows for a given asset region and commission year.
+pub type ProcessFlowsMap = HashMap<(RegionID, u32), Rc<Vec<ProcessFlow>>>;
 
 /// Map of process investment constraints, keyed by region and year
 pub type ProcessInvestmentConstraintsMap =

--- a/src/simulation/investment.rs
+++ b/src/simulation/investment.rs
@@ -951,8 +951,7 @@ mod tests {
             kind: FlowType::Fixed,
             cost: MoneyPerFlow(0.0),
         };
-        let process_flows =
-            indexmap! { (commodity_rc.id.clone(), RegionID::from("GBR")) => process_flow.clone() };
+        let process_flows = vec![process_flow.clone()];
         let process_flows_map = process_flows_map(process.regions.clone(), Rc::new(process_flows));
         process.flows = process_flows_map;
 
@@ -989,8 +988,7 @@ mod tests {
             kind: FlowType::Fixed,
             cost: MoneyPerFlow(0.0),
         };
-        let process_flows =
-            indexmap! { (commodity_rc.id.clone(), RegionID::from("GBR")) => process_flow.clone() };
+        let process_flows = vec![process_flow.clone()];
         let process_flows_map = process_flows_map(process.regions.clone(), Rc::new(process_flows));
         process.flows = process_flows_map;
 

--- a/src/simulation/investment.rs
+++ b/src/simulation/investment.rs
@@ -571,7 +571,10 @@ fn get_demand_limiting_capacity(
     commodity: &Commodity,
     demand: &DemandMap,
 ) -> Capacity {
-    let coeff = asset.get_flow(&commodity.id).unwrap().coeff;
+    let coeff = asset
+        .get_flow_for_market(&commodity.id, asset.region_id())
+        .unwrap()
+        .coeff;
     let mut capacity = Capacity(0.0);
 
     for time_slice_selection in time_slice_info.iter_selections_at_level(commodity.time_slice_level)
@@ -948,7 +951,8 @@ mod tests {
             kind: FlowType::Fixed,
             cost: MoneyPerFlow(0.0),
         };
-        let process_flows = indexmap! { commodity_rc.id.clone() => process_flow.clone() };
+        let process_flows =
+            indexmap! { (commodity_rc.id.clone(), RegionID::from("GBR")) => process_flow.clone() };
         let process_flows_map = process_flows_map(process.regions.clone(), Rc::new(process_flows));
         process.flows = process_flows_map;
 
@@ -985,7 +989,8 @@ mod tests {
             kind: FlowType::Fixed,
             cost: MoneyPerFlow(0.0),
         };
-        let process_flows = indexmap! { commodity_rc.id.clone() => process_flow.clone() };
+        let process_flows =
+            indexmap! { (commodity_rc.id.clone(), RegionID::from("GBR")) => process_flow.clone() };
         let process_flows_map = process_flows_map(process.regions.clone(), Rc::new(process_flows));
         process.flows = process_flows_map;
 

--- a/src/simulation/investment/appraisal/constraints.rs
+++ b/src/simulation/investment/appraisal/constraints.rs
@@ -152,7 +152,10 @@ pub fn add_demand_constraints(
         let mut terms = Vec::new();
         for (time_slice, _) in ts_selection.iter(time_slice_info) {
             demand_for_ts_selection += demand[time_slice];
-            let flow_coeff = asset.get_flow(&commodity.id).unwrap().coeff;
+            let flow_coeff = asset
+                .get_flow_for_market(&commodity.id, asset.region_id())
+                .unwrap()
+                .coeff;
             terms.push((activity_vars[time_slice], flow_coeff.value()));
             terms.push((unmet_demand_vars[time_slice], 1.0));
         }

--- a/src/simulation/optimisation/constraints.rs
+++ b/src/simulation/optimisation/constraints.rs
@@ -145,11 +145,7 @@ where
             .time_slice_info
             .iter_selections_at_level(commodity.time_slice_level)
         {
-            for (asset, flow) in assets
-                .clone()
-                .filter_region(region_id)
-                .flows_for_commodity(commodity_id)
-            {
+            for (asset, flow) in assets.clone().flows_for_market(commodity_id, region_id) {
                 // If the commodity has a time slice level of season/annual, the constraint will
                 // cover multiple time slices
                 for (time_slice, _) in ts_selection.iter(&model.time_slice_info) {

--- a/src/simulation/prices.rs
+++ b/src/simulation/prices.rs
@@ -946,7 +946,7 @@ where
 
             // Costs will be weighted by output (activity * coefficient)
             let output_coeff = asset
-                .get_flow(&commodity_id)
+                .get_flow_for_market(&commodity_id, region_id)
                 .expect("Commodity should be an output flow for this asset")
                 .coeff;
             let output_weight = activity * output_coeff;
@@ -1183,7 +1183,7 @@ mod tests {
 
     #[allow(clippy::too_many_arguments)]
     fn build_process(
-        flows: IndexMap<CommodityID, ProcessFlow>,
+        flows: IndexMap<(CommodityID, RegionID), ProcessFlow>,
         region_id: &RegionID,
         year: u32,
         time_slice_info: &TimeSliceInfo,
@@ -1312,19 +1312,19 @@ mod tests {
 
         let mut flows = IndexMap::new();
         flows.insert(
-            a.id.clone(),
+            (a.id.clone(), region_id.clone()),
             build_process_flow(&a, -1.0, MoneyPerFlow(0.0), &region_id),
         );
         flows.insert(
-            b.id.clone(),
+            (b.id.clone(), region_id.clone()),
             build_process_flow(&b, 1.0, MoneyPerFlow(0.0), &region_id),
         );
         flows.insert(
-            c.id.clone(),
+            (c.id.clone(), region_id.clone()),
             build_process_flow(&c, 2.0, MoneyPerFlow(3.0), &region_id),
         );
         flows.insert(
-            d.id.clone(),
+            (d.id.clone(), region_id.clone()),
             build_process_flow(&d, 1.0, MoneyPerFlow(4.0), &region_id),
         );
 
@@ -1404,19 +1404,19 @@ mod tests {
 
         let mut flows = IndexMap::new();
         flows.insert(
-            a.id.clone(),
+            (a.id.clone(), region_id.clone()),
             build_process_flow(&a, -1.0, MoneyPerFlow(0.0), &region_id),
         );
         flows.insert(
-            b.id.clone(),
+            (b.id.clone(), region_id.clone()),
             build_process_flow(&b, 1.0, MoneyPerFlow(0.0), &region_id),
         );
         flows.insert(
-            c.id.clone(),
+            (c.id.clone(), region_id.clone()),
             build_process_flow(&c, 2.0, MoneyPerFlow(3.0), &region_id),
         );
         flows.insert(
-            d.id.clone(),
+            (d.id.clone(), region_id.clone()),
             build_process_flow(&d, 1.0, MoneyPerFlow(4.0), &region_id),
         );
 

--- a/src/simulation/prices.rs
+++ b/src/simulation/prices.rs
@@ -1161,7 +1161,7 @@ mod tests {
         MoneyPerCapacityPerYear, MoneyPerFlow,
     };
     use float_cmp::assert_approx_eq;
-    use indexmap::{IndexMap, IndexSet};
+    use indexmap::IndexSet;
     use rstest::rstest;
     use std::collections::{HashMap, HashSet};
     use std::rc::Rc;
@@ -1183,7 +1183,7 @@ mod tests {
 
     #[allow(clippy::too_many_arguments)]
     fn build_process(
-        flows: IndexMap<(CommodityID, RegionID), ProcessFlow>,
+        flows: Vec<ProcessFlow>,
         region_id: &RegionID,
         year: u32,
         time_slice_info: &TimeSliceInfo,
@@ -1310,23 +1310,12 @@ mod tests {
         let mut d = other_commodity.clone();
         d.id = "D".into();
 
-        let mut flows = IndexMap::new();
-        flows.insert(
-            (a.id.clone(), region_id.clone()),
+        let flows = vec![
             build_process_flow(&a, -1.0, MoneyPerFlow(0.0), &region_id),
-        );
-        flows.insert(
-            (b.id.clone(), region_id.clone()),
             build_process_flow(&b, 1.0, MoneyPerFlow(0.0), &region_id),
-        );
-        flows.insert(
-            (c.id.clone(), region_id.clone()),
             build_process_flow(&c, 2.0, MoneyPerFlow(3.0), &region_id),
-        );
-        flows.insert(
-            (d.id.clone(), region_id.clone()),
             build_process_flow(&d, 1.0, MoneyPerFlow(4.0), &region_id),
-        );
+        ];
 
         let process = build_process(
             flows,
@@ -1402,23 +1391,12 @@ mod tests {
         let mut d = other_commodity.clone();
         d.id = "D".into();
 
-        let mut flows = IndexMap::new();
-        flows.insert(
-            (a.id.clone(), region_id.clone()),
+        let flows = vec![
             build_process_flow(&a, -1.0, MoneyPerFlow(0.0), &region_id),
-        );
-        flows.insert(
-            (b.id.clone(), region_id.clone()),
             build_process_flow(&b, 1.0, MoneyPerFlow(0.0), &region_id),
-        );
-        flows.insert(
-            (c.id.clone(), region_id.clone()),
             build_process_flow(&c, 2.0, MoneyPerFlow(3.0), &region_id),
-        );
-        flows.insert(
-            (d.id.clone(), region_id.clone()),
             build_process_flow(&d, 1.0, MoneyPerFlow(4.0), &region_id),
-        );
+        ];
 
         let process = build_process(
             flows,


### PR DESCRIPTION
To allow processes to have multiple flows for the same commodity (i.e. an input flow in one region and an output flow to another).