### PR TITLE
Unify and improve error handling when looking up IDs

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -10,7 +10,7 @@ use serde_string_enum::DeserializeLabeledStringEnum;
 use std::collections::HashMap;
 use std::rc::Rc;
 
-define_id_type! {AgentID}
+define_id_type! {AgentID, "agent ID"}
 
 /// A map of [`Agent`]s, keyed by agent ID
 pub type AgentMap = IndexMap<AgentID, Agent>;

--- a/src/commodity.rs
+++ b/src/commodity.rs
@@ -9,7 +9,7 @@ use serde_string_enum::DeserializeLabeledStringEnum;
 use std::collections::HashMap;
 use std::rc::Rc;
 
-define_id_type! {CommodityID}
+define_id_type! {CommodityID, "commodity ID"}
 
 /// A map of [`Commodity`]s, keyed by commodity ID
 pub type CommodityMap = IndexMap<CommodityID, Rc<Commodity>>;

--- a/src/id.rs
+++ b/src/id.rs
@@ -1,14 +1,16 @@
 //! Code for handling IDs
-use anyhow::{Context, Result};
+use anyhow::Result;
 use indexmap::{IndexMap, IndexSet};
 use std::borrow::Borrow;
 use std::collections::HashSet;
+use std::error::Error;
 use std::fmt::{Debug, Display};
 use std::hash::Hash;
+use std::marker::PhantomData;
 
-/// A trait alias for ID types
+/// A trait for ID types
 pub trait ID: Eq + Hash + Borrow<str> + Clone + Display + Debug + From<String> {
-    /// Get the name of this type of ID (e.g. "commodity", "region" etc.)
+    /// Get the name of this type of ID (e.g. "commodity ID", "region ID" etc.)
     fn get_type_name() -> &'static str;
 }
 
