### PR TITLE
Reduce boilerplate with `derive_more` and remove other redundant code

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ indexmap = "2.14.0"
 human-panic = "2.0.8"
 clap-markdown = "0.1.5"
 platform-info = "2.1.0"
-derive_more = {version = "2.1", features = ["add", "display", "from_str"]}
+derive_more = {version = "2.1", features = ["add", "deref", "display", "from", "from_str", "into"]}
 petgraph = "0.8.3"
 strum = {version = "0.28.0", features = ["derive"]}
 documented = "0.9.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ indexmap = "2.14.0"
 human-panic = "2.0.8"
 clap-markdown = "0.1.5"
 platform-info = "2.1.0"
-derive_more = {version = "2.1", features = ["add", "deref", "display", "from", "from_str", "into"]}
+derive_more = {version = "2.1", features = ["add", "add_assign", "not", "deref", "display", "sum", "from_str", "from", "into"]}
 petgraph = "0.8.3"
 strum = {version = "0.28.0", features = ["derive"]}
 documented = "0.9.2"

--- a/src/asset.rs
+++ b/src/asset.rs
@@ -20,7 +20,7 @@ use std::cell::Cell;
 use std::cmp::Ordering;
 use std::hash::{Hash, Hasher};
 use std::iter;
-use std::ops::{Deref, RangeInclusive};
+use std::ops::RangeInclusive;
 use std::rc::Rc;
 
 mod capacity;
@@ -964,8 +964,8 @@ pub fn check_region_year_valid_for_process(
 }
 
 /// An asset defined by the user in the assets input file
