### PR TITLE
Define regression tests in submodule

### DIFF
--- a/tests/regression.rs
+++ b/tests/regression.rs
@@ -11,28 +11,29 @@ use tempfile::{TempDir, tempdir};
 mod common;
 use common::*;
 
-// ------ BEGIN: regression tests ------
+/// Define regression tests
+mod regression {
+    use super::*;
 
-// We only check the debug files for the `simple` example at present
-define_regression_test_with_debug_files!(simple);
+    // We only check the debug files for the `simple` example at present
+    define_regression_test_with_debug_files!(simple);
 
-// Other example models
-define_regression_test!(missing_commodity);
-define_regression_test!(muse1_default);
-define_regression_test!(two_outputs);
-define_regression_test!(circularity);
-define_regression_test!(two_regions);
+    // Other example models
+    define_regression_test!(missing_commodity);
+    define_regression_test!(muse1_default);
+    define_regression_test!(two_outputs);
+    define_regression_test!(circularity);
+    define_regression_test!(two_regions);
 
-// Patched examples
-define_regression_test_with_patches!(simple_divisible);
-define_regression_test_with_patches!(simple_npv);
-define_regression_test_with_patches!(simple_marginal);
-define_regression_test_with_patches!(simple_marginal_average);
-define_regression_test_with_patches!(simple_full);
-define_regression_test_with_patches!(simple_shadow);
-define_regression_test_with_patches!(simple_ironing_out);
-
-// ------  END: regression tests  ------
+    // Patched examples
+    define_regression_test_with_patches!(simple_divisible);
+    define_regression_test_with_patches!(simple_npv);
+    define_regression_test_with_patches!(simple_marginal);
+    define_regression_test_with_patches!(simple_marginal_average);
+    define_regression_test_with_patches!(simple_full);
+    define_regression_test_with_patches!(simple_shadow);
+    define_regression_test_with_patches!(simple_ironing_out);
+}
 
 /// The tolerance when comparing floating-point values in CSV files
 const FLOAT_CMP_TOLERANCE: f64 = 1e-10;


### PR DESCRIPTION
# Description

When I first wrote the macros we use to define regression tests, I wanted to prefix each test function with `regression_`, but there isn't a way to do this in macros with stable Rust. You can achieve the same thing by putting the test function definitions into a submodule though, which is what I've done here.

The main advantage of this is that it means you can actually run _just_ the regression tests if you want, with `cargo test -- regression::`. I also think it's a little clearer.

```
     Running tests/regression.rs (target/debug/deps/regression-38c7e46fd3f5aae3)

running 13 tests
test regression::simple_marginal ... ok
test regression::simple_npv ... ok
test regression::simple_full ... ok
test regression::simple ... ok
test regression::simple_shadow ... ok
test regression::simple_divisible ... ok
test regression::missing_commodity ... ok
test regression::simple_marginal_average ... ok
test regression::muse1_default ... ok
test regression::simple_ironing_out ... ok
test regression::two_outputs ... ok
test regression::circularity ... ok
test regression::two_regions ... ok

test result: ok. 13 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.53s
```