### PR TITLE
Mark `max_decommission_year` as optional

### DIFF
--- a/schemas/input/assets.yaml
+++ b/schemas/input/assets.yaml
@@ -26,6 +26,6 @@ fields:
     type: integer
     description: The latest year in which this asset can be decommissioned
     notes: |
-      Optional. This value can be any integer >= `commission_year`. If it is set before the
+      Optional. This value can be any integer > `commission_year`. If it is set before the
       simulation starting year, the asset will not be commissioned during the simulation. If not
       set, will default to `commission_year` + the `lifetime` of the process in that year.

--- a/schemas/input/assets.yaml
+++ b/schemas/input/assets.yaml
@@ -26,6 +26,6 @@ fields:
     type: integer
     description: The latest year in which this asset can be decommissioned
     notes: |
-      This value can be any integer that satisfies max_decommission_year >= commission_year >=0.
-      If it is set before the simulation starting year, the asset will not be commissioned during the
-      simulation.
+      Optional. This value can be any integer >= `commission_year`. If it is set before the
+      simulation starting year, the asset will not be commissioned during the simulation. If not
+      set, will default to `commission_year` + the `lifetime` of the process in that year.

--- a/src/input/asset.rs
+++ b/src/input/asset.rs
@@ -214,6 +214,14 @@ mod tests {
             commission_year: 2010,
             max_decommission_year: Some(2005),
         })]
+    #[case(AssetRaw { // Bad max_decommission_year: equal to commission_year
+            agent_id: "agent1".into(),
+            process_id: "process1".into(),
+            region_id: "GBR".into(),
+            capacity: Capacity(1.0),
+            commission_year: 2010,
+            max_decommission_year: Some(2010),
+        })]
     fn read_assets_from_iter_invalid(
         #[case] asset: AssetRaw,
         agent_ids: IndexSet<AgentID>,


### PR DESCRIPTION
# Description

Marking this parameter as optional, and describing the default. It would be nice to automatically mark optional parameters, but that's probably more effort than it's worth

Copilot also flagged that we reject `max_decommission_year = commission_year`, which wasn't correct in the docs before, so I've updated this and added a test.

Fixes #1219

## Type of change

- [ ] Bug fix (non-breaking change to fix an issue)
- [ ] New feature (non-breaking change to add functionality)
- [ ] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [x] Documentation (improve or add documentation)

## Key checklist

- [ ] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`
- [ ] Update release notes for the latest release if this PR adds a new feature or fixes a bug
      present in the previous release

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
