### PR TITLE
Include a link to the docs in the cli help

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -17,7 +17,14 @@ use settings::SettingsSubcommands;
 
 /// The command line interface for the simulation.
 #[derive(Parser)]
-#[command(version, about)]
+#[command(
+    version,
+    about,
+    after_help = format!(
+        "For more detailed documentation on this version of MUSE2, see: https://energysystemsmodellinglab.github.io/MUSE2/release/v{}/",
+        env!("CARGO_PKG_VERSION")
+    )
+)]
 struct Cli {
     /// The available commands.
     #[command(subcommand)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -20,9 +20,10 @@ use settings::SettingsSubcommands;
 #[command(
     version,
     about,
-    after_help = format!(
-        "For more detailed documentation on this version of MUSE2, see: https://energysystemsmodellinglab.github.io/MUSE2/release/v{}/",
-        env!("CARGO_PKG_VERSION")
+    after_help = concat!(
+        "For more detailed documentation on this version of MUSE2, see: https://energysystemsmodellinglab.github.io/MUSE2/release/v",
+        env!("CARGO_PKG_VERSION"),
+        "/"
     )
 )]
 struct Cli {

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -11,6 +11,20 @@ const EXAMPLE_NAME: &str = "simple";
 const MODEL_DIR: &str = "examples/simple";
 const PATCH_EXAMPLE_NAME: &str = "simple_divisible";
 
+/// Test the `help` command
+#[test]
+fn check_help_command() {
+    assert!(
+        get_muse2_stdout(&["help"]).contains(
+            format!(
+                "https://energysystemsmodellinglab.github.io/MUSE2/release/v{}/",
+                env!("CARGO_PKG_VERSION")
+            )
+            .as_str()
+        )
+    );
+}
+
 /// Test the `run` command
 #[test]
 fn check_run_command() {


### PR DESCRIPTION
# Description

This PR adds a link to the docs for the corresponding version of muse to the help text when running `muse2 help` (or `--help` or `-h`).

This turned out to be fairly simple. Let me know if there is a preferred option for the specific text. Output is currently:

```
$ muse2 help
A tool for running simulations of energy systems

Usage: muse2 [COMMAND]

Commands:
  run          Run a simulation model
  example      Manage example models
  validate     Validate a model
  save-graphs  Build and output commodity flow graphs for a model
  settings     Manage settings file
  help         Print this message or the help of the given subcommand(s)

Options:
  -h, --help     Print help
  -V, --version  Print version

For more detailed documentation on this version of MUSE2, see: https://energysystemsmodellinglab.github.io/MUSE2/release/v2.1.0/
```

Fixes #1073 

## Type of change

- [ ] Bug fix (non-breaking change to fix an issue)
- [ ] New feature (non-breaking change to add functionality)
- [ ] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [ ] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`
- [ ] Update release notes for the latest release if this PR adds a new feature or fixes a bug
      present in the previous release

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