@@ -89,7 +91,7 @@ macro_rules! define_id_type {
 pub(crate) use define_id_type;
 
 #[cfg(test)]
-define_id_type!(GenericID, "generic");
+define_id_type!(GenericID, "generic ID");
 
 /// Indicates that the struct has an ID field
 pub trait HasID<T: ID> {
@@ -109,6 +111,31 @@ macro_rules! define_id_getter {
 }
 pub(crate) use define_id_getter;
 
+/// Indicates that the specified ID was not found in a given collection
+#[derive(Debug)]
+pub struct MissingIDError<T: ID> {
+    missing_id: String,
+    _phantom: PhantomData<fn() -> T>,
+}
+
+impl<T: ID> MissingIDError<T> {
+    /// Create a new `MissingIDError`
+    pub fn new(missing_id: &str) -> MissingIDError<T> {
+        MissingIDError::<T> {
+            missing_id: missing_id.to_string(),
+            _phantom: std::marker::PhantomData,
+        }
+    }
+}
+
+impl<T: ID> Display for MissingIDError<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Unknown {} '{}'", T::get_type_name(), self.missing_id)
+    }
+}
+
+impl<T: ID> Error for MissingIDError<T> {}
+
 /// A data structure containing a set of IDs
 pub trait IDCollection<T: ID> {
     /// Check if the ID is in the collection, returning a reference to it if found.
@@ -120,16 +147,14 @@ pub trait IDCollection<T: ID> {
     /// # Returns
     ///
     /// A reference to the ID in `self`, or an error if not found.
-    fn get_id<S: Borrow<str> + Display + ?Sized>(&self, id: &S) -> Result<&T>;
+    fn get_id<S: Borrow<str> + ?Sized>(&self, id: &S) -> Result<&T, MissingIDError<T>>;
 }
 
 macro_rules! define_id_methods {
     () => {
-        fn get_id<S: Borrow<str> + Display + ?Sized>(&self, id: &S) -> Result<&T> {
-            let found = self
-                .get(id.borrow())
-                .with_context(|| format!("Unknown ID {id} found"))?;
-            Ok(found)
+        fn get_id<S: Borrow<str> + ?Sized>(&self, id: &S) -> Result<&T, MissingIDError<T>> {
+            self.get(id.borrow())
+                .ok_or_else(|| MissingIDError::new(id.borrow()))
         }
     };
 }
@@ -143,10 +168,10 @@ impl<T: ID> IDCollection<T> for IndexSet<T> {
 }
 
 impl<T: ID, V> IDCollection<T> for IndexMap<T, V> {
-    fn get_id<S: Borrow<str> + Display + ?Sized>(&self, id: &S) -> Result<&T> {
+    fn get_id<S: Borrow<str> + ?Sized>(&self, id: &S) -> Result<&T, MissingIDError<T>> {
         let (found, _) = self
             .get_key_value(id.borrow())
-            .with_context(|| format!("Unknown ID {id} found"))?;
+            .ok_or_else(|| MissingIDError::new(id.borrow()))?;
         Ok(found)
     }
 }

--- a/src/id.rs
+++ b/src/id.rs
@@ -8,7 +8,6 @@ use std::hash::Hash;
 
 /// A trait alias for ID types
 pub trait ID: Eq + Hash + Borrow<str> + Clone + Display + From<String> {}
-impl<T> ID for T where T: Eq + Hash + Borrow<str> + Clone + Display + From<String> {}
 
 macro_rules! define_id_type {
     ($name:ident) => {
@@ -69,6 +68,8 @@ macro_rules! define_id_type {
                 Ok(id.into())
             }
         }
+
+        impl crate::id::ID for $name {}
 
         impl $name {
             /// Create a new ID from a string slice

--- a/src/id.rs
+++ b/src/id.rs
@@ -3,11 +3,11 @@ use anyhow::{Context, Result};
 use indexmap::{IndexMap, IndexSet};
 use std::borrow::Borrow;
 use std::collections::HashSet;
-use std::fmt::Display;
+use std::fmt::{Debug, Display};
 use std::hash::Hash;
 
 /// A trait alias for ID types
-pub trait ID: Eq + Hash + Borrow<str> + Clone + Display + From<String> {
+pub trait ID: Eq + Hash + Borrow<str> + Clone + Display + Debug + From<String> {
     /// Get the name of this type of ID (e.g. "commodity", "region" etc.)
     fn get_type_name() -> &'static str;
 }

--- a/src/id.rs
+++ b/src/id.rs
@@ -7,8 +7,8 @@ use std::fmt::Display;
 use std::hash::Hash;
 
 /// A trait alias for ID types
-pub trait IDLike: Eq + Hash + Borrow<str> + Clone + Display + From<String> {}
-impl<T> IDLike for T where T: Eq + Hash + Borrow<str> + Clone + Display + From<String> {}
+pub trait ID: Eq + Hash + Borrow<str> + Clone + Display + From<String> {}
+impl<T> ID for T where T: Eq + Hash + Borrow<str> + Clone + Display + From<String> {}
 
 macro_rules! define_id_type {
     ($name:ident) => {
@@ -84,9 +84,9 @@ pub(crate) use define_id_type;
 define_id_type!(GenericID);
 
 /// Indicates that the struct has an ID field
-pub trait HasID<ID: IDLike> {
+pub trait HasID<T: ID> {
     /// Get the struct's ID
-    fn get_id(&self) -> &ID;
+    fn get_id(&self) -> &T;
 }
 
 /// Implement the `HasID` trait for the given type, assuming it has a field called `id`
@@ -102,7 +102,7 @@ macro_rules! define_id_getter {
 pub(crate) use define_id_getter;
 
 /// A data structure containing a set of IDs
-pub trait IDCollection<ID: IDLike> {
+pub trait IDCollection<T: ID> {
     /// Check if the ID is in the collection, returning a reference to it if found.
     ///
     /// # Arguments
@@ -112,12 +112,12 @@ pub trait IDCollection<ID: IDLike> {
     /// # Returns
     ///
     /// A reference to the ID in `self`, or an error if not found.
-    fn get_id<T: Borrow<str> + Display + ?Sized>(&self, id: &T) -> Result<&ID>;
+    fn get_id<S: Borrow<str> + Display + ?Sized>(&self, id: &S) -> Result<&T>;
 }
 
 macro_rules! define_id_methods {
     () => {
-        fn get_id<T: Borrow<str> + Display + ?Sized>(&self, id: &T) -> Result<&ID> {
+        fn get_id<S: Borrow<str> + Display + ?Sized>(&self, id: &S) -> Result<&T> {
             let found = self
                 .get(id.borrow())
                 .with_context(|| format!("Unknown ID {id} found"))?;
@@ -126,16 +126,16 @@ macro_rules! define_id_methods {
     };
 }
 
-impl<ID: IDLike> IDCollection<ID> for HashSet<ID> {
+impl<T: ID> IDCollection<T> for HashSet<T> {
     define_id_methods!();
 }
 
-impl<ID: IDLike> IDCollection<ID> for IndexSet<ID> {
+impl<T: ID> IDCollection<T> for IndexSet<T> {
     define_id_methods!();
 }
 
-impl<ID: IDLike, V> IDCollection<ID> for IndexMap<ID, V> {
-    fn get_id<T: Borrow<str> + Display + ?Sized>(&self, id: &T) -> Result<&ID> {
+impl<T: ID, V> IDCollection<T> for IndexMap<T, V> {
+    fn get_id<S: Borrow<str> + Display + ?Sized>(&self, id: &S) -> Result<&T> {
         let (found, _) = self
             .get_key_value(id.borrow())
             .with_context(|| format!("Unknown ID {id} found"))?;

--- a/src/id.rs
+++ b/src/id.rs
@@ -7,10 +7,13 @@ use std::fmt::Display;
 use std::hash::Hash;
 
 /// A trait alias for ID types
-pub trait ID: Eq + Hash + Borrow<str> + Clone + Display + From<String> {}
+pub trait ID: Eq + Hash + Borrow<str> + Clone + Display + From<String> {
+    /// Get the name of this type of ID (e.g. "commodity", "region" etc.)
+    fn get_type_name() -> &'static str;
+}
 
 macro_rules! define_id_type {
-    ($name:ident) => {
+    ($name:ident, $type_name:expr) => {
         #[derive(
             Clone,
             derive_more::Display,
@@ -69,7 +72,11 @@ macro_rules! define_id_type {
             }
         }
 
-        impl crate::id::ID for $name {}
+        impl crate::id::ID for $name {
+            fn get_type_name() -> &'static str {
+                $type_name
+            }
+        }
 
         impl $name {
             /// Create a new ID from a string slice
@@ -82,7 +89,7 @@ macro_rules! define_id_type {
 pub(crate) use define_id_type;
 
 #[cfg(test)]
-define_id_type!(GenericID);
+define_id_type!(GenericID, "generic");
 
 /// Indicates that the struct has an ID field
 pub trait HasID<T: ID> {

--- a/src/id.rs
+++ b/src/id.rs
@@ -176,6 +176,19 @@ impl<T: ID, V> IDCollection<T> for IndexMap<T, V> {
     }
 }
 
+/// A trait for getting an ID and a value from a map
+pub trait GetIDValue<K: ID, V> {
+    /// Get the ID and value, if any, for the given collection
+    fn get_id_value<S: Borrow<str> + ?Sized>(&self, id: &S) -> Result<(&K, &V), MissingIDError<K>>;
+}
+
+impl<K: ID + Borrow<str>, V> GetIDValue<K, V> for IndexMap<K, V> {
+    fn get_id_value<S: Borrow<str> + ?Sized>(&self, id: &S) -> Result<(&K, &V), MissingIDError<K>> {
+        self.get_key_value(id.borrow())
+            .ok_or_else(|| MissingIDError::new(id.borrow()))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/input.rs
+++ b/src/input.rs
@@ -2,7 +2,7 @@
 use crate::graph::investment::solve_investment_order_for_model;
 use crate::graph::validate::validate_commodity_graphs_for_model;
 use crate::graph::{CommoditiesGraph, build_commodity_graphs_for_model};
-use crate::id::{HasID, IDLike};
+use crate::id::{HasID, ID};
 use crate::model::{Model, ModelParameters};
 use crate::region::RegionID;
 use crate::units::UnitType;
@@ -135,13 +135,13 @@ pub fn input_err_msg<P: AsRef<Path>>(file_path: P) -> String {
 ///
 /// As this function is only ever used for top-level CSV files (i.e. the ones which actually define
 /// the IDs for a given type), we use an ordered map to maintain the order in the input files.
-fn read_csv_id_file<T, ID: IDLike>(file_path: &Path) -> Result<IndexMap<ID, T>>
+fn read_csv_id_file<T, I: ID>(file_path: &Path) -> Result<IndexMap<I, T>>
 where
-    T: HasID<ID> + DeserializeOwned,
+    T: HasID<I> + DeserializeOwned,
 {
-    fn fill_and_validate_map<T, ID: IDLike>(file_path: &Path) -> Result<IndexMap<ID, T>>
+    fn fill_and_validate_map<T, I: ID>(file_path: &Path) -> Result<IndexMap<I, T>>
     where
-        T: HasID<ID> + DeserializeOwned,
+        T: HasID<I> + DeserializeOwned,
     {
         let mut map = IndexMap::new();
         for record in read_csv::<T>(file_path)? {

--- a/src/input/agent/commodity_portion.rs
+++ b/src/input/agent/commodity_portion.rs
@@ -133,7 +133,7 @@ fn validate_agent_commodity_portions(
     // as the sum of the portions for that key across all agents
     let mut summed_portions = HashMap::new();
     for (id, agent_commodity_portions) in agent_commodity_portions {
-        let agent = agents.get(id).context("Invalid agent ID")?;
+        let agent = &agents[id];
         for ((commodity_id, year), portion) in agent_commodity_portions {
             for region in region_ids {
                 if agent.regions.contains(region) {

--- a/src/input/agent/objective.rs
+++ b/src/input/agent/objective.rs
@@ -1,6 +1,7 @@
 //! Code for reading agent objectives from a CSV file.
 use super::super::{input_err_msg, read_csv, try_insert};
 use crate::agent::{AgentID, AgentMap, AgentObjectiveMap, DecisionRule, ObjectiveType};
+use crate::id::GetIDValue;
 use crate::input::parse_year_str;
 use crate::units::Dimensionless;
 use anyhow::{Context, Result, ensure};
@@ -58,9 +59,7 @@ where
 {
     let mut all_objectives = HashMap::new();
     for objective in iter {
-        let (id, agent) = agents
-            .get_key_value(&objective.agent_id)
-            .context("Invalid agent ID")?;
+        let (id, agent) = agents.get_id_value(&objective.agent_id)?;
 
         // Check that required parameters are present and others are absent
         check_objective_parameter(&objective, &agent.decision_rule)?;

--- a/src/input/agent/search_space.rs
+++ b/src/input/agent/search_space.rs
@@ -2,7 +2,7 @@
 use super::super::{input_err_msg, read_csv_optional, try_insert};
 use crate::agent::{Agent, AgentID, AgentMap, AgentSearchSpaceMap};
 use crate::commodity::CommodityID;
-use crate::id::IDCollection;
+use crate::id::{GetIDValue, IDCollection};
 use crate::input::parse_year_str;
 use crate::process::{Process, ProcessMap};
 use crate::region::RegionID;
@@ -46,9 +46,7 @@ fn add_entry_to_search_space_map(
     producers: &ProducersMap,
     map: &mut HashMap<AgentID, AgentSearchSpaceMap>,
 ) -> Result<()> {
-    let (agent_id, agent) = agents
-        .get_key_value(entry.agent_id.as_str())
-        .with_context(|| format!("Invalid agent ID '{}'", &entry.agent_id))?;
+    let (agent_id, agent) = agents.get_id_value(&entry.agent_id)?;
     let commodity_id = commodity_ids.get_id(&entry.commodity_id)?;
     let years = parse_year_str(&entry.years, milestone_years)?;
     ensure!(
@@ -109,9 +107,7 @@ where
             search_space
                 .split(';')
                 .map(|process_id_str| {
-                    let process = processes
-                        .get(process_id_str.trim())
-                        .with_context(|| format!("Invalid process ID '{process_id_str}'"))?;
+                    let (_, process) = processes.get_id_value(process_id_str.trim())?;
 
                     // Check that the specified process is a possibility for all specified regions
                     // and years
@@ -476,7 +472,7 @@ mod tests {
                     "UNKNOWN_AGENT,GASPRD,all,all",
                 ])
             ],
-            "Invalid agent ID 'UNKNOWN_AGENT'"
+            "Unknown agent ID 'UNKNOWN_AGENT'"
         );
     }
 
@@ -529,7 +525,7 @@ mod tests {
                     "A0_GEX,GASPRD,all,NONEXISTENT_PROCESS",
                 ])
             ],
-            "Invalid process ID 'NONEXISTENT_PROCESS'"
+            "Unknown process ID 'NONEXISTENT_PROCESS'"
         );
     }
 

--- a/src/input/agent/search_space.rs
+++ b/src/input/agent/search_space.rs
@@ -489,7 +489,7 @@ mod tests {
                     "A0_GEX,UNKNOWN_COMMODITY,all,all",
                 ])
             ],
-            "Unknown ID UNKNOWN_COMMODITY found"
+            "Unknown commodity ID 'UNKNOWN_COMMODITY'"
         );
     }
 

--- a/src/input/asset.rs
+++ b/src/input/asset.rs
@@ -2,7 +2,7 @@
 use super::{input_err_msg, read_csv_optional};
 use crate::agent::AgentID;
 use crate::asset::{Asset, AssetRef};
-use crate::id::IDCollection;
+use crate::id::{GetIDValue, IDCollection};
 use crate::process::ProcessMap;
 use crate::region::RegionID;
 use crate::units::Capacity;
@@ -75,9 +75,8 @@ where
 {
     iter.map(|asset| -> Result<_> {
         let agent_id = agent_ids.get_id(&asset.agent_id)?;
-        let process = processes
-            .get(asset.process_id.as_str())
-            .with_context(|| format!("Invalid process ID: {}", &asset.process_id))?;
+        let (process_id, process) = processes
+            .get_id_value(&asset.process_id)?;
         let region_id = region_ids.get_id(&asset.region_id)?;
 
         // Validate commission year. It should be within the process valid range...
@@ -86,21 +85,21 @@ where
             "Agent {} has asset with commission year {}, not within process {} commission years: {:?}",
             asset.agent_id,
             asset.commission_year,
-            asset.process_id,
+            process_id,
             process.years
         );
         // ... and also have associated process parameters and flows
         ensure!(
             process.parameters.contains_key(&(region_id.clone(), asset.commission_year)),
             "Parameters for process {} do not contain entry for year {}, required for asset in agent {}",
-            asset.process_id,
+            process_id,
             asset.commission_year,
             asset.agent_id,
         );
         ensure!(
             process.flows.contains_key(&(region_id.clone(), asset.commission_year)),
             "Flows for process {} do not contain entry for year {}, required for asset in agent {}",
-            asset.process_id,
+            process_id,
             asset.commission_year,
             asset.agent_id,
         );
@@ -115,7 +114,7 @@ where
                     "Asset capacity {} for process {} is not a multiple of unit size {}. \
                      Asset will be divided into {} units with combined capacity of {}.",
                     asset.capacity,
-                    asset.process_id,
+                    process_id,
                     unit_size,
                     n_units,
                     unit_size.value() * n_units

--- a/src/input/commodity/demand.rs
+++ b/src/input/commodity/demand.rs
@@ -301,7 +301,7 @@ mod tests {
         ];
         assert_error!(
             read_demand_from_iter(demand.into_iter(), &svd_commodities, &region_ids, &[2020]),
-            "Unknown ID FRA found"
+            "Unknown region ID 'FRA'"
         );
     }
 

--- a/src/input/commodity/demand_slicing.rs
+++ b/src/input/commodity/demand_slicing.rs
@@ -368,7 +368,7 @@ mod tests {
                 &region_ids,
                 &time_slice_info,
             ),
-            "Unknown ID FRA found"
+            "Unknown region ID 'FRA'"
         );
     }
 
@@ -393,7 +393,7 @@ mod tests {
                 &region_ids,
                 &time_slice_info,
             ),
-            "'summer' is not a valid season"
+            "Unknown season 'summer'"
         );
     }
 

--- a/src/input/process/availability.rs
+++ b/src/input/process/availability.rs
@@ -1,5 +1,6 @@
 //! Code for reading process availabilities from a CSV file.
 use super::super::{input_err_msg, parse_range, read_csv_optional, try_insert};
+use crate::id::GetIDValue;
 use crate::input::parse_year_str;
 use crate::process::{ActivityLimits, ProcessActivityLimitsMap, ProcessID, ProcessMap};
 use crate::region::parse_region_str;
@@ -98,9 +99,7 @@ where
 
     for record in iter {
         // Get process
-        let (id, process) = processes
-            .get_key_value(record.process_id.as_str())
-            .with_context(|| format!("Process {} not found", record.process_id))?;
+        let (id, process) = processes.get_id_value(&record.process_id)?;
 
         // Get regions
         let process_regions = &process.regions;

--- a/src/input/process/flow.rs
+++ b/src/input/process/flow.rs
@@ -1,6 +1,7 @@
 //! Code for reading process flows from a CSV file.
 use super::super::{input_err_msg, read_csv};
 use crate::commodity::{CommodityID, CommodityMap, CommodityType};
+use crate::id::GetIDValue;
 use crate::input::parse_year_str;
 use crate::process::{
     FlowDirection, FlowType, ProcessFlow, ProcessFlowsMap, ProcessID, ProcessMap,
@@ -161,9 +162,7 @@ where
         record.validate()?;
 
         // Get process
-        let (id, process) = processes
-            .get_key_value(record.process_id.as_str())
-            .with_context(|| format!("Process {} not found", record.process_id))?;
+        let (id, process) = processes.get_id_value(&record.process_id)?;
 
         // Get regions
         let process_regions = &process.regions;
@@ -180,9 +179,7 @@ where
             })?;
 
         // Get commodity
-        let commodity = commodities
-            .get(record.commodity_id.as_str())
-            .with_context(|| format!("{} is not a valid commodity ID", &record.commodity_id))?;
+        let (_, commodity) = commodities.get_id_value(&record.commodity_id)?;
 
         // Create ProcessFlow object
         let process_flow = ProcessFlow {

--- a/src/input/process/investment_constraints.rs
+++ b/src/input/process/investment_constraints.rs
@@ -1,5 +1,6 @@
 //! Code for reading process investment constraints from a CSV file.
 use super::super::input_err_msg;
+use crate::id::GetIDValue;
 use crate::input::parse_year_str;
 use crate::input::{read_csv_optional, try_insert};
 use crate::process::{
@@ -92,9 +93,7 @@ where
         record.validate()?;
 
         // Verify the process exists
-        let (process_id, process) = processes
-            .get_key_value(record.process_id.as_str())
-            .with_context(|| format!("Process {} not found", record.process_id))?;
+        let (process_id, process) = processes.get_id_value(&record.process_id)?;
 
         // Parse and validate regions
         let process_regions = &process.regions;

--- a/src/input/process/parameter.rs
+++ b/src/input/process/parameter.rs
@@ -1,5 +1,6 @@
 //! Code for reading process parameters from a CSV file
 use super::super::{format_items_with_cap, input_err_msg, read_csv, try_insert};
+use crate::id::GetIDValue;
 use crate::input::parse_year_str;
 use crate::process::{ProcessID, ProcessMap, ProcessParameter, ProcessParameterMap};
 use crate::region::parse_region_str;
@@ -105,9 +106,7 @@ where
     let mut map: HashMap<ProcessID, ProcessParameterMap> = HashMap::new();
     for param_raw in iter {
         // Get process
-        let (id, process) = processes
-            .get_key_value(param_raw.process_id.as_str())
-            .with_context(|| format!("Process {} not found", param_raw.process_id))?;
+        let (id, process) = processes.get_id_value(&param_raw.process_id)?;
 
         // Get years
         let process_years: Vec<u32> = process.years.clone().collect();

--- a/src/input/time_slice.rs
+++ b/src/input/time_slice.rs
@@ -1,6 +1,6 @@
 //! Code for reading time slice info from a CSV file.
 use super::{
-    IDLike, check_values_sum_to_one_approx, deserialise_proportion_nonzero, input_err_msg, read_csv,
+    ID, check_values_sum_to_one_approx, deserialise_proportion_nonzero, input_err_msg, read_csv,
 };
 use crate::id::IDCollection;
 use crate::time_slice::{Season, TimeOfDay, TimeSliceID, TimeSliceInfo};
@@ -24,7 +24,7 @@ struct TimeSliceRaw {
 /// Get the specified ID in `set`, if present, inserting it if not.
 ///
 /// By returning an existing ID, we can avoid having extra copies.
-fn get_or_insert<T: IDLike>(id: T, set: &mut IndexSet<T>) -> T {
+fn get_or_insert<T: ID>(id: T, set: &mut IndexSet<T>) -> T {
     // Sadly there's no entry API for HashSets: https://github.com/rust-lang/rfcs/issues/1490
     if let Ok(id) = set.get_id(&id) {
         id.clone()

--- a/src/process.rs
+++ b/src/process.rs
@@ -16,7 +16,7 @@ use std::collections::HashMap;
 use std::ops::RangeInclusive;
 use std::rc::Rc;
 
-define_id_type! {ProcessID}
+define_id_type! {ProcessID, "process ID"}
 
 /// A map of [`Process`]es, keyed by process ID
 pub type ProcessMap = IndexMap<ProcessID, Rc<Process>>;

--- a/src/region.rs
+++ b/src/region.rs
@@ -4,7 +4,7 @@ use anyhow::{Result, ensure};
 use indexmap::{IndexMap, IndexSet};
 use serde::Deserialize;
 
-define_id_type! {RegionID}
+define_id_type! {RegionID, "region ID"}
 
 /// A map of [`Region`]s, keyed by region ID
 pub type RegionMap = IndexMap<RegionID, Region>;

--- a/src/time_slice.rs
+++ b/src/time_slice.rs
@@ -255,14 +255,8 @@ impl TimeSliceInfo {
             .split('.')
             .collect_tuple()
             .context("Time slice must be in the form season.time_of_day")?;
-        let season = self
-            .seasons
-            .get_id(season)
-            .with_context(|| format!("{season} is not a known season"))?;
-        let time_of_day = self
-            .times_of_day
-            .get_id(time_of_day)
-            .with_context(|| format!("{time_of_day} is not a known time of day"))?;
+        let season = self.seasons.get_id(season)?;
+        let time_of_day = self.times_of_day.get_id(time_of_day)?;
 
         Ok(TimeSliceID {
             season: season.clone(),
@@ -280,11 +274,7 @@ impl TimeSliceInfo {
             let time_slice = self.get_time_slice_id_from_str(time_slice)?;
             Ok(TimeSliceSelection::Single(time_slice))
         } else {
-            let season = self
-                .seasons
-                .get_id(time_slice)
-                .with_context(|| format!("'{time_slice}' is not a valid season"))?
-                .clone();
+            let season = self.seasons.get_id(time_slice)?.clone();
             Ok(TimeSliceSelection::Season(season))
         }
     }

--- a/src/time_slice.rs
+++ b/src/time_slice.rs
@@ -13,8 +13,8 @@ use serde_string_enum::DeserializeLabeledStringEnum;
 use std::fmt::Display;
 use std::iter;
 
-define_id_type! {Season}
-define_id_type! {TimeOfDay}
+define_id_type! {Season, "season"}
+define_id_type! {TimeOfDay, "time of day"}
 
 /// An ID describing season and time of day
 #[derive(Hash, Eq, PartialEq, Ord, PartialOrd, Clone, Debug)]


### PR DESCRIPTION
# Description

I've made a few small improvements to how we handle errors related to getting IDs from sets and maps.

Firstly, I added a string description to each ID type (e.g. "commodity ID"), which is used in error messages to provide more information (currently, users will just be told "Unknown ID X", without context about what kind of ID X is supposed to be). Secondly, I added a new trait for getting an ID + a value from an `IndexMap`, which is something we do fairly often in the `input` module, but each time with custom error handling. Again, this should yield an improvement to the quality of error messages (e.g. instead of seeing "Invalid process ID", the user will see "Unknown process ID X").

As a result of these changes, I needed to change the expected error messages for a few of the tests.

## Type of change

- [ ] Bug fix (non-breaking change to fix an issue)
- [ ] New feature (non-breaking change to add functionality)
- [x] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [x] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`
- [ ] Update release notes for the latest release if this PR adds a new feature or fixes a bug
      present in the previous release

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
