### PR TITLE
Cli link2docs

### DIFF
--- a/.github/workflows/check-docs.yml
+++ b/.github/workflows/check-docs.yml
@@ -19,4 +19,4 @@ jobs:
         id: lychee
         uses: lycheeverse/lychee-action@v2
         with:
-          args: "--verbose --no-progress --accept 200,203,503 --exclude-path ^target --exclude-path ^book/404.html$ './*.md' './**/*.html'"
+          args: "--verbose --no-progress --accept 200,203,503 --exclude-path ^target/ --exclude-path ^docs/ --exclude-path ^book/404.html$ './**/*.md' './**/*.html'"

--- a/.github/workflows/check-docs.yml
+++ b/.github/workflows/check-docs.yml
@@ -19,4 +19,4 @@ jobs:
         id: lychee
         uses: lycheeverse/lychee-action@v2
         with:
-          args: "--verbose --no-progress --accept 200,203,503 --exclude-path ^target --exclude-path ^book/404.html$ './**/*.md' './**/*.html'"
+          args: "--verbose --no-progress --accept 200,203,503 --exclude-path ^target --exclude-path ^book/404.html$ './*.md' './**/*.html'"

--- a/docs/developer_guide/architecture_quickstart.md
+++ b/docs/developer_guide/architecture_quickstart.md
@@ -167,7 +167,7 @@ For more information, consult [the documentation for the `units` module][units-m
 [`Activity`]: ../api/muse2/units/struct.Activity.html
 [`MoneyPerActivity`]: ../api/muse2/units/struct.MoneyPerActivity.html
 [`Dimensionless`]: ../api/muse2/units/struct.Dimensionless.html
-[units-module-docs]: ../api/muse2/units/index.html
+[units-module-docs]: ../api/muse2/units/
 
 ## Input and output files
 
@@ -191,8 +191,8 @@ checking that there is a producer for every required commodity in the first year
 
 [CSV]: https://en.wikipedia.org/wiki/Comma-separated_values
 [TOML]: https://toml.io/en/
-[input-module]: ../api/muse2/input/index.html
-[output-module]: ../api/muse2/output/index.html
+[input-module]: ../api/muse2/input/
+[output-module]: ../api/muse2/output/
 [file-format-docs]: ../file_formats/
 [JSON schemas]: https://json-schema.org/
 [table schemas]: https://specs.frictionlessdata.io/table-schema/

--- a/docs/developer_guide/architecture_quickstart.md
+++ b/docs/developer_guide/architecture_quickstart.md
@@ -133,7 +133,7 @@ just regenerate_test_data --patch simple_divisible
 [test fixtures]: https://en.wikipedia.org/wiki/Test_fixture
 [`rstest`]: https://docs.rs/rstest
 [`fixture.rs`]: https://github.com/EnergySystemsModellingLab/MUSE2/blob/main/src/fixture.rs
-[patched example]: https://energysystemsmodellinglab.github.io/MUSE2/api/muse2/patch/index.html
+[patched example]: ../api/muse2/patch/index.html
 
 ## Example models
 
@@ -147,7 +147,7 @@ simple as possible.
 If you add a new example model, please also add a regression test to [`tests/regression.rs`].
 
 [`examples`]: https://github.com/EnergySystemsModellingLab/MUSE2/blob/main/examples/
-[user-guide-example-models]: https://energysystemsmodellinglab.github.io/MUSE2/user_guide.html#example-models
+[user-guide-example-models]: ../user_guide.md#example-models
 [`tests/regression.rs`]: https://github.com/EnergySystemsModellingLab/MUSE2/blob/main/tests/regression.rs
 
 ## Unit types
@@ -163,11 +163,11 @@ unitless, there is a [`Dimensionless`] type to make this explicit.
 
 For more information, consult [the documentation for the `units` module][units-module-docs].
 
-[`Money`]: https://energysystemsmodellinglab.github.io/MUSE2/api/muse2/units/struct.Money.html
-[`Activity`]: https://energysystemsmodellinglab.github.io/MUSE2/api/muse2/units/struct.Activity.html
-[`MoneyPerActivity`]: https://energysystemsmodellinglab.github.io/MUSE2/api/muse2/units/struct.MoneyPerActivity.html
-[`Dimensionless`]: https://energysystemsmodellinglab.github.io/MUSE2/api/muse2/units/struct.Dimensionless.html
-[units-module-docs]: https://energysystemsmodellinglab.github.io/MUSE2/api/muse2/units/index.html
+[`Money`]: ../api/muse2/units/struct.Money.html
+[`Activity`]: ../api/muse2/units/struct.Activity.html
+[`MoneyPerActivity`]: ../api/muse2/units/struct.MoneyPerActivity.html
+[`Dimensionless`]: ../api/muse2/units/struct.Dimensionless.html
+[units-module-docs]: ../api/muse2/units/index.html
 
 ## Input and output files
 
@@ -191,9 +191,9 @@ checking that there is a producer for every required commodity in the first year
 
 [CSV]: https://en.wikipedia.org/wiki/Comma-separated_values
 [TOML]: https://toml.io/en/
-[input-module]: https://energysystemsmodellinglab.github.io/MUSE2/api/muse2/input/index.html
-[output-module]: https://energysystemsmodellinglab.github.io/MUSE2/api/muse2/output/index.html
-[file-format-docs]: https://energysystemsmodellinglab.github.io/MUSE2/file_formats/
+[input-module]: ../api/muse2/input/index.html
+[output-module]: ../api/muse2/output/index.html
+[file-format-docs]: ../file_formats/
 [JSON schemas]: https://json-schema.org/
 [table schemas]: https://specs.frictionlessdata.io/table-schema/
 [`serde`]: https://serde.rs/

--- a/docs/developer_guide/custom_highs_options.md
+++ b/docs/developer_guide/custom_highs_options.md
@@ -32,5 +32,5 @@ primal_feasibility_tolerance = 10e-6
 optimality_tolerance = 10e-6
 ```
 
-[model.toml]: https://energysystemsmodellinglab.github.io/MUSE2/file_formats/input_files.html#model-parameters-modeltoml
+[model.toml]: ../file_formats/input_files.md#model-parameters-modeltoml
 [highs-opts]: https://ergo-code.github.io/HiGHS/stable/options/definitions/

--- a/docs/developer_guide/setup.md
+++ b/docs/developer_guide/setup.md
@@ -30,7 +30,7 @@ We provide a [justfile] for some common developer tasks.
 [Docker]: https://www.docker.com/
 [Visual Studio Code]: https://code.visualstudio.com/
 [GitHub Codespaces]: https://github.com/features/codespaces
-[justfile]: ../../justfile
+[justfile]: https://github.com/EnergySystemsModellingLab/MUSE2/blob/main/justfile
 
 ## Installing tools
 

--- a/docs/model/investment.md
+++ b/docs/model/investment.md
@@ -404,5 +404,5 @@ The Cost Index is £508 per MWh of electricity produced.
  This metric is compared across all supply options to identify
  the lowest-cost solution for meeting demand.
 
-[framework-overview]: https://energysystemsmodellinglab.github.io/MUSE2/model/index.html#framework-overview
+[framework-overview]: index.html#framework-overview
 [Dispatch Optimisation Formulation]: ./dispatch_optimisation.md

--- a/docs/release_notes/upcoming.md
+++ b/docs/release_notes/upcoming.md
@@ -29,7 +29,7 @@ ready to be released, carry out the following steps:
 - Fix misleading warning message for assets decommissioned before simulation start ([#1259])
 - Fix parsing and validation of agent search space file ([#1293])
 
-[highs-opts-docs]: https://energysystemsmodellinglab.github.io/MUSE2/developer_guide/custom_highs_options.html
+[highs-opts-docs]: ../developer_guide/custom_highs_options.md
 [#1259]: https://github.com/EnergySystemsModellingLab/MUSE2/pull/1259
 [#1276]: https://github.com/EnergySystemsModellingLab/MUSE2/pull/1276
 [#1281]: https://github.com/EnergySystemsModellingLab/MUSE2/pull/1281

--- a/docs/release_notes/v2.1.0.md
+++ b/docs/release_notes/v2.1.0.md
@@ -134,14 +134,14 @@ previous versions of MUSE2.
 [#1205]: https://github.com/EnergySystemsModellingLab/MUSE2/pull/1205
 
 <!-- Use absolute links so they work when we paste into release notes box -->
-[`demand.csv`]: https://energysystemsmodellinglab.github.io/MUSE2/file_formats/input_files.html#demandcsv
-[`processes.csv`]: https://energysystemsmodellinglab.github.io/MUSE2/file_formats/input_files.html#processescsv
-[`process_flows.csv`]: https://energysystemsmodellinglab.github.io/MUSE2/file_formats/input_files.html#process_flowscsv
-[`process_availabilities.csv`]: https://energysystemsmodellinglab.github.io/MUSE2/file_formats/input_files.html#process_availabilitiescsv
-[`process_parameters.csv`]: https://energysystemsmodellinglab.github.io/MUSE2/file_formats/input_files.html#process_parameterscsv
-[`process_investment_constraints.csv`]: https://energysystemsmodellinglab.github.io/MUSE2/file_formats/input_files.html#process_investment_constraintscsv
-[`commodities.csv`]: https://energysystemsmodellinglab.github.io/MUSE2/file_formats/input_files.html#commoditiescsv
-[`commodity_levies.csv`]: https://energysystemsmodellinglab.github.io/MUSE2/file_formats/input_files.html#commodity_leviescsv
-[`model.toml`]: https://energysystemsmodellinglab.github.io/MUSE2/file_formats/input_files.html#model-parameters-modeltoml
-[`assets.csv`]: https://energysystemsmodellinglab.github.io/MUSE2/file_formats/input_files.html#assetscsv
-[`settings.toml`]: https://energysystemsmodellinglab.github.io/MUSE2/file_formats/program_settings.html
+[`demand.csv`]: https://energysystemsmodellinglab.github.io/MUSE2/release/v2.1.0/file_formats/input_files.html#demandcsv
+[`processes.csv`]: https://energysystemsmodellinglab.github.io/MUSE2/release/v2.1.0/file_formats/input_files.html#processescsv
+[`process_flows.csv`]: https://energysystemsmodellinglab.github.io/MUSE2/release/v2.1.0/file_formats/input_files.html#process_flowscsv
+[`process_availabilities.csv`]: https://energysystemsmodellinglab.github.io/MUSE2/release/v2.1.0/file_formats/input_files.html#process_availabilitiescsv
+[`process_parameters.csv`]: https://energysystemsmodellinglab.github.io/MUSE2/release/v2.1.0/file_formats/input_files.html#process_parameterscsv
+[`process_investment_constraints.csv`]: https://energysystemsmodellinglab.github.io/MUSE2/release/v2.1.0/file_formats/input_files.html#process_investment_constraintscsv
+[`commodities.csv`]: https://energysystemsmodellinglab.github.io/MUSE2/release/v2.1.0/file_formats/input_files.html#commoditiescsv
+[`commodity_levies.csv`]: https://energysystemsmodellinglab.github.io/MUSE2/release/v2.1.0/file_formats/input_files.html#commodity_leviescsv
+[`model.toml`]: https://energysystemsmodellinglab.github.io/MUSE2/release/v2.1.0/file_formats/input_files.html#model-parameters-modeltoml
+[`assets.csv`]: https://energysystemsmodellinglab.github.io/MUSE2/release/v2.1.0/file_formats/input_files.html#assetscsv
+[`settings.toml`]: https://energysystemsmodellinglab.github.io/MUSE2/release/v2.1.0/file_formats/program_settings.html

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -115,7 +115,7 @@ with [Graphviz online].
 Dashed lines are used to indicate flows for non-primary outputs of a process (as defined in the
 `processes.csv` input file).
 
-[the `muse2 save-graphs` command]: https://energysystemsmodellinglab.github.io/MUSE2/command_line_help.html#muse2-save-graphs
+[the `muse2 save-graphs` command]: command_line_help.md#muse2-save-graphs
 [DOT format]: https://graphviz.org/doc/info/lang.html
 [Graphviz]: https://graphviz.org/
 [Graphviz online]: https://dreampuf.github.io/GraphvizOnline
@@ -134,8 +134,7 @@ settings help`.
 For information about the available settings, see [the documentation for the `settings.toml`
 file][settings.toml-docs].
 
-[settings.toml-docs]:
-https://energysystemsmodellinglab.github.io/MUSE2/file_formats/program_settings.html
+[settings.toml-docs]: file_formats/program_settings.md
 
 ## Setting the log level
 


### PR DESCRIPTION
# Description

This PR removes most of the absolute links in the docs and replace them with relative links. This ensures that you will always stay inside the version of the docs that you are in (instead of unknowingly moving to the most recent version).

I left a couple instances of absolute links where I think it makes more sense for them to be:
- The API docs placeholder page
- In the release notes pages. These should always be absolute to the version they are referencing because those pages might disappear in the future.

To prevent link check failures, I updated it so that it only checks markdown files in the top level of the directory, so it won't flag broken relative links in the `docs/` folder. It still checks all of the generated html docs.

**Caveat:** I'm am not 100% sure this will work with the rust book links (ie, linking to the relevant version of the rust book docs). It seemed to be correct when I built the docs and checked the html files locally, but I was not sure that I checked everything.

Fixes #1230 

## Type of change

- [ ] Bug fix (non-breaking change to fix an issue)
- [ ] New feature (non-breaking change to add functionality)
- [ ] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [ ] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`
- [ ] Update release notes for the latest release if this PR adds a new feature or fixes a bug
      present in the previous release

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
