### PR TITLE
Fix CI failures on Windows runner by bumping version of `cmake` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -149,7 +149,7 @@ dependencies = [
  "quote",
  "regex",
  "rustc-hash",
- "shlex",
+ "shlex 1.3.0",
  "syn",
 ]
 
@@ -188,14 +188,14 @@ checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
 name = "cc"
-version = "1.2.36"
+version = "1.2.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5252b3d2648e5eedbc1a6f501e3c795e07025c1e93bbf8bbdd6eef7f447a6d54"
+checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
  "libc",
- "shlex",
+ "shlex 2.0.1",
 ]
 
 [[package]]
@@ -288,9 +288,9 @@ checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
 name = "cmake"
-version = "0.1.54"
+version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7caa3f9de89ddbe2c607f4101924c5abec803763ae9534e4f4d7d8f84aa81f0"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
 dependencies = [
  "cc",
 ]
@@ -494,9 +494,9 @@ dependencies = [
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.1"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fd99930f64d146689264c637b5af2f0233a933bef0d8570e2526bf9e083192d"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "fixedbitset"
@@ -1363,6 +1363,12 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "siphasher"


### PR DESCRIPTION
# Description

CI is currently failing to run `cargo test` on the Windows runner, giving error messages like:

```
error: failed to run custom build command for `highs-sys v1.12.1`
note: To improve backtraces for build dependencies, set the CARGO_PROFILE_TEST_BUILD_OVERRIDE_DEBUG=true environment variable to enable debug information generation.
Caused by:
  process didn't exit successfully: `D:\a\MUSE2\MUSE2\target\debug\build\highs-sys-fc7c23690354f87c\build-script-build` (exit code: 101)
```

The problem seems to be that the `windows-latest` image has been [updated to Visual Studio 2026](https://github.com/actions/runner-images/issues/14017), which isn't supported by the version of the `cmake` crate we have pinned in `Cargo.lock` (v0.1.54), although [it has now been fixed](https://github.com/rust-lang/cmake-rs/issues/253).

Seemingly dependabot doesn't update the versions of transitive deps in `Cargo.lock` ([it's the same for `uv`](https://github.com/ImperialCollegeLondon/python-template/issues/551)), so that's why we're stuck on an old version. Maybe it would be worth setting up a GitHub workflow to do this periodically.

Fix by manually bumping the version of the `cmake` dependency with `cargo update -p cmake --precise 0.1.58`.

I initially just ran `cargo generate-lockfile`, which bumps the versions of all transitive dependencies. The problem with this is that it also bumped the version of the `highs-sys` crate (which bundles the HiGHS C++ code) and this caused a load of regression tests to fail! On reflection, it makes sense that changes to HiGHS would lead to different results, but it's probably something we should be mindful of (for example, anyone installing MUSE2 with `cargo install` should add the `--locked` flag, if they want to ensure they get the same results as other users). I think it's worth bumping the version of `highs-sys` we're using too, but this PR probably isn't the place to do that.

## Type of change

- [x] Bug fix (non-breaking change to fix an issue)
- [ ] New feature (non-breaking change to add functionality)
- [ ] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [ ] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`
- [ ] Update release notes for the latest release if this PR adds a new feature or fixes a bug
      present in the previous release

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