-#[derive(Clone, Debug, PartialEq)]
-pub struct UserAsset(AssetRef);
+#[derive(Clone, Debug, PartialEq, derive_more::Deref, derive_more::Into)]
+pub struct UserAsset(#[deref(forward)] AssetRef);
 
 impl UserAsset {
     /// Create a new [`UserAsset`]
@@ -1006,14 +1006,6 @@ impl From<Asset> for UserAsset {
     }
 }
 
-impl Deref for UserAsset {
-    type Target = Asset;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
 /// Whether the specified value is a valid capacity for an asset
 pub fn check_capacity_valid_for_asset(capacity: Capacity) -> Result<()> {
     ensure!(
@@ -1028,8 +1020,8 @@ pub fn check_capacity_valid_for_asset(capacity: Capacity) -> Result<()> {
 /// [`AssetRef`] implements equality, ordering, and hashing using an [`AssetID`], if available, but
 /// otherwise using a combination of other fields which should be unique at all the relevant points
 /// in the simulation.
-#[derive(Clone, Debug)]
-pub struct AssetRef(Rc<Asset>);
+#[derive(Clone, Debug, derive_more::Deref, derive_more::From, derive_more::Into)]
+pub struct AssetRef(#[deref(forward)] Rc<Asset>);
 
 impl AssetRef {
     /// Make a mutable reference to the underlying [`Asset`]
@@ -1136,35 +1128,9 @@ impl AssetRef {
     }
 }
 
-impl From<Rc<Asset>> for AssetRef {
-    fn from(value: Rc<Asset>) -> Self {
-        Self(value)
-    }
-}
-
 impl From<Asset> for AssetRef {
     fn from(value: Asset) -> Self {
         Self::from(Rc::new(value))
-    }
-}
-
-impl From<UserAsset> for AssetRef {
-    fn from(value: UserAsset) -> Self {
-        value.0
-    }
-}
-
-impl From<AssetRef> for Rc<Asset> {
-    fn from(value: AssetRef) -> Self {
-        value.0
-    }
-}
-
-impl Deref for AssetRef {
-    type Target = Asset;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
     }
 }
 

--- a/src/asset/pool.rs
+++ b/src/asset/pool.rs
@@ -8,7 +8,7 @@ use std::cmp::min;
 #[derive(Default, derive_more::Deref)]
 pub struct AssetPool {
     /// The pool of active assets, sorted by ID
-    #[deref(forward)]
+    #[deref]
     assets: Vec<AssetRef>,
     /// Next available asset ID number
     next_id: u32,
@@ -20,11 +20,6 @@ impl AssetPool {
     /// Create a new empty [`AssetPool`]
     pub fn new() -> Self {
         Self::default()
-    }
-
-    /// Get the active pool as a slice of [`AssetRef`]s
-    pub fn as_slice(&self) -> &[AssetRef] {
-        &self.assets
     }
 
     /// Commission new assets for the specified milestone year from the input data.

--- a/src/asset/pool.rs
+++ b/src/asset/pool.rs
@@ -3,13 +3,12 @@ use super::{AssetID, AssetRef, AssetState, UserAsset};
 use itertools::Itertools;
 use log::warn;
 use std::cmp::min;
-use std::ops::Deref;
-use std::slice;
 
 /// The active pool of [`super::Asset`]s
-#[derive(Default)]
+#[derive(Default, derive_more::Deref)]
 pub struct AssetPool {
     /// The pool of active assets, sorted by ID
+    #[deref(forward)]
     assets: Vec<AssetRef>,
     /// Next available asset ID number
     next_id: u32,
@@ -145,12 +144,6 @@ impl AssetPool {
         Some(&self.assets[idx])
     }
 
-    /// Iterate over active assets
-    #[allow(clippy::iter_without_into_iter)]
-    pub fn iter(&self) -> slice::Iter<'_, AssetRef> {
-        self.assets.iter()
-    }
-
     /// Return current active pool and clear
     pub fn take(&mut self) -> Vec<AssetRef> {
         std::mem::take(&mut self.assets)
@@ -197,14 +190,6 @@ impl AssetPool {
             _ => panic!("Active pool should only contain commissioned assets"),
         });
         &self.assets[new_start..]
-    }
-}
-
-impl Deref for AssetPool {
-    type Target = [AssetRef];
-
-    fn deref(&self) -> &Self::Target {
-        self.as_slice()
     }
 }
 

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -9,7 +9,6 @@ use petgraph::Directed;
 use petgraph::dot::Dot;
 use petgraph::graph::{EdgeReference, Graph};
 use std::collections::HashMap;
-use std::fmt::Display;
 use std::fs::File;
 use std::io::Write as IoWrite;
 use std::path::Path;
@@ -21,50 +20,35 @@ pub mod validate;
 /// A graph of commodity flows for a given region and year
 pub type CommoditiesGraph = Graph<GraphNode, GraphEdge, Directed>;
 
-#[derive(Eq, PartialEq, Clone, Hash)]
+#[derive(Eq, PartialEq, Clone, Hash, derive_more::Display)]
 /// A node in the commodity graph
 pub enum GraphNode {
     /// A node representing a commodity
+    #[display("{_0}")]
     Commodity(CommodityID),
     /// A source node for processes that have no inputs
+    #[display("SOURCE")]
     Source,
     /// A sink node for processes that have no outputs
+    #[display("SINK")]
     Sink,
     /// A demand node for commodities with service demands
+    #[display("DEMAND")]
     Demand,
 }
 
-impl Display for GraphNode {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            GraphNode::Commodity(id) => write!(f, "{id}"),
-            GraphNode::Source => write!(f, "SOURCE"),
-            GraphNode::Sink => write!(f, "SINK"),
-            GraphNode::Demand => write!(f, "DEMAND"),
-        }
-    }
-}
-
-#[derive(Eq, PartialEq, Clone, Hash)]
+#[derive(Eq, PartialEq, Clone, Hash, derive_more::Display)]
 /// An edge in the commodity graph
 pub enum GraphEdge {
     /// An edge representing a primary flow of a process
+    #[display("{_0}")]
     Primary(ProcessID),
     /// An edge representing a secondary (non-primary) flow of a process
+    #[display("{_0}")]
     Secondary(ProcessID),
     /// An edge representing a service demand
+    #[display("DEMAND")]
     Demand,
-}
-
-impl Display for GraphEdge {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            GraphEdge::Primary(process_id) | GraphEdge::Secondary(process_id) => {
-                write!(f, "{process_id}")
-            }
-            GraphEdge::Demand => write!(f, "DEMAND"),
-        }
-    }
 }
 
 /// Helper function to return a possible flow operating in the requested year

--- a/src/id.rs
+++ b/src/id.rs
@@ -10,8 +10,8 @@ use std::marker::PhantomData;
 
 /// A trait for ID types
 pub trait ID: Eq + Hash + Borrow<str> + Clone + Display + Debug + From<String> {
-    /// Get the name of this type of ID (e.g. "commodity ID", "region ID" etc.)
-    fn get_type_name() -> &'static str;
+    /// The name of this type of ID (e.g. "commodity ID", "region ID" etc.)
+    const TYPE_NAME: &'static str;
 }
 
 macro_rules! define_id_type {
@@ -65,9 +65,7 @@ macro_rules! define_id_type {
         }
 
         impl crate::id::ID for $name {
-            fn get_type_name() -> &'static str {
-                $type_name
-            }
+            const TYPE_NAME: &'static str = $type_name;
         }
 
         impl $name {
@@ -103,7 +101,7 @@ pub(crate) use define_id_getter;
 
 /// Indicates that the specified ID was not found in a given collection
 #[derive(Debug, derive_more::Display)]
-#[display("Unknown {} '{missing_id}'", T::get_type_name())]
+#[display("Unknown {} '{missing_id}'", T::TYPE_NAME)]
 pub struct MissingIDError<T: ID> {
     missing_id: String,
     _phantom: PhantomData<fn() -> T>,

--- a/src/id.rs
+++ b/src/id.rs
@@ -19,6 +19,7 @@ macro_rules! define_id_type {
         #[derive(
             Clone,
             derive_more::Display,
+            derive_more::From,
             std::hash::Hash,
             PartialOrd,
             Ord,
@@ -28,23 +29,12 @@ macro_rules! define_id_type {
             serde::Serialize,
         )]
         /// An ID type (e.g. `AgentID`, `CommodityID`, etc.)
+        #[from(forward)]
         pub struct $name(pub std::rc::Rc<str>);
 
         impl std::borrow::Borrow<str> for $name {
             fn borrow(&self) -> &str {
                 &self.0
-            }
-        }
-
-        impl From<&str> for $name {
-            fn from(s: &str) -> Self {
-                $name(std::rc::Rc::from(s))
-            }
-        }
-
-        impl From<String> for $name {
-            fn from(s: String) -> Self {
-                $name(std::rc::Rc::from(s))
             }
         }
 
@@ -112,7 +102,8 @@ macro_rules! define_id_getter {
 pub(crate) use define_id_getter;
 
 /// Indicates that the specified ID was not found in a given collection
-#[derive(Debug)]
+#[derive(Debug, derive_more::Display)]
+#[display("Unknown {} '{missing_id}'", T::get_type_name())]
 pub struct MissingIDError<T: ID> {
     missing_id: String,
     _phantom: PhantomData<fn() -> T>,
@@ -125,12 +116,6 @@ impl<T: ID> MissingIDError<T> {
             missing_id: missing_id.to_string(),
             _phantom: std::marker::PhantomData,
         }
-    }
-}
-
-impl<T: ID> Display for MissingIDError<T> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "Unknown {} '{}'", T::get_type_name(), self.missing_id)
     }
 }
 

