### PR TITLE
Fix bug with `select_assets_for_cycle`

### DIFF
--- a/src/asset.rs
+++ b/src/asset.rs
@@ -665,6 +665,11 @@ impl Asset {
             .map(|commodity_id| &self.flows[commodity_id])
     }
 
+    /// Get the primary output commodity (if any) for this asset
+    pub fn primary_output_commodity(&self) -> Option<&CommodityID> {
+        self.process.primary_output.as_ref()
+    }
+
     /// Whether this asset has been commissioned
     pub fn is_commissioned(&self) -> bool {
         matches!(&self.state, AssetState::Commissioned { .. })

--- a/src/simulation/investment.rs
+++ b/src/simulation/investment.rs
@@ -391,7 +391,7 @@ fn select_assets_for_cycle(
                 let agent_id = asset.agent_id().unwrap();
                 let commodity_id = asset.primary_output_commodity().unwrap();
                 let agent_share = *agent_share_cache
-                    .entry((agent_id, commodity_id.clone()))
+                    .entry((agent_id, commodity_id))
                     .or_insert_with(|| {
                         model.agents[agent_id].commodity_portions[&(commodity_id.clone(), year)]
                     });

--- a/src/simulation/investment.rs
+++ b/src/simulation/investment.rs
@@ -384,15 +384,17 @@ fn select_assets_for_cycle(
             .collect();
 
         // Retrieve installable capacity limits for flexible capacity assets.
-        let key = (commodity_id.clone(), year);
         let mut agent_share_cache = HashMap::new();
         let capacity_limits = flexible_capacity_assets
             .iter()
             .filter_map(|asset| {
                 let agent_id = asset.agent_id().unwrap();
+                let commodity_id = asset.primary_output_commodity().unwrap();
                 let agent_share = *agent_share_cache
-                    .entry(agent_id.clone())
-                    .or_insert_with(|| model.agents[agent_id].commodity_portions[&key]);
+                    .entry((agent_id, commodity_id.clone()))
+                    .or_insert_with(|| {
+                        model.agents[agent_id].commodity_portions[&(commodity_id.clone(), year)]
+                    });
                 asset
                     .max_installable_capacity(agent_share)
                     .map(|max_capacity| (asset.clone(), max_capacity))


### PR DESCRIPTION
# Description

This function currently calculates asset capacity limits based on the commodity portion for the commodity we're _currently looking at_. However, since this function iterates over multiple commodities and progressively expands the asset pool, this may be incorrect for assets invested in in previous iterations. We need to look at the commodity portion relevant for the agent and primary commodity of each asset.

`agent_share_cache` now keyed by (agent, commodity), since agents can have different shares for different commodities.

Important if commodities in a cycle are owned by different agents (currently it would panic)

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change to fix an issue)
- [ ] New feature (non-breaking change to add functionality)
- [ ] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [ ] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`
- [ ] Update release notes for the latest release if this PR adds a new feature or fixes a bug
      present in the previous release

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
