### PR TITLE
Define user asset type and remove `AssetState::Future`

### DIFF
--- a/src/asset.rs
+++ b/src/asset.rs
@@ -68,7 +68,7 @@ pub struct AssetGroupID(u32);
 /// determined by the investment algorithm.
 ///
 /// `Future` and `Candidate` assets can be converted to `Commissioned` assets by calling
-/// the `commission` method (or via pool operations that commission future/selected assets).
+/// the `commission` method (or via pool operations that commission future/ready assets).
 #[derive(Clone, Debug, PartialEq, strum::Display)]
 pub enum AssetState {
     /// The asset has been commissioned
@@ -89,8 +89,8 @@ pub enum AssetState {
         /// The ID of the agent that will own the asset
         agent_id: AgentID,
     },
-    /// The asset has been selected for investment, but not yet confirmed
-    Selected {
+    /// The asset is ready for investment, but not yet confirmed
+    Ready {
         /// The ID of the agent that would own the asset
         agent_id: AgentID,
     },
@@ -220,12 +220,12 @@ impl Asset {
         )
     }
 
-    /// Create a new selected asset
+    /// Create a new ready asset
     ///
-    /// This is only used for testing. In the real program, Selected assets can only be created from
+    /// This is only used for testing. In the real program, Ready assets can only be created from
     /// Candidate assets by calling `select_candidate_for_investment`.
     #[cfg(test)]
-    fn new_selected(
+    fn new_ready(
         agent_id: AgentID,
         process: Rc<Process>,
         region_id: RegionID,
@@ -234,7 +234,7 @@ impl Asset {
     ) -> Result<Self> {
         let unit_size = process.unit_size;
         Self::new_with_state(
-            AssetState::Selected { agent_id },
+            AssetState::Ready { agent_id },
             process,
             region_id,
             AssetCapacity::from_capacity(capacity, unit_size),
@@ -746,7 +746,7 @@ impl Asset {
         match &self.state {
             AssetState::Commissioned { agent_id, .. }
             | AssetState::Future { agent_id }
-            | AssetState::Selected { agent_id }
+            | AssetState::Ready { agent_id }
             | AssetState::Parent { agent_id, .. } => Some(agent_id),
             AssetState::Candidate => None,
         }
@@ -762,14 +762,11 @@ impl Asset {
         self.capacity().total_capacity()
     }
 
-    /// Set the capacity for this asset (only for Candidate or Selected assets)
+    /// Set the capacity for this asset (only for Candidate or Ready assets)
     pub fn set_capacity(&mut self, capacity: AssetCapacity) {
         assert!(
-            matches!(
-                self.state,
-                AssetState::Candidate | AssetState::Selected { .. }
-            ),
-            "set_capacity can only be called on Candidate or Selected assets"
+            matches!(self.state, AssetState::Candidate | AssetState::Ready { .. }),
+            "set_capacity can only be called on Candidate or Ready assets"
         );
         assert!(
             capacity.total_capacity() >= Capacity(0.0),
@@ -842,7 +839,7 @@ impl Asset {
 
     /// Commission the asset.
     ///
-    /// Only assets with an [`AssetState`] of `Future` or `Selected` can be commissioned. If the
+    /// Only assets with an [`AssetState`] of `Future` or `Ready` can be commissioned. If the
     /// asset's state is something else, this function will panic.
     ///
     /// # Arguments
@@ -852,7 +849,7 @@ impl Asset {
     /// * `parent` - The parent asset, if this is a child asset
     fn commission(&mut self, id: AssetID, parent: Option<AssetRef>, reason: &str) {
         let agent_id = match &self.state {
-            AssetState::Future { agent_id } | AssetState::Selected { agent_id } => agent_id,
+            AssetState::Future { agent_id } | AssetState::Ready { agent_id } => agent_id,
             state => panic!("Assets with state {state} cannot be commissioned"),
         };
         debug!(
@@ -871,14 +868,14 @@ impl Asset {
         };
     }
 
-    /// Select a Candidate asset for investment, converting it to a Selected state
+    /// Select a Candidate asset for investment, converting it to a Ready state
     pub fn select_candidate_for_investment(&mut self, agent_id: AgentID) {
         assert!(
             self.state == AssetState::Candidate,
             "select_candidate_for_investment can only be called on Candidate assets"
         );
         check_capacity_valid_for_asset(self.total_capacity()).unwrap();
-        self.state = AssetState::Selected { agent_id };
+        self.state = AssetState::Ready { agent_id };
     }
 
     /// Set the year this asset was mothballed
@@ -1050,7 +1047,7 @@ impl AssetRef {
     /// When the asset has a discrete capacity, each of the children will be made up of a single
     /// unit of the original asset's unit size.
     ///
-    /// Panics if this asset's state is not `Future` or `Selected`.
+    /// Panics if this asset's state is not `Future` or `Ready`.
     fn into_for_each_child<F>(mut self, next_group_id: &mut u32, mut f: F)
     where
         F: FnMut(Option<&AssetRef>, AssetRef),
@@ -1058,9 +1055,9 @@ impl AssetRef {
         assert!(
             matches!(
                 self.state,
-                AssetState::Future { .. } | AssetState::Selected { .. }
+                AssetState::Future { .. } | AssetState::Ready { .. }
             ),
-            "Assets with state {} cannot be divided. Only Future or Selected assets can be divided",
+            "Assets with state {} cannot be divided. Only Future or Ready assets can be divided",
             self.state
         );
 
@@ -1517,8 +1514,8 @@ mod tests {
         assert!(asset1.is_commissioned());
         assert_eq!(asset1.id(), Some(AssetID(1)));
 
-        // Test successful commissioning of Selected asset
-        let mut asset2 = Asset::new_selected(
+        // Test successful commissioning of Ready asset
+        let mut asset2 = Asset::new_ready(
             "agent1".into(),
             Rc::clone(&process_rc),
             "GBR".into(),

--- a/src/asset.rs
+++ b/src/asset.rs
@@ -62,13 +62,13 @@ pub struct AssetGroupID(u32);
 
 /// The state of an asset
 ///
-/// New assets are created as either `Future` or `Candidate` assets. `Future` assets (which are
-/// specified in the input data) have a fixed capacity and capital costs already accounted for,
-/// whereas `Candidate` assets capital costs are not yet accounted for, and their capacity is
-/// determined by the investment algorithm.
+/// New assets are created as either `Ready` or `Candidate` assets. `Ready` assets from the input
+/// data have a fixed capacity and capital costs already accounted for, whereas `Candidate` assets'
+/// capital costs are not yet accounted for, and their capacity is determined by the investment
+/// algorithm.
 ///
-/// `Future` and `Candidate` assets can be converted to `Commissioned` assets by calling
-/// the `commission` method (or via pool operations that commission future/ready assets).
+/// `Ready` and `Candidate` assets can be converted to `Commissioned` assets by calling the
+/// `commission` method (or via pool operations that commission ready assets).
 #[derive(Clone, Debug, PartialEq, strum::Display)]
 pub enum AssetState {
     /// The asset has been commissioned
@@ -84,15 +84,12 @@ pub enum AssetState {
         /// All divided assets have a parent, which tracks the total capacity across the children.
         parent: Option<AssetRef>,
     },
-    /// The asset is planned for commissioning in the future
-    Future {
-        /// The ID of the agent that will own the asset
-        agent_id: AgentID,
-    },
     /// The asset is ready for investment, but not yet confirmed
     Ready {
         /// The ID of the agent that would own the asset
         agent_id: AgentID,
+        /// The reason why this asset is due to be commissioned
+        commission_reason: &'static str,
     },
     /// The asset is a parent of other assets.
     ///
@@ -193,7 +190,10 @@ impl Asset {
         check_capacity_valid_for_asset(capacity)?;
         let unit_size = process.unit_size;
         Self::new_with_state(
-            AssetState::Future { agent_id },
+            AssetState::Ready {
+                agent_id,
+                commission_reason: "user input",
+            },
             process,
             region_id,
             AssetCapacity::from_capacity(capacity, unit_size),
@@ -234,7 +234,10 @@ impl Asset {
     ) -> Result<Self> {
         let unit_size = process.unit_size;
         Self::new_with_state(
-            AssetState::Ready { agent_id },
+            AssetState::Ready {
+                agent_id,
+                commission_reason: "selected",
+            },
             process,
             region_id,
             AssetCapacity::from_capacity(capacity, unit_size),
@@ -745,8 +748,7 @@ impl Asset {
     pub fn agent_id(&self) -> Option<&AgentID> {
         match &self.state {
             AssetState::Commissioned { agent_id, .. }
-            | AssetState::Future { agent_id }
-            | AssetState::Ready { agent_id }
+            | AssetState::Ready { agent_id, .. }
             | AssetState::Parent { agent_id, .. } => Some(agent_id),
             AssetState::Candidate => None,
         }
@@ -845,11 +847,13 @@ impl Asset {
     /// # Arguments
     ///
     /// * `id` - The ID to give the newly commissioned asset
-    /// * `reason` - The reason for commissioning (included in log)
     /// * `parent` - The parent asset, if this is a child asset
-    fn commission(&mut self, id: AssetID, parent: Option<AssetRef>, reason: &str) {
-        let agent_id = match &self.state {
-            AssetState::Future { agent_id } | AssetState::Ready { agent_id } => agent_id,
+    fn commission(&mut self, id: AssetID, parent: Option<AssetRef>) {
+        let (agent_id, reason) = match &self.state {
+            AssetState::Ready {
+                agent_id,
+                commission_reason,
+            } => (agent_id, commission_reason),
             state => panic!("Assets with state {state} cannot be commissioned"),
         };
         debug!(
@@ -875,7 +879,10 @@ impl Asset {
             "select_candidate_for_investment can only be called on Candidate assets"
         );
         check_capacity_valid_for_asset(self.total_capacity()).unwrap();
-        self.state = AssetState::Ready { agent_id };
+        self.state = AssetState::Ready {
+            agent_id,
+            commission_reason: "selected",
+        };
     }
 
     /// Set the year this asset was mothballed
@@ -1053,11 +1060,8 @@ impl AssetRef {
         F: FnMut(Option<&AssetRef>, AssetRef),
     {
         assert!(
-            matches!(
-                self.state,
-                AssetState::Future { .. } | AssetState::Ready { .. }
-            ),
-            "Assets with state {} cannot be divided. Only Future or Ready assets can be divided",
+            matches!(self.state, AssetState::Ready { .. }),
+            "Assets with state {} cannot be divided. Only Ready assets can be divided",
             self.state
         );
 
@@ -1510,7 +1514,7 @@ mod tests {
             2020,
         )
         .unwrap();
-        asset1.commission(AssetID(1), None, "");
+        asset1.commission(AssetID(1), None);
         assert!(asset1.is_commissioned());
         assert_eq!(asset1.id(), Some(AssetID(1)));
 
@@ -1523,7 +1527,7 @@ mod tests {
             2020,
         )
         .unwrap();
-        asset2.commission(AssetID(2), None, "");
+        asset2.commission(AssetID(2), None);
         assert!(asset2.is_commissioned());
         assert_eq!(asset2.id(), Some(AssetID(2)));
     }
@@ -1533,7 +1537,7 @@ mod tests {
     fn commission_wrong_states(process: Process) {
         let mut asset =
             Asset::new_candidate(process.into(), "GBR".into(), Capacity(1.0), 2020).unwrap();
-        asset.commission(AssetID(1), None, "");
+        asset.commission(AssetID(1), None);
     }
 
     #[test]

--- a/src/asset.rs
+++ b/src/asset.rs
@@ -67,8 +67,8 @@ pub struct AssetGroupID(u32);
 /// capital costs are not yet accounted for, and their capacity is determined by the investment
 /// algorithm.
 ///
-/// `Ready` and `Candidate` assets can be converted to `Commissioned` assets by calling the
-/// `commission` method (or via pool operations that commission ready assets).
+/// `Ready` assets can be converted to `Commissioned` assets by calling the `commission` method (or
+/// via pool operations that commission ready assets).
 #[derive(Clone, Debug, PartialEq, strum::Display)]
 pub enum AssetState {
     /// The asset has been commissioned
@@ -799,8 +799,8 @@ impl Asset {
 
     /// Commission the asset.
     ///
-    /// Only assets with an [`AssetState`] of `Future` or `Ready` can be commissioned. If the
-    /// asset's state is something else, this function will panic.
+    /// Only assets with an [`AssetState`] of `Ready` can be commissioned. If the asset's state is
+    /// something else, this function will panic.
     ///
     /// # Arguments
     ///
@@ -1063,7 +1063,7 @@ impl AssetRef {
     /// When the asset has a discrete capacity, each of the children will be made up of a single
     /// unit of the original asset's unit size.
     ///
-    /// Panics if this asset's state is not `Future` or `Ready`.
+    /// Panics if this asset's state is not `Ready`.
     fn into_for_each_child<F>(mut self, next_group_id: &mut u32, mut f: F)
     where
         F: FnMut(Option<&AssetRef>, AssetRef),

--- a/src/asset.rs
+++ b/src/asset.rs
@@ -178,54 +178,12 @@ impl Asset {
         }
     }
 
-    /// Create a new future asset
-    pub fn new_future_with_max_decommission(
-        agent_id: AgentID,
-        process: Rc<Process>,
-        region_id: RegionID,
-        capacity: Capacity,
-        commission_year: u32,
-        max_decommission_year: Option<u32>,
-    ) -> Result<Self> {
-        check_capacity_valid_for_asset(capacity)?;
-        let unit_size = process.unit_size;
-        Self::new_with_state(
-            AssetState::Ready {
-                agent_id,
-                commission_reason: "user input",
-            },
-            process,
-            region_id,
-            AssetCapacity::from_capacity(capacity, unit_size),
-            commission_year,
-            max_decommission_year,
-        )
-    }
-
-    /// Create a new future asset
-    pub fn new_future(
-        agent_id: AgentID,
-        process: Rc<Process>,
-        region_id: RegionID,
-        capacity: Capacity,
-        commission_year: u32,
-    ) -> Result<Self> {
-        Self::new_future_with_max_decommission(
-            agent_id,
-            process,
-            region_id,
-            capacity,
-            commission_year,
-            None,
-        )
-    }
-
     /// Create a new ready asset
     ///
     /// This is only used for testing. In the real program, Ready assets can only be created from
     /// Candidate assets by calling `select_candidate_for_investment`.
     #[cfg(test)]
-    fn new_ready(
+    pub fn new_ready(
         agent_id: AgentID,
         process: Rc<Process>,
         region_id: RegionID,
@@ -1005,6 +963,57 @@ pub fn check_region_year_valid_for_process(
     Ok(())
 }
 
+/// An asset defined by the user in the assets input file
+#[derive(Clone, Debug, PartialEq)]
+pub struct UserAsset(AssetRef);
+
+impl UserAsset {
+    /// Create a new [`UserAsset`]
+    pub fn new(
+        agent_id: AgentID,
+        process: Rc<Process>,
+        region_id: RegionID,
+        capacity: Capacity,
+        commission_year: u32,
+        max_decommission_year: Option<u32>,
+    ) -> Result<Self> {
+        check_capacity_valid_for_asset(capacity)?;
+        let unit_size = process.unit_size;
+        let asset = Asset::new_with_state(
+            AssetState::Ready {
+                agent_id,
+                commission_reason: "user input",
+            },
+            process,
+            region_id,
+            AssetCapacity::from_capacity(capacity, unit_size),
+            commission_year,
+            max_decommission_year,
+        )?;
+
+        Ok(Self(asset.into()))
+    }
+}
+
+#[cfg(test)]
+impl From<Asset> for UserAsset {
+    fn from(asset: Asset) -> Self {
+        assert!(
+            matches!(asset.state, AssetState::Ready { .. }),
+            "User assets must be in Ready state"
+        );
+        Self(asset.into())
+    }
+}
+
+impl Deref for UserAsset {
+    type Target = Asset;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
 /// Whether the specified value is a valid capacity for an asset
 pub fn check_capacity_valid_for_asset(capacity: Capacity) -> Result<()> {
     ensure!(
@@ -1139,6 +1148,12 @@ impl From<Asset> for AssetRef {
     }
 }
 
+impl From<UserAsset> for AssetRef {
+    fn from(value: UserAsset) -> Self {
+        value.0
+    }
+}
+
 impl From<AssetRef> for Rc<Asset> {
     fn from(value: AssetRef) -> Self {
         value.0
@@ -1241,8 +1256,8 @@ mod tests {
     use super::*;
     use crate::commodity::Commodity;
     use crate::fixture::{
-        assert_error, assert_patched_runs_ok_simple, assert_validate_fails_with_simple, asset,
-        asset_divisible, process, process_activity_limits_map, process_flows_map, region_id,
+        agent_id, assert_error, assert_patched_runs_ok_simple, assert_validate_fails_with_simple,
+        asset, asset_divisible, process, process_activity_limits_map, process_flows_map, region_id,
         svd_commodity, time_slice, time_slice_info,
     };
     use crate::patch::FilePatch;
@@ -1291,54 +1306,6 @@ mod tests {
         assert_approx_eq!(MoneyPerActivity, cost, MoneyPerActivity(6.0));
     }
 
-    #[rstest]
-    #[case(Capacity(0.01))]
-    #[case(Capacity(0.5))]
-    #[case(Capacity(1.0))]
-    #[case(Capacity(100.0))]
-    fn asset_new_valid(process: Process, #[case] capacity: Capacity) {
-        let agent_id = AgentID("agent1".into());
-        let region_id = RegionID("GBR".into());
-        let asset = Asset::new_future(agent_id, process.into(), region_id, capacity, 2015).unwrap();
-        assert!(asset.id().is_none());
-    }
-
-    #[rstest]
-    #[case(Capacity(0.0))]
-    #[case(Capacity(-0.01))]
-    #[case(Capacity(-1.0))]
-    #[case(Capacity(f64::NAN))]
-    #[case(Capacity(f64::INFINITY))]
-    #[case(Capacity(f64::NEG_INFINITY))]
-    fn asset_new_invalid_capacity(process: Process, #[case] capacity: Capacity) {
-        let agent_id = AgentID("agent1".into());
-        let region_id = RegionID("GBR".into());
-        assert_error!(
-            Asset::new_future(agent_id, process.into(), region_id, capacity, 2015),
-            "Capacity must be a finite, positive number"
-        );
-    }
-
-    #[rstest]
-    fn asset_new_invalid_commission_year(process: Process) {
-        let agent_id = AgentID("agent1".into());
-        let region_id = RegionID("GBR".into());
-        assert_error!(
-            Asset::new_future(agent_id, process.into(), region_id, Capacity(1.0), 2007),
-            "Process process1 does not operate in the year 2007"
-        );
-    }
-
-    #[rstest]
-    fn asset_new_invalid_region(process: Process) {
-        let agent_id = AgentID("agent1".into());
-        let region_id = RegionID("FRA".into());
-        assert_error!(
-            Asset::new_future(agent_id, process.into(), region_id, Capacity(1.0), 2015),
-            "Process process1 does not operate in region FRA"
-        );
-    }
-
     #[fixture]
     fn process_with_activity_limits(
         mut process: Process,
@@ -1358,7 +1325,7 @@ mod tests {
 
     #[fixture]
     fn asset_with_activity_limits(process_with_activity_limits: Process) -> Asset {
-        Asset::new_future(
+        Asset::new_ready(
             "agent1".into(),
             Rc::new(process_with_activity_limits),
             "GBR".into(),
@@ -1381,6 +1348,76 @@ mod tests {
     }
 
     #[rstest]
+    #[case(Capacity(0.01))]
+    #[case(Capacity(0.5))]
+    #[case(Capacity(1.0))]
+    #[case(Capacity(100.0))]
+    fn user_asset_new_valid(
+        agent_id: AgentID,
+        process: Process,
+        region_id: RegionID,
+        #[case] capacity: Capacity,
+    ) {
+        let asset =
+            UserAsset::new(agent_id, process.into(), region_id, capacity, 2015, None).unwrap();
+        assert!(asset.id().is_none());
+    }
+
+    #[rstest]
+    #[case(Capacity(0.0))]
+    #[case(Capacity(-0.01))]
+    #[case(Capacity(-1.0))]
+    #[case(Capacity(f64::NAN))]
+    #[case(Capacity(f64::INFINITY))]
+    #[case(Capacity(f64::NEG_INFINITY))]
+    fn user_asset_new_invalid_capacity(
+        agent_id: AgentID,
+        process: Process,
+        region_id: RegionID,
+        #[case] capacity: Capacity,
+    ) {
+        assert_error!(
+            UserAsset::new(agent_id, process.into(), region_id, capacity, 2015, None),
+            "Capacity must be a finite, positive number"
+        );
+    }
+
+    #[rstest]
+    fn user_asset_new_invalid_commission_year(
+        agent_id: AgentID,
+        process: Process,
+        region_id: RegionID,
+    ) {
+        assert_error!(
+            UserAsset::new(
+                agent_id,
+                process.into(),
+                region_id,
+                Capacity(1.0),
+                2007,
+                None
+            ),
+            "Process process1 does not operate in the year 2007"
+        );
+    }
+
+    #[rstest]
+    fn user_asset_new_invalid_region(agent_id: AgentID, process: Process) {
+        let region_id = RegionID("FRA".into());
+        assert_error!(
+            UserAsset::new(
+                agent_id,
+                process.into(),
+                region_id,
+                Capacity(1.0),
+                2015,
+                None
+            ),
+            "Process process1 does not operate in region FRA"
+        );
+    }
+
+    #[rstest]
     #[case::exact_multiple(Capacity(12.0), Capacity(4.0), 3)] // 12 / 4 = 3
     #[case::rounded_up(Capacity(11.0), Capacity(4.0), 3)] // 11 / 4 = 2.75 -> 3
     #[case::unit_size_equals_capacity(Capacity(4.0), Capacity(4.0), 1)] // 4 / 4 = 1
@@ -1393,7 +1430,7 @@ mod tests {
     ) {
         process.unit_size = Some(unit_size);
         let asset = AssetRef::from(
-            Asset::new_future(
+            Asset::new_ready(
                 "agent1".into(),
                 Rc::new(process),
                 "GBR".into(),
@@ -1504,32 +1541,18 @@ mod tests {
 
     #[rstest]
     fn asset_commission(process: Process) {
-        // Test successful commissioning of Future asset
-        let process_rc = Rc::new(process);
-        let mut asset1 = Asset::new_future(
-            "agent1".into(),
-            Rc::clone(&process_rc),
-            "GBR".into(),
-            Capacity(1.0),
-            2020,
-        )
-        .unwrap();
-        asset1.commission(AssetID(1), None);
-        assert!(asset1.is_commissioned());
-        assert_eq!(asset1.id(), Some(AssetID(1)));
-
         // Test successful commissioning of Ready asset
-        let mut asset2 = Asset::new_ready(
+        let mut asset = Asset::new_ready(
             "agent1".into(),
-            Rc::clone(&process_rc),
+            process.into(),
             "GBR".into(),
             Capacity(1.0),
             2020,
         )
         .unwrap();
-        asset2.commission(AssetID(2), None);
-        assert!(asset2.is_commissioned());
-        assert_eq!(asset2.id(), Some(AssetID(2)));
+        asset.commission(AssetID(2), None);
+        assert!(asset.is_commissioned());
+        assert_eq!(asset.id(), Some(AssetID(2)));
     }
 
     #[rstest]

--- a/src/asset/pool.rs
+++ b/src/asset/pool.rs
@@ -47,18 +47,18 @@ impl AssetPool {
                 continue;
             }
 
-            self.commission(asset, "user input");
+            self.commission(asset);
         }
 
         &self.assets[start..]
     }
 
     /// Commission the specified asset or, if divisible, its children
-    fn commission(&mut self, asset: AssetRef, reason: &str) {
+    fn commission(&mut self, asset: AssetRef) {
         asset.into_for_each_child(&mut self.next_group_id, |parent, mut child| {
             child
                 .make_mut()
-                .commission(AssetID(self.next_id), parent.cloned(), reason);
+                .commission(AssetID(self.next_id), parent.cloned());
             self.next_id += 1;
             self.assets.push(child);
         });
@@ -173,7 +173,7 @@ impl AssetPool {
                     self.assets.push(asset);
                 }
                 AssetState::Ready { .. } => {
-                    self.commission(asset, "selected");
+                    self.commission(asset);
                 }
                 _ => panic!(
                     "Cannot extend asset pool with asset in state {}. Only assets in \

--- a/src/asset/pool.rs
+++ b/src/asset/pool.rs
@@ -155,16 +155,16 @@ impl AssetPool {
         std::mem::take(&mut self.assets)
     }
 
-    /// Extend the active pool with Commissioned or Selected assets.
+    /// Extend the active pool with Commissioned or Ready assets.
     ///
-    /// Returns the newly commissioned assets (those that were in `Selected` state on entry).
+    /// Returns the newly commissioned assets (those that were in `Ready` state on entry).
     pub fn extend<I>(&mut self, assets: I) -> &[AssetRef]
     where
         I: IntoIterator<Item = AssetRef>,
     {
         let first_new_id = self.next_id;
 
-        // Check all assets are either Commissioned or Selected, and, if the latter,
+        // Check all assets are either Commissioned or Ready, and, if the latter,
         // then commission them
         for mut asset in assets {
             match &asset.state {
@@ -172,12 +172,12 @@ impl AssetPool {
                     asset.make_mut().unmothball();
                     self.assets.push(asset);
                 }
-                AssetState::Selected { .. } => {
+                AssetState::Ready { .. } => {
                     self.commission(asset, "selected");
                 }
                 _ => panic!(
                     "Cannot extend asset pool with asset in state {}. Only assets in \
-                Commissioned or Selected states are allowed.",
+                    Commissioned or Ready states are allowed.",
                     asset.state
                 ),
             }
@@ -406,7 +406,7 @@ mod tests {
         // Create new non-commissioned assets
         let process_rc = Rc::new(process);
         let new_assets = vec![
-            Asset::new_selected(
+            Asset::new_ready(
                 "agent2".into(),
                 Rc::clone(&process_rc),
                 "GBR".into(),
@@ -415,7 +415,7 @@ mod tests {
             )
             .unwrap()
             .into(),
-            Asset::new_selected(
+            Asset::new_ready(
                 "agent3".into(),
                 Rc::clone(&process_rc),
                 "GBR".into(),
@@ -456,7 +456,7 @@ mod tests {
         process.unit_size = Some(Capacity(4.0));
         let process_rc = Rc::new(process);
         let new_assets: Vec<AssetRef> = vec![
-            Asset::new_selected(
+            Asset::new_ready(
                 "agent2".into(),
                 Rc::clone(&process_rc),
                 "GBR".into(),
@@ -484,10 +484,10 @@ mod tests {
         let initial_count = initial_assets.len();
         let existing_assets = asset_pool.take();
 
-        // Add one selected divisible asset so extend commissions multiple new children
+        // Add one ready divisible asset so extend() commissions multiple new children
         process.unit_size = Some(Capacity(4.0));
         let process_rc = Rc::new(process);
-        let selected_divisible: AssetRef = Asset::new_selected(
+        let ready_divisible: AssetRef = Asset::new_ready(
             "agent_selected".into(),
             Rc::clone(&process_rc),
             "GBR".into(),
@@ -496,15 +496,15 @@ mod tests {
         )
         .unwrap()
         .into();
-        let expected_new = expected_children_for_divisible(&selected_divisible);
+        let expected_new = expected_children_for_divisible(&ready_divisible);
 
-        // Extend with a mix of existing commissioned assets and one selected divisible asset
+        // Extend with a mix of existing commissioned assets and one ready divisible asset
         let returned = asset_pool
             .extend(
                 existing_assets
                     .iter()
                     .cloned()
-                    .chain(iter::once(selected_divisible)),
+                    .chain(iter::once(ready_divisible)),
             )
             .to_vec();
 
@@ -526,7 +526,7 @@ mod tests {
         asset_pool.commission_new(2020, &mut user_assets);
 
         // Create a new non-commissioned asset
-        let new_asset = Asset::new_selected(
+        let new_asset = Asset::new_ready(
             "agent_new".into(),
             process.into(),
             "GBR".into(),
@@ -562,7 +562,7 @@ mod tests {
         // Create new assets that would be out of order if added at the end
         let process_rc = Rc::new(process);
         let new_assets = vec![
-            Asset::new_selected(
+            Asset::new_ready(
                 "agent_high_id".into(),
                 Rc::clone(&process_rc),
                 "GBR".into(),
@@ -571,7 +571,7 @@ mod tests {
             )
             .unwrap()
             .into(),
-            Asset::new_selected(
+            Asset::new_ready(
                 "agent_low_id".into(),
                 Rc::clone(&process_rc),
                 "GBR".into(),
@@ -618,7 +618,7 @@ mod tests {
         // Create new non-commissioned assets
         let process_rc = Rc::new(process);
         let new_assets = vec![
-            Asset::new_selected(
+            Asset::new_ready(
                 "agent1".into(),
                 Rc::clone(&process_rc),
                 "GBR".into(),
@@ -627,7 +627,7 @@ mod tests {
             )
             .unwrap()
             .into(),
-            Asset::new_selected(
+            Asset::new_ready(
                 "agent2".into(),
                 Rc::clone(&process_rc),
                 "GBR".into(),

--- a/src/asset/pool.rs
+++ b/src/asset/pool.rs
@@ -1,5 +1,5 @@
 //! Defines a data structure for representing the current active pool of assets.
-use super::{AssetID, AssetRef, AssetState};
+use super::{AssetID, AssetRef, AssetState, UserAsset};
 use itertools::Itertools;
 use log::warn;
 use std::cmp::min;
@@ -30,7 +30,7 @@ impl AssetPool {
     /// Commission new assets for the specified milestone year from the input data.
     ///
     /// Returns the newly commissioned assets (children, for divisible assets).
-    pub fn commission_new(&mut self, year: u32, user_assets: &mut Vec<AssetRef>) -> &[AssetRef] {
+    pub fn commission_new(&mut self, year: u32, user_assets: &mut Vec<UserAsset>) -> &[AssetRef] {
         let start = self.assets.len();
         let to_commission = user_assets.extract_if(.., |asset| asset.commission_year <= year);
 
@@ -47,7 +47,7 @@ impl AssetPool {
                 continue;
             }
 
-            self.commission(asset);
+            self.commission(asset.into());
         }
 
         &self.assets[start..]
@@ -214,7 +214,7 @@ mod tests {
     use std::rc::Rc;
 
     #[fixture]
-    fn user_assets(mut process: Process) -> Vec<AssetRef> {
+    fn user_assets(mut process: Process) -> Vec<UserAsset> {
         // Update process parameters (lifetime = 20 years)
         let process_param = ProcessParameter {
             capital_cost: MoneyPerCapacity(5.0),
@@ -229,15 +229,15 @@ mod tests {
         let rc_process = Rc::new(process);
         [2020, 2010]
             .map(|year| {
-                Asset::new_future(
+                UserAsset::new(
                     "agent1".into(),
                     Rc::clone(&rc_process),
                     "GBR".into(),
                     Capacity(1.0),
                     year,
+                    None,
                 )
                 .unwrap()
-                .into()
             })
             .into_iter()
             .collect_vec()
@@ -249,7 +249,7 @@ mod tests {
     }
 
     #[rstest]
-    fn asset_pool_commission_new1(mut user_assets: Vec<AssetRef>) {
+    fn asset_pool_commission_new1(mut user_assets: Vec<UserAsset>) {
         // Asset to be commissioned in this year
         let mut asset_pool = AssetPool::new();
         asset_pool.commission_new(2010, &mut user_assets);
@@ -257,7 +257,7 @@ mod tests {
     }
 
     #[rstest]
-    fn asset_pool_commission_new2(mut user_assets: Vec<AssetRef>) {
+    fn asset_pool_commission_new2(mut user_assets: Vec<UserAsset>) {
         // Commission year has passed
         let mut asset_pool = AssetPool::new();
         asset_pool.commission_new(2011, &mut user_assets);
@@ -265,7 +265,7 @@ mod tests {
     }
 
     #[rstest]
-    fn asset_pool_commission_new3(mut user_assets: Vec<AssetRef>) {
+    fn asset_pool_commission_new3(mut user_assets: Vec<UserAsset>) {
         // Nothing to commission for this year
         let mut asset_pool = AssetPool::new();
         asset_pool.commission_new(2000, &mut user_assets);
@@ -338,7 +338,7 @@ mod tests {
     }
 
     #[rstest]
-    fn asset_pool_decommission_old(mut user_assets: Vec<AssetRef>) {
+    fn asset_pool_decommission_old(mut user_assets: Vec<UserAsset>) {
         let mut asset_pool = AssetPool::new();
         asset_pool.commission_new(2020, &mut user_assets);
         assert!(user_assets.is_empty());
@@ -360,7 +360,7 @@ mod tests {
     }
 
     #[rstest]
-    fn asset_pool_get(mut user_assets: Vec<AssetRef>) {
+    fn asset_pool_get(mut user_assets: Vec<UserAsset>) {
         let mut asset_pool = AssetPool::new();
         asset_pool.commission_new(2020, &mut user_assets);
         assert_eq!(asset_pool.get(AssetID(0)), Some(&asset_pool.assets[0]));
@@ -368,7 +368,7 @@ mod tests {
     }
 
     #[rstest]
-    fn asset_pool_extend_empty(mut user_assets: Vec<AssetRef>) {
+    fn asset_pool_extend_empty(mut user_assets: Vec<UserAsset>) {
         // Start with commissioned assets
         let mut asset_pool = AssetPool::new();
         asset_pool.commission_new(2020, &mut user_assets);
@@ -381,7 +381,7 @@ mod tests {
     }
 
     #[rstest]
-    fn asset_pool_extend_existing_assets(mut user_assets: Vec<AssetRef>) {
+    fn asset_pool_extend_existing_assets(mut user_assets: Vec<UserAsset>) {
         // Start with some commissioned assets
         let mut asset_pool = AssetPool::new();
         asset_pool.commission_new(2020, &mut user_assets);
@@ -397,7 +397,7 @@ mod tests {
     }
 
     #[rstest]
-    fn asset_pool_extend_new_assets(mut user_assets: Vec<AssetRef>, process: Process) {
+    fn asset_pool_extend_new_assets(mut user_assets: Vec<UserAsset>, process: Process) {
         // Start with some commissioned assets
         let mut asset_pool = AssetPool::new();
         asset_pool.commission_new(2020, &mut user_assets);
@@ -444,7 +444,7 @@ mod tests {
 
     #[rstest]
     fn asset_pool_extend_new_divisible_assets(
-        mut user_assets: Vec<AssetRef>,
+        mut user_assets: Vec<UserAsset>,
         mut process: Process,
     ) {
         // Start with some commissioned assets
@@ -474,7 +474,7 @@ mod tests {
     #[rstest]
     #[allow(clippy::cast_possible_truncation)]
     fn asset_pool_extend_returns_only_newly_commissioned_assets(
-        mut user_assets: Vec<AssetRef>,
+        mut user_assets: Vec<UserAsset>,
         mut process: Process,
     ) {
         let mut asset_pool = AssetPool::new();
@@ -520,7 +520,7 @@ mod tests {
     }
 
     #[rstest]
-    fn asset_pool_extend_mixed_assets(mut user_assets: Vec<AssetRef>, process: Process) {
+    fn asset_pool_extend_mixed_assets(mut user_assets: Vec<UserAsset>, process: Process) {
         // Start with some commissioned assets
         let mut asset_pool = AssetPool::new();
         asset_pool.commission_new(2020, &mut user_assets);
@@ -554,7 +554,7 @@ mod tests {
     }
 
     #[rstest]
-    fn asset_pool_extend_maintains_sort_order(mut user_assets: Vec<AssetRef>, process: Process) {
+    fn asset_pool_extend_maintains_sort_order(mut user_assets: Vec<UserAsset>, process: Process) {
         // Start with some commissioned assets
         let mut asset_pool = AssetPool::new();
         asset_pool.commission_new(2020, &mut user_assets);
@@ -590,7 +590,7 @@ mod tests {
     }
 
     #[rstest]
-    fn asset_pool_extend_no_duplicates_expected(mut user_assets: Vec<AssetRef>) {
+    fn asset_pool_extend_no_duplicates_expected(mut user_assets: Vec<UserAsset>) {
         // Start with some commissioned assets
         let mut asset_pool = AssetPool::new();
         asset_pool.commission_new(2020, &mut user_assets);
@@ -609,7 +609,7 @@ mod tests {
     }
 
     #[rstest]
-    fn asset_pool_extend_increments_next_id(mut user_assets: Vec<AssetRef>, process: Process) {
+    fn asset_pool_extend_increments_next_id(mut user_assets: Vec<UserAsset>, process: Process) {
         // Start with some commissioned assets
         let mut asset_pool = AssetPool::new();
         asset_pool.commission_new(2020, &mut user_assets);
@@ -647,7 +647,7 @@ mod tests {
     }
 
     #[rstest]
-    fn asset_pool_mothball_unretained(mut user_assets: Vec<AssetRef>) {
+    fn asset_pool_mothball_unretained(mut user_assets: Vec<UserAsset>) {
         // Commission some assets
         let mut asset_pool = AssetPool::new();
         asset_pool.commission_new(2020, &mut user_assets);
@@ -667,7 +667,7 @@ mod tests {
     }
 
     #[rstest]
-    fn asset_pool_decommission_unused(mut user_assets: Vec<AssetRef>) {
+    fn asset_pool_decommission_unused(mut user_assets: Vec<UserAsset>) {
         // Commission some assets
         let mut asset_pool = AssetPool::new();
         asset_pool.commission_new(2020, &mut user_assets);
@@ -692,7 +692,7 @@ mod tests {
     }
 
     #[rstest]
-    fn asset_pool_decommission_if_not_active_none_active(mut user_assets: Vec<AssetRef>) {
+    fn asset_pool_decommission_if_not_active_none_active(mut user_assets: Vec<UserAsset>) {
         // Commission some assets
         let mut asset_pool = AssetPool::new();
         asset_pool.commission_new(2020, &mut user_assets);
@@ -716,7 +716,7 @@ mod tests {
     #[should_panic(expected = "Cannot mothball asset that has not been commissioned")]
     fn asset_pool_decommission_if_not_active_non_commissioned_asset(process: Process) {
         // Create a non-commissioned asset
-        let non_commissioned_asset = Asset::new_future(
+        let non_commissioned_asset = Asset::new_ready(
             "agent_new".into(),
             process.into(),
             "GBR".into(),

--- a/src/fixture.rs
+++ b/src/fixture.rs
@@ -200,7 +200,7 @@ pub fn asset(process: Process) -> Asset {
     let region_id: RegionID = "GBR".into();
     let agent_id = "agent1".into();
     let commission_year = 2015;
-    Asset::new_future(
+    Asset::new_ready(
         agent_id,
         process.into(),
         region_id,
@@ -213,7 +213,7 @@ pub fn asset(process: Process) -> Asset {
 #[fixture]
 pub fn asset_divisible(mut process: Process) -> Asset {
     process.unit_size = Some(Capacity(4.0));
-    Asset::new_future(
+    Asset::new_ready(
         "agent1".into(),
         Rc::new(process),
         "GBR".into(),

--- a/src/input/asset.rs
+++ b/src/input/asset.rs
@@ -1,7 +1,7 @@
-//! Code for reading [`Asset`]s from a CSV file.
+//! Code for reading user assets from a CSV file.
 use super::{input_err_msg, read_csv_optional};
 use crate::agent::AgentID;
-use crate::asset::{Asset, AssetRef};
+use crate::asset::UserAsset;
 use crate::id::{GetIDValue, IDCollection};
 use crate::process::ProcessMap;
 use crate::region::RegionID;
@@ -39,13 +39,13 @@ struct AssetRaw {
 ///
 /// # Returns
 ///
-/// A `Vec` of [`AssetRef`]s or an error.
+/// A `Vec` of [`UserAsset`]s or an error.
 pub fn read_user_assets(
     model_dir: &Path,
     agent_ids: &IndexSet<AgentID>,
     processes: &ProcessMap,
     region_ids: &IndexSet<RegionID>,
-) -> Result<Vec<AssetRef>> {
+) -> Result<Vec<UserAsset>> {
     let file_path = model_dir.join(ASSETS_FILE_NAME);
     let assets_csv = read_csv_optional(&file_path)?;
     read_assets_from_iter(assets_csv, agent_ids, processes, region_ids)
@@ -63,13 +63,13 @@ pub fn read_user_assets(
 ///
 /// # Returns
 ///
-/// A [`Vec`] of [`Asset`]s or an error.
+/// A [`Vec`] of [`UserAsset`]s or an error.
 fn read_assets_from_iter<I>(
     iter: I,
     agent_ids: &IndexSet<AgentID>,
     processes: &ProcessMap,
     region_ids: &IndexSet<RegionID>,
-) -> Result<Vec<AssetRef>>
+) -> Result<Vec<UserAsset>>
 where
     I: Iterator<Item = AssetRaw>,
 {
@@ -122,15 +122,14 @@ where
             }
         }
 
-        let asset = Asset::new_future_with_max_decommission(
+        UserAsset::new(
             agent_id.clone(),
             Rc::clone(process),
             region_id.clone(),
             asset.capacity,
             asset.commission_year,
             asset.max_decommission_year,
-        )?;
-        Ok(asset.into())
+        )
     })
     .try_collect()
 }
@@ -166,7 +165,7 @@ mod tests {
             commission_year: 2010,
             max_decommission_year,
         };
-        let asset_out = Asset::new_future_with_max_decommission(
+        let asset_out = UserAsset::new(
             "agent1".into(),
             Rc::clone(processes.values().next().unwrap()),
             "GBR".into(),
@@ -174,8 +173,7 @@ mod tests {
             2010,
             max_decommission_year,
         )
-        .unwrap()
-        .into();
+        .unwrap();
         assert_equal(
             read_assets_from_iter(iter::once(asset_in), &agent_ids, &processes, &region_ids)
                 .unwrap(),

--- a/src/model.rs
+++ b/src/model.rs
@@ -1,6 +1,6 @@
 //! The model represents the static input data provided by the user.
 use crate::agent::AgentMap;
-use crate::asset::AssetRef;
+use crate::asset::UserAsset;
 use crate::commodity::{CommodityID, CommodityMap};
 use crate::process::ProcessMap;
 use crate::region::{Region, RegionID, RegionMap};
@@ -31,7 +31,7 @@ pub struct Model {
     /// Regions for the simulation
     pub regions: RegionMap,
     /// User-defined assets
-    pub user_assets: Vec<AssetRef>,
+    pub user_assets: Vec<UserAsset>,
     /// Commodity ordering for each milestone year
     pub investment_order: HashMap<u32, Vec<InvestmentSet>>,
 }

--- a/src/simulation/investment.rs
+++ b/src/simulation/investment.rs
@@ -181,7 +181,7 @@ pub fn perform_agent_investment(
         flatten_preset_demands_for_year(&model.commodities, &model.time_slice_info, year);
 
     // Keep a list of all the assets selected
-    // This includes Commissioned assets that are selected for retention, and new Selected assets
+    // This includes Commissioned assets that are selected for retention, and new Ready assets
     let mut all_selected_assets = Vec::new();
 
     let investment_order = &model.investment_order[&year];
@@ -321,7 +321,7 @@ fn select_assets_for_single_market(
 /// market in turn.
 ///
 /// Dispatch optimisation is performed after each market is visited to rebalance demand.
-/// While dispatching, newly selected (`Selected`) assets are given flexible capacity (bounded by
+/// While dispatching, newly selected (`Ready`) assets are given flexible capacity (bounded by
 /// `capacity_margin`) so small demand shifts caused by later markets can be absorbed. After all
 /// markets have been visited once, the final set of assets is returned, applying any capacity
 /// adjustments from the final full-system dispatch optimisation.
@@ -376,10 +376,10 @@ fn select_assets_for_cycle(
         let mut markets_to_balance = seen_markets.to_vec();
         markets_to_balance.extend_from_slice(&markets[0..=idx]);
 
-        // We allow all `Selected` state assets to have flexible capacity
+        // We allow all `Ready` state assets to have flexible capacity
         let flexible_capacity_assets: Vec<_> = assets_for_cycle_flat
             .iter()
-            .filter(|asset| matches!(asset.state(), AssetState::Selected { .. }))
+            .filter(|asset| matches!(asset.state(), AssetState::Ready { .. }))
             .cloned()
             .collect();
 
@@ -856,7 +856,7 @@ fn select_best_assets(
         round += 1;
     }
 
-    // Convert Candidate assets to Selected
+    // Convert Candidate assets to Ready
     // At this point we also assign the agent ID to the asset
     for asset in &mut best_assets {
         if let AssetState::Candidate = asset.state() {

--- a/src/simulation/optimisation.rs
+++ b/src/simulation/optimisation.rs
@@ -800,10 +800,10 @@ fn add_capacity_variables(
     let start = problem.num_cols();
 
     for asset in assets {
-        // Can only have flexible capacity for `Selected` assets
+        // Can only have flexible capacity for `Ready` assets
         assert!(
-            matches!(asset.state(), AssetState::Selected { .. }),
-            "Flexible capacity can only be assigned to `Selected` type assets. Offending asset: {asset:?}"
+            matches!(asset.state(), AssetState::Ready { .. }),
+            "Flexible capacity can only be assigned to `Ready` type assets. Offending asset: {asset:?}"
         );
 
         let current_capacity = asset.capacity();


### PR DESCRIPTION
# Description

As I mentioned in #1255, I think it would be a good idea to define different structs to represent different kinds of assets, rather than having the differences encapsulated in their `AssetState`.

As one step along that path, I've defined a separate type for user assets, which removes the need for the `AssetState::Future` variant. As the data contained in `AssetState::Future` and `AssetState::Selected` was the same, I combined the two into a new `AssetState::Ready` variant. All user assets should be represented with the `UserAsset` type, so we shouldn't confuse these with `Selected` assets.

Longer term, I'd like to get rid of the `state` field of `Asset` altogether (see #1255). Once we get rid of child assets (#1123), we won't have the `AssetState::Parent` variant either. At that point, it will be easier to turn the others into separate structs too.

## Type of change

- [ ] Bug fix (non-breaking change to fix an issue)
- [ ] New feature (non-breaking change to add functionality)
- [x] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [ ] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`
- [ ] Update release notes for the latest release if this PR adds a new feature or fixes a bug
      present in the previous release

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