--- a/src/input.rs
+++ b/src/input.rs
@@ -30,7 +30,7 @@ use region::read_regions;
 mod time_slice;
 use time_slice::read_time_slice_info;
 mod range;
-use range::{parse_range, parse_range_parts, partition};
+use range::{parse_range, parse_range_parts};
 mod year;
 use year::parse_year_str;
 

--- a/src/input/range.rs
+++ b/src/input/range.rs
@@ -5,19 +5,6 @@ use std::fmt::Display;
 use std::ops::RangeInclusive;
 use std::str::FromStr;
 
-/// Try to divide a string into two parts at the specified delimiter.
-///
-/// # Returns
-///
-/// - `None` if `delimiter` is not present
-/// - `Some` tuple of the two strings if it is
-pub fn partition<'a>(s: &'a str, delimiter: &str) -> Option<(&'a str, &'a str)> {
-    let idx = s.find(delimiter)?;
-
-    #[allow(clippy::string_slice)]
-    Some((&s[..idx], &s[idx + delimiter.len()..]))
-}
-
 /// Parse a range from an input string, using values in `limits` as defaults.
 ///
 /// Start and end values must be a type that is parseable from a string. Ranges are inclusive.
@@ -33,7 +20,7 @@ where
     T: FromStr + Copy + PartialOrd + Display,
     <T as FromStr>::Err: Error + Sync + Send + 'static,
 {
-    let (start, end) = partition(s, "..").context(
+    let (start, end) = s.split_once("..").context(
         "Range must be in the form [start]..[end] (where [start] and [end] can be empty)",
     )?;
     parse_range_parts(start, end, limits.clone(), *limits.start(), *limits.end())
@@ -110,22 +97,6 @@ where
 mod tests {
     use super::*;
     use rstest::rstest;
-
-    #[rstest]
-    #[case("1,2", ",", Some(("1","2")))]
-    #[case("hello world", " ", Some(("hello", "world")))]
-    #[case("a..b", "..", Some(("a","b")))]
-    #[case("a", "", Some(("", "a")))]
-    #[case("", "", Some(("", "")))]
-    #[case("a..b", "c", None)]
-    #[case("🙂😐😞", "😐", Some(("🙂", "😞")))]
-    fn partition_works(
-        #[case] input: &str,
-        #[case] delim: &str,
-        #[case] expected: Option<(&str, &str)>,
-    ) {
-        assert_eq!(partition(input, delim), expected);
-    }
 
     #[rstest]
     #[case("1..2", 1..=2)]

--- a/src/input/year.rs
+++ b/src/input/year.rs
@@ -1,5 +1,5 @@
 //! Code for working with years.
-use super::{is_sorted_and_unique, is_sorted_and_unique_with, parse_range_parts, partition};
+use super::{is_sorted_and_unique, is_sorted_and_unique_with, parse_range_parts};
 use anyhow::{Context, Result, bail, ensure};
 use itertools::Itertools;
 use std::ops::RangeInclusive;
@@ -51,7 +51,7 @@ pub fn parse_year_str(s: &str, valid_years: &[u32]) -> Result<Vec<u32>> {
     let ranges: Vec<_> = s
         .split(';')
         .map(|s| {
-            let (start, end) = partition(s, "..").unwrap_or((s, s));
+            let (start, end) = s.split_once("..").unwrap_or((s, s));
             parse_range_parts(
                 start,
                 end,

--- a/src/simulation/optimisation.rs
+++ b/src/simulation/optimisation.rs
@@ -21,7 +21,6 @@ use itertools::{chain, iproduct};
 use std::cell::Cell;
 use std::collections::HashMap;
 use std::error::Error;
-use std::fmt;
 use std::ops::Range;
 
 mod constraints;
@@ -368,18 +367,14 @@ impl Solution<'_> {
 }
 
 /// Defines the possible errors that can occur when running the solver
-#[derive(Debug)]
+#[derive(Debug, derive_more::Display, derive_more::From)]
 pub enum ModelError {
     /// An optimal solution could not be found
+    #[display("Could not find optimal result: {_0:?}")]
     NonOptimal(HighsModelStatus),
     /// Another error occurred
+    #[display("{_0}")]
     Other(anyhow::Error),
-}
-
-impl From<anyhow::Error> for ModelError {
-    fn from(value: anyhow::Error) -> Self {
-        Self::Other(value)
-    }
 }
 
 impl ModelError {
@@ -388,17 +383,6 @@ impl ModelError {
         match self {
             ModelError::NonOptimal(status) => anyhow!("Could not find optimal result: {status:?}"),
             ModelError::Other(error) => error,
-        }
-    }
-}
-
-impl fmt::Display for ModelError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            ModelError::NonOptimal(status) => {
-                write!(f, "Could not find optimal result: {status:?}")
-            }
-            ModelError::Other(error) => error.fmt(f),
         }
     }
 }
@@ -454,7 +438,7 @@ pub fn solve_optimal(model: highs::Model) -> Result<highs::SolvedModel, ModelErr
 
     match solved.status() {
         HighsModelStatus::Optimal => Ok(solved),
-        status => Err(ModelError::NonOptimal(status)),
+        status => Err(status.into()),
     }
 }
 

--- a/src/time_slice.rs
+++ b/src/time_slice.rs
@@ -10,14 +10,14 @@ use itertools::Itertools;
 use serde::de::Error;
 use serde::{Deserialize, Serialize};
 use serde_string_enum::DeserializeLabeledStringEnum;
-use std::fmt::Display;
 use std::iter;
 
 define_id_type! {Season, "season"}
 define_id_type! {TimeOfDay, "time of day"}
 
 /// An ID describing season and time of day
-#[derive(Hash, Eq, PartialEq, Ord, PartialOrd, Clone, Debug)]
+#[derive(Hash, Eq, PartialEq, Ord, PartialOrd, Clone, Debug, derive_more::Display)]
+#[display("{season}.{time_of_day}")]
 pub struct TimeSliceID {
     /// The name of each season.
     pub season: Season,
@@ -37,12 +37,6 @@ impl From<&str> for TimeSliceID {
             season: season.into(),
             time_of_day: time_of_day.into(),
         }
-    }
-}
-
-impl Display for TimeSliceID {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}.{}", self.season, self.time_of_day)
     }
 }
 
