### PR TITLE
Tidy-ups for `DataWriter`

### DIFF
--- a/src/asset/pool.rs
+++ b/src/asset/pool.rs
@@ -3,6 +3,7 @@ use super::{AssetID, AssetRef, AssetState, UserAsset};
 use itertools::Itertools;
 use log::warn;
 use std::cmp::min;
+use std::ops::Deref;
 use std::slice;
 
 /// The active pool of [`super::Asset`]s
@@ -196,6 +197,14 @@ impl AssetPool {
             _ => panic!("Active pool should only contain commissioned assets"),
         });
         &self.assets[new_start..]
+    }
+}
+
+impl Deref for AssetPool {
+    type Target = [AssetRef];
+
+    fn deref(&self) -> &Self::Target {
+        self.as_slice()
     }
 }
 

--- a/src/output.rs
+++ b/src/output.rs
@@ -771,7 +771,7 @@ mod tests {
         // Write an asset
         {
             let mut writer = DataWriter::create(dir.path(), dir.path(), false).unwrap();
-            writer.write_assets(assets.as_slice()).unwrap();
+            writer.write_assets(&assets).unwrap();
             writer.flush().unwrap();
         }
 
@@ -835,7 +835,7 @@ mod tests {
         // Write all active assets: divisible children should collapse to one group row
         {
             let mut writer = DataWriter::create(dir.path(), dir.path(), false).unwrap();
-            writer.write_assets(assets.as_slice()).unwrap();
+            writer.write_assets(&assets).unwrap();
             writer.flush().unwrap();
         }
 

--- a/src/output.rs
+++ b/src/output.rs
@@ -650,10 +650,11 @@ impl DataWriter {
     ///
     /// This file is appended to on each invocation. For divisible asset groups, a single row is
     /// emitted per group with the total capacity.
-    pub fn write_asset_capacities<'a, I>(&mut self, milestone_year: u32, assets: I) -> Result<()>
-    where
-        I: Iterator<Item = &'a AssetRef>,
-    {
+    pub fn write_asset_capacities(
+        &mut self,
+        milestone_year: u32,
+        assets: &[AssetRef],
+    ) -> Result<()> {
         let mut seen_group_ids: HashSet<AssetGroupID> = HashSet::new();
         for asset in assets {
             if let Some(parent) = asset.parent() {
@@ -795,7 +796,7 @@ mod tests {
         {
             let mut writer = DataWriter::create(dir.path(), dir.path(), false).unwrap();
             writer
-                .write_asset_capacities(milestone_year, assets.iter())
+                .write_asset_capacities(milestone_year, &assets)
                 .unwrap();
             writer.flush().unwrap();
         }
@@ -873,7 +874,7 @@ mod tests {
         {
             let mut writer = DataWriter::create(dir.path(), dir.path(), false).unwrap();
             writer
-                .write_asset_capacities(milestone_year, assets.iter())
+                .write_asset_capacities(milestone_year, &assets)
                 .unwrap();
             writer.flush().unwrap();
         }

--- a/src/output.rs
+++ b/src/output.rs
@@ -388,12 +388,7 @@ impl DebugDataWriter {
             map.entry((asset, time_slice)).or_default().2 = Some(column_dual);
         }
 
-        for (asset, time_slice, activity, activity_dual, column_dual) in
-            map.iter()
-                .map(|(&(agent, ts), &(activity, activity_dual, column_dual))| {
-                    (agent, ts, activity, activity_dual, column_dual)
-                })
-        {
+        for ((asset, time_slice), (activity, activity_dual, column_dual)) in map {
             let row = DispatchRow {
                 milestone_year,
                 run_description: self.with_context(run_description),

--- a/src/output.rs
+++ b/src/output.rs
@@ -629,10 +629,7 @@ impl DataWriter {
     ///
     /// For divisible asset groups, a single row is emitted per group (using the parent asset's
     /// metadata).
-    pub fn write_assets<'a, I>(&mut self, assets: I) -> Result<()>
-    where
-        I: Iterator<Item = &'a AssetRef>,
-    {
+    pub fn write_assets(&mut self, assets: &[AssetRef]) -> Result<()> {
         let mut seen_group_ids: HashSet<AssetGroupID> = HashSet::new();
         for asset in assets {
             if let Some(parent) = asset.parent() {
@@ -774,7 +771,7 @@ mod tests {
         // Write an asset
         {
             let mut writer = DataWriter::create(dir.path(), dir.path(), false).unwrap();
-            writer.write_assets(assets.iter()).unwrap();
+            writer.write_assets(assets.as_slice()).unwrap();
             writer.flush().unwrap();
         }
 
@@ -824,11 +821,11 @@ mod tests {
     #[rstest]
     fn write_assets_divisible_group_deduplicated(asset_divisible: Asset) {
         let milestone_year = asset_divisible.commission_year();
-        let mut pool = AssetPool::new();
+        let mut assets = AssetPool::new();
         let mut user_assets = vec![asset_divisible.into()];
 
         // Commission a divisible asset so the active pool contains multiple children in one group
-        let commissioned = pool
+        let commissioned = assets
             .commission_new(milestone_year, &mut user_assets)
             .to_vec();
         assert!(commissioned.len() > 1);
@@ -838,7 +835,7 @@ mod tests {
         // Write all active assets: divisible children should collapse to one group row
         {
             let mut writer = DataWriter::create(dir.path(), dir.path(), false).unwrap();
-            writer.write_assets(pool.iter()).unwrap();
+            writer.write_assets(assets.as_slice()).unwrap();
             writer.flush().unwrap();
         }
 
@@ -861,11 +858,11 @@ mod tests {
     #[rstest]
     fn write_asset_capacities_divisible_group_deduplicated(asset_divisible: Asset) {
         let milestone_year = asset_divisible.commission_year();
-        let mut pool = AssetPool::new();
+        let mut assets = AssetPool::new();
         let mut user_assets = vec![asset_divisible.into()];
 
         // Commission a divisible asset so we get several children under one parent/group
-        let commissioned = pool
+        let commissioned = assets
             .commission_new(milestone_year, &mut user_assets)
             .to_vec();
         assert!(commissioned.len() > 1);
@@ -876,7 +873,7 @@ mod tests {
         {
             let mut writer = DataWriter::create(dir.path(), dir.path(), false).unwrap();
             writer
-                .write_asset_capacities(milestone_year, pool.iter())
+                .write_asset_capacities(milestone_year, assets.iter())
                 .unwrap();
             writer.flush().unwrap();
         }

--- a/src/simulation.rs
+++ b/src/simulation.rs
@@ -40,7 +40,7 @@ pub fn run(model: &Model, output_path: &Path, debug_model: bool) -> Result<()> {
 
     // Write assets to file
     writer.write_assets(new_assets)?;
-    writer.write_asset_capacities(year, asset_pool.iter())?;
+    writer.write_asset_capacities(year, &asset_pool)?;
 
     // Gather candidates for the next year, if any
     let next_year = year_iter.peek().copied();
@@ -128,7 +128,7 @@ pub fn run(model: &Model, output_path: &Path, debug_model: bool) -> Result<()> {
 
         // Write newly commissioned assets
         writer.write_assets(&new_assets)?;
-        writer.write_asset_capacities(year, asset_pool.iter())?;
+        writer.write_asset_capacities(year, &asset_pool)?;
 
         // Gather candidates for the next year, if any
         let next_year = year_iter.peek().copied();

--- a/src/simulation.rs
+++ b/src/simulation.rs
@@ -39,7 +39,7 @@ pub fn run(model: &Model, output_path: &Path, debug_model: bool) -> Result<()> {
     let new_assets = asset_pool.commission_new(year, &mut user_assets);
 
     // Write assets to file
-    writer.write_assets(new_assets.iter())?;
+    writer.write_assets(new_assets)?;
     writer.write_asset_capacities(year, asset_pool.iter())?;
 
     // Gather candidates for the next year, if any
@@ -66,7 +66,7 @@ pub fn run(model: &Model, output_path: &Path, debug_model: bool) -> Result<()> {
         asset_pool.decommission_old(year);
 
         // Commission user-defined assets for this year
-        let new_user_assets = asset_pool.commission_new(year, &mut user_assets).to_vec();
+        let mut new_assets = asset_pool.commission_new(year, &mut user_assets).to_vec();
 
         // Take all the active assets as a list of existing assets
         let existing_assets = asset_pool.take();
@@ -119,14 +119,15 @@ pub fn run(model: &Model, output_path: &Path, debug_model: bool) -> Result<()> {
         };
 
         // Add selected_assets to the active pool, receiving the newly commissioned ones
-        let newly_commissioned = asset_pool.extend(selected_assets).to_vec();
+        let newly_selected = asset_pool.extend(selected_assets);
+        new_assets.extend_from_slice(newly_selected);
 
         // Decommission unused assets
         asset_pool.mothball_unretained(existing_assets, year);
         asset_pool.decommission_mothballed(year, model.parameters.mothball_years);
 
         // Write newly commissioned assets
-        writer.write_assets(new_user_assets.iter().chain(newly_commissioned.iter()))?;
+        writer.write_assets(&new_assets)?;
         writer.write_asset_capacities(year, asset_pool.iter())?;
 
         // Gather candidates for the next year, if any

--- a/src/simulation.rs
+++ b/src/simulation.rs
@@ -53,7 +53,7 @@ pub fn run(model: &Model, output_path: &Path, debug_model: bool) -> Result<()> {
     // Run dispatch optimisation
     info!("Running dispatch optimisation...");
     let (mut prices, flow_map) =
-        run_dispatch_for_year(model, asset_pool.as_slice(), &candidates, year, &mut writer)?;
+        run_dispatch_for_year(model, &asset_pool, &candidates, year, &mut writer)?;
 
     // Write results of dispatch optimisation to file
     writer.write_flows(year, &flow_map)?;
@@ -141,7 +141,7 @@ pub fn run(model: &Model, output_path: &Path, debug_model: bool) -> Result<()> {
         // Run dispatch optimisation
         info!("Running final dispatch optimisation for year {year}...");
         let (new_prices, flow_map) =
-            run_dispatch_for_year(model, asset_pool.as_slice(), &candidates, year, &mut writer)?;
+            run_dispatch_for_year(model, &asset_pool, &candidates, year, &mut writer)?;
 
         // Write results of dispatch optimisation to file
         writer.write_flows(year, &flow_map)?;


### PR DESCRIPTION
# Description

Here are a few small tidy-ups for `DataWriter`. The main thing is that I changed a couple of places where we were taking iterators of `AssetRef`s and changed them to be slices instead, which is a bit cleaner. (There are also some other benefits to avoiding templates.)

## Type of change

- [ ] Bug fix (non-breaking change to fix an issue)
- [ ] New feature (non-breaking change to add functionality)
- [x] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [x] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`
- [ ] Update release notes for the latest release if this PR adds a new feature or fixes a bug
      present in the previous release

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
