### PR TITLE
`pre-commit`-related updates

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -60,10 +60,6 @@ repos:
         args: [--fix]
       - id: ruff-format
         types_or: [python]
-  - repo: https://github.com/kynan/nbstripout
-    rev: 0.9.1
-    hooks:
-      - id: nbstripout
   - repo: https://github.com/codespell-project/codespell
     rev: v2.4.2
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -70,7 +70,7 @@ repos:
       - id: codespell
         args: [--ignore-words, .codespell_ignore.txt]
         exclude: \.svg$
-  - repo: https://github.com/EnergySystemsModellingLab/cffconvert
+  - repo: https://github.com/ImperialCollegeLondon/cffconvert
     rev: 2.1.0
     hooks:
       - id: validate-cff

--- a/docs/developer_guide/setup.md
+++ b/docs/developer_guide/setup.md
@@ -94,6 +94,9 @@ The source code will now be available in a folder named `MUSE2`.
 We use [pre-commit] to automatically run a number of hooks for this repository when a new Git
 commit is made. You can run `pre-commit` via our `justfile`, provided you have `uv` installed.
 
+Alternatively, you can use [prek], which aims to be a drop-in replacement for `pre-commit`. Being
+written in Rust, it has no dependencies and can be installed with `cargo`.
+
 You can enable `pre-commit` for this repository with:
 
 ```sh
@@ -107,5 +110,6 @@ Note: you may get errors due to the [`clippy`] hook failing. In this case, you m
 automatically fix them by running `cargo clipfix` (which we have defined as an alias in
 [`.cargo/config.toml`]).
 
+[prek]: https://prek.j178.dev/
 [`clippy`]: https://doc.rust-lang.org/clippy
 [`.cargo/config.toml`]: https://github.com/EnergySystemsModellingLab/MUSE2/blob/main/.cargo/config.toml

--- a/docs/developer_guide/setup.md
+++ b/docs/developer_guide/setup.md
@@ -9,7 +9,7 @@ To develop MUSE2 locally you will need the following components:
 Optional requirements:
 
 - [Just] (recommended)
-- [uv] (required for [pre-commit] and file format documentation)
+- [uv] (required for file format documentation)
 
 You can either install the necessary developer tools locally on your machine manually (a bare metal
 installation) or use the provided [development container]. Bare metal installation should generally
@@ -25,7 +25,6 @@ We provide a [justfile] for some common developer tasks.
 [HiGHS]: https://highs.dev/
 [Just]: https://github.com/casey/just
 [uv]: https://docs.astral.sh/uv/
-[pre-commit]: https://pre-commit.com/
 [development container]: https://devcontainers.github.io/
 [Docker]: https://www.docker.com/
 [Visual Studio Code]: https://code.visualstudio.com/
@@ -91,25 +90,30 @@ The source code will now be available in a folder named `MUSE2`.
 
 ## Pre-Commit hooks
 
-We use [pre-commit] to automatically run a number of hooks for this repository when a new Git
-commit is made. You can run `pre-commit` via our `justfile`, provided you have `uv` installed.
+We use [`prek`] to automatically run a number of hooks for this repository when a new Git
+commit is made. `prek` is a Rust rewrite of the [`pre-commit`] tool (which you can use instead, if
+you prefer).
 
-Alternatively, you can use [prek], which aims to be a drop-in replacement for `pre-commit`. Being
-written in Rust, it has no dependencies and can be installed with `cargo`.
-
-You can enable `pre-commit` for this repository with:
+`prek` can be installed via `cargo`:
 
 ```sh
-just pre-commit install
+cargo install --locked prek
+```
+
+You can enable `prek` for this repository with:
+
+```sh
+prek install
 ```
 
 Thereafter, a series of checks should be run every time you commit with Git. In addition, the
-`pre-commit` hooks are also run as part of the CI pipeline.
+pre-commit hooks are also run as part of the CI pipeline.
 
 Note: you may get errors due to the [`clippy`] hook failing. In this case, you may be able to
 automatically fix them by running `cargo clipfix` (which we have defined as an alias in
 [`.cargo/config.toml`]).
 
-[prek]: https://prek.j178.dev/
+[`prek`]: https://prek.j178.dev/
+[`pre-commit`]: https://pre-commit.com/
 [`clippy`]: https://doc.rust-lang.org/clippy
 [`.cargo/config.toml`]: https://github.com/EnergySystemsModellingLab/MUSE2/blob/main/.cargo/config.toml

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -31,8 +31,8 @@ historical base year.
 
 <!-- markdownlint-disable-next-line MD033 -->
 **Commodity:** A substance (e.g. CO<sub>2</sub>) or form of energy (e.g. electricity) that can be
-produced and/or consumed by *Process*es* in the model. A *Service Demand* is a type of commodity
-that is defined at the end point of the system.
+produced and/or consumed by *Process*es in the model. A *Service Demand* is a type of commodity that
+is defined at the end point of the system.
 
 **Commodity Levy:** Represents a tax, levy or other external cost on a commodity. Levies can be
 applied to all commodity production (sum of output of all processes for that commodity), net

--- a/justfile
+++ b/justfile
@@ -21,7 +21,3 @@ coverage *ARGS:
 # Regenerate data for regression tests
 regenerate_test_data *ARGS:
     @tests/regenerate_test_data.sh {{ARGS}}
-
-# Run the pre-commit tool
-pre-commit *ARGS:
-    @uv tool run pre-commit {{ARGS}}


### PR DESCRIPTION
# Description

A few small `pre-commit`-related changes:

- Remove unneeded `nbstripout` hook
- Update URL for `cffconvert` hook
- Signpost [prek](https://prek.j178.dev/) as an alternative to pre-commit in docs

I toyed with doing #582 and also adding a hook for [mdformat](https://mdformat.readthedocs.io/en/stable/users/installation_and_usage.html) while I was at it, but the alternative YAML formatter ended up fighting with another hook and mdformat was making more changes to the md files than I was comfortable with (not sure if mdbook's slightly weird equation handling might be broken by it), so I left these for now.

Unrelated change:

- Remove stray asterisk in docs

## Type of change

- [ ] Bug fix (non-breaking change to fix an issue)
- [ ] New feature (non-breaking change to add functionality)
- [x] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [x] Documentation (improve or add documentation)

## Key checklist

- [ ] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`
- [ ] Update release notes for the latest release if this PR adds a new feature or fixes a bug
      present in the previous release

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