@@ -74,13 +68,18 @@ impl Serialize for TimeSliceID {
 }
 
 /// Represents a time slice read from an input file, which can be all
-#[derive(PartialEq, Eq, Hash, Clone, Debug)]
+#[derive(PartialEq, Eq, Hash, Clone, Debug, derive_more::From, derive_more::Display)]
 pub enum TimeSliceSelection {
     /// All year and all day
+    #[display("annual")]
     Annual,
     /// Only applies to one season
+    #[from]
+    #[display("{_0}")]
     Season(Season),
     /// Only applies to a single time slice
+    #[from]
+    #[display("{_0}")]
     Single(TimeSliceID),
 }
 
@@ -165,28 +164,6 @@ impl TimeSliceSelection {
         };
 
         Some(iter)
-    }
-}
-
-impl From<TimeSliceID> for TimeSliceSelection {
-    fn from(value: TimeSliceID) -> Self {
-        Self::Single(value)
-    }
-}
-
-impl From<Season> for TimeSliceSelection {
-    fn from(value: Season) -> Self {
-        Self::Season(value)
-    }
-}
-
-impl Display for TimeSliceSelection {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::Annual => write!(f, "annual"),
-            Self::Season(season) => write!(f, "{season}"),
-            Self::Single(ts) => write!(f, "{ts}"),
-        }
     }
 }
 

--- a/src/units.rs
+++ b/src/units.rs
@@ -71,6 +71,22 @@ macro_rules! base_unit_struct {
                 Dimensionless(self.0 / rhs.0)
             }
         }
+        impl std::ops::Mul<Dimensionless> for $name {
+            type Output = $name;
+            fn mul(self, rhs: Dimensionless) -> $name {
+                $name(self.0 * rhs.0)
+            }
+        }
+        impl std::ops::MulAssign<Dimensionless> for $name {
+            fn mul_assign(&mut self, rhs: Dimensionless) {
+                self.0 *= rhs.0;
+            }
+        }
+        impl std::ops::DivAssign<Dimensionless> for $name {
+            fn div_assign(&mut self, rhs: Dimensionless) {
+                self.0 /= rhs.0;
+            }
+        }
         impl float_cmp::ApproxEq for $name {
             type Margin = float_cmp::F64Margin;
             fn approx_eq<T: Into<Self::Margin>>(self, other: Self, margin: T) -> bool {
@@ -167,14 +183,6 @@ macro_rules! base_unit_struct {
 // Define Dimensionless first
 base_unit_struct!(Dimensionless, derive_more::From, derive_more::Into);
 
-impl Mul for Dimensionless {
-    type Output = Dimensionless;
-
-    fn mul(self, rhs: Self) -> Self::Output {
-        Dimensionless(self.0 * rhs.0)
-    }
-}
-
 impl Dimensionless {
     /// Raises this dimensionless number to the power of `rhs`.
     pub fn powi(self, rhs: i32) -> Self {
@@ -187,12 +195,6 @@ macro_rules! unit_struct {
     ($name:ident) => {
         base_unit_struct!($name);
 
-        impl std::ops::Mul<Dimensionless> for $name {
-            type Output = $name;
-            fn mul(self, rhs: Dimensionless) -> $name {
-                $name(self.0 * rhs.0)
-            }
-        }
         impl std::ops::Mul<$name> for Dimensionless {
             type Output = $name;
             fn mul(self, rhs: $name) -> $name {

--- a/src/units.rs
+++ b/src/units.rs
@@ -44,7 +44,7 @@ pub trait UnitType:
 }
 
 macro_rules! base_unit_struct {
-    ($name:ident) => {
+    ($name:ident $(, $extra_derive:path)* $(,)?) => {
         /// A basic unit type wrapper around an `f64` scalar value.
         #[derive(
             Debug,
@@ -61,6 +61,7 @@ macro_rules! base_unit_struct {
             derive_more::Sum,
             derive_more::Display,
             derive_more::FromStr,
+            $($extra_derive,)*
         )]
         pub struct $name(pub f64);
 
@@ -164,19 +165,7 @@ macro_rules! base_unit_struct {
 }
 
 // Define Dimensionless first
-base_unit_struct!(Dimensionless);
-
-// Add extra methods for Dimensionless
-impl From<f64> for Dimensionless {
-    fn from(val: f64) -> Self {
-        Self(val)
-    }
-}
-impl From<Dimensionless> for f64 {
-    fn from(val: Dimensionless) -> Self {
-        val.0
-    }
-}
+base_unit_struct!(Dimensionless, derive_more::From, derive_more::Into);
 
 impl Mul for Dimensionless {
     type Output = Dimensionless;

--- a/src/units.rs
+++ b/src/units.rs
@@ -54,6 +54,11 @@ macro_rules! base_unit_struct {
             Serialize,
             derive_more::Add,
             derive_more::Sub,
+            derive_more::AddAssign,
+            derive_more::SubAssign,
+            derive_more::Neg,
+            derive_more::Sum,
+            derive_more::Display,
             derive_more::FromStr,
         )]
         pub struct $name(pub f64);
@@ -64,36 +69,10 @@ macro_rules! base_unit_struct {
                 Dimensionless(self.0 / rhs.0)
             }
         }
-        impl std::iter::Sum for $name {
-            fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {
-                iter.fold($name(0.0), |a, b| $name(a.0 + b.0))
-            }
-        }
-        impl AddAssign for $name {
-            fn add_assign(&mut self, other: Self) {
-                self.0 += other.0;
-            }
-        }
-        impl SubAssign for $name {
-            fn sub_assign(&mut self, other: Self) {
-                self.0 -= other.0;
-            }
-        }
-        impl fmt::Display for $name {
-            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-                write!(f, "{}", self.0)
-            }
-        }
         impl float_cmp::ApproxEq for $name {
             type Margin = float_cmp::F64Margin;
             fn approx_eq<T: Into<Self::Margin>>(self, other: Self, margin: T) -> bool {
                 self.0.approx_eq(other.0, margin)
-            }
-        }
-        impl std::ops::Neg for $name {
-            type Output = $name;
-            fn neg(self) -> $name {
-                $name(-self.0)
             }
         }
         impl $name {

--- a/src/units.rs
+++ b/src/units.rs
@@ -3,7 +3,7 @@ use float_cmp::{ApproxEq, F64Margin};
 use serde::{Deserialize, Serialize};
 use std::fmt;
 use std::iter::Sum;
-use std::ops::{Add, AddAssign, Div, Mul, Sub, SubAssign};
+use std::ops::{Add, AddAssign, Div, Mul, Neg, Sub, SubAssign};
 use std::str::FromStr;
 
 /// A trait encompassing most of the functionality of unit types
@@ -17,6 +17,7 @@ pub trait UnitType:
     + Add
     + Sub
     + Div
+    + Neg
     + Mul<Dimensionless, Output = Self>
     + AddAssign
     + SubAssign


### PR DESCRIPTION
# Description

While working on something else, I noticed there are lots of places where we could be leaning on the `derive_more` crate instead of manually writing lots of boilerplate code, so I've had a go at doing this across the codebase (well, Copilot did most of it...).

I also removed the `partition` function which just replicates the `split_once` method in the standard library.

It's pleasing how much code this has removed!

## Type of change

- [ ] Bug fix (non-breaking change to fix an issue)
- [ ] New feature (non-breaking change to add functionality)
- [x] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [x] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`
- [ ] Update release notes for the latest release if this PR adds a new feature or fixes a bug
      present in the previous release

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
