### PR TITLE
Add version banner to docs

### DIFF
--- a/docs/build_old_docs.py
+++ b/docs/build_old_docs.py
@@ -108,7 +108,9 @@ def build_old_docs() -> None:
 
             # Copy latest release into stable dir
             if i == 0:
-                shutil.copytree(release_outdir, outdir / "stable")
+                stable_dir = outdir / "stable"
+                shutil.rmtree(stable_dir, ignore_errors=True)
+                shutil.copytree(release_outdir, stable_dir)
 
 
 if __name__ == "__main__":

--- a/docs/build_old_docs.py
+++ b/docs/build_old_docs.py
@@ -72,6 +72,9 @@ def build_docs_for_release(release: str, repo_path: Path, outdir: Path) -> None:
     # Apply patches, if any
     apply_patches_for_release(release, release_path)
 
+    # Copy current theme into the release worktree so theme is consistent
+    shutil.copytree(REPO_ROOT / "theme", release_path / "theme", dirs_exist_ok=True)
+
     # Build docs
     sp.run(("just", f"{release_path!s}/build-docs"), check=True)
 

--- a/docs/build_old_docs.py
+++ b/docs/build_old_docs.py
@@ -64,7 +64,7 @@ def apply_patches_for_release(release: str, repo_path: Path) -> None:
         sp.run(("git", "-C", str(repo_path), "am", str(patch_path)), check=True)
 
 
-def build_docs_for_release(release: str, repo_path: Path, outdir: Path) -> None:
+def build_docs_for_release(release: str, repo_path: Path, outdir: Path) -> Path:
     """Build documentation for a given release."""
     print(f"Building docs for {release}")
     release_path = add_worktree_for_release(repo_path, release)
@@ -89,6 +89,8 @@ def build_docs_for_release(release: str, repo_path: Path, outdir: Path) -> None:
     print(f"Copying to {release_outdir}")
     shutil.move((release_path / "book"), release_outdir)
 
+    return release_outdir
+
 
 def build_old_docs() -> None:
     """Build documentation for previous releases."""
@@ -101,8 +103,12 @@ def build_old_docs() -> None:
         clone_repo_to(repo_path)
 
         # Generate documentation for each previous release
-        for release in get_releases():
-            build_docs_for_release(release, repo_path, outdir)
+        for i, release in enumerate(get_releases()):
+            release_outdir = build_docs_for_release(release, repo_path, outdir)
+
+            # Copy latest release into stable dir
+            if i == 0:
+                shutil.copytree(release_outdir, outdir / "stable")
 
 
 if __name__ == "__main__":

--- a/docs/templates/versions.md.jinja
+++ b/docs/templates/versions.md.jinja
@@ -3,6 +3,7 @@
 The MUSE2 documentation for different releases is available below.
 
 - [Current development version](index.html)
+- [Stable version](release/stable/index.html)
 {%- for release in releases %}
 - [{{ release }}](release/{{ release }}/index.html)
 {%- endfor %}

--- a/theme/header.hbs
+++ b/theme/header.hbs
@@ -1,0 +1,33 @@
+<style>
+  :root { --banner-height: 36px; }
+
+  #version-banner {
+    position: fixed;
+    top: 0; left: 0; right: 0;
+    height: var(--banner-height);
+    z-index: 9999;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 0.875em;
+    box-sizing: border-box;
+    padding: 0 16px;
+    background-color: #fff3cd;
+    border-bottom: 1px solid #ffc107;
+  }
+
+  #version-banner, #version-banner * {
+    color: #664d03 !important;
+  }
+
+  body { padding-top: var(--banner-height); }
+  #mdbook-menu-bar.sticky { top: var(--banner-height) !important; }
+  #mdbook-sidebar {
+    top: var(--banner-height) !important;
+    height: calc(100vh - var(--banner-height)) !important;
+  }
+</style>
+
+<div id="version-banner">
+  This is the <strong>&nbsp;development version&nbsp;</strong> of the MUSE2 documentation.
+</div>

--- a/theme/header.hbs
+++ b/theme/header.hbs
@@ -15,7 +15,7 @@
   }
 </style>
 
-<div id="version-banner"></div>
+<div id="version-banner" role="status" aria-live="polite"></div>
 
 <script>
   (function () {

--- a/theme/header.hbs
+++ b/theme/header.hbs
@@ -31,3 +31,26 @@
 <div id="version-banner">
   This is the <strong>&nbsp;development version&nbsp;</strong> of the MUSE2 documentation.
 </div>
+
+<script>
+  (function () {
+    var match = /\/release\/(v[\d.]+)\//.exec(window.location.pathname);
+    if (!match) return;
+
+    var version = match[1];
+    var banner = document.getElementById("version-banner");
+
+    banner.innerHTML =
+      "You are viewing docs for <strong>\u00a0" + version + "\u00a0</strong> of MUSE2. " +
+      "This is not the latest version.";
+
+    banner.style.backgroundColor = "#f8d7da";
+    banner.style.borderBottomColor = "#f5c2c7";
+    banner.style.color = "#842029";
+
+    // Override the !important colour rule by injecting a higher-specificity style
+    var s = document.createElement("style");
+    s.textContent = "#version-banner, #version-banner * { color: #842029 !important; }";
+    document.head.appendChild(s);
+  })();
+</script>

--- a/theme/header.hbs
+++ b/theme/header.hbs
@@ -2,55 +2,55 @@
   :root { --banner-height: 36px; }
 
   #version-banner {
+    display: none;
     position: fixed;
     top: 0; left: 0; right: 0;
     height: var(--banner-height);
     z-index: 9999;
-    display: flex;
     align-items: center;
     justify-content: center;
     font-size: 0.875em;
     box-sizing: border-box;
     padding: 0 16px;
-    background-color: #fff3cd;
-    border-bottom: 1px solid #ffc107;
-  }
-
-  #version-banner, #version-banner * {
-    color: #664d03 !important;
-  }
-
-  body { padding-top: var(--banner-height); }
-  #mdbook-menu-bar.sticky { top: var(--banner-height) !important; }
-  #mdbook-sidebar {
-    top: var(--banner-height) !important;
-    height: calc(100vh - var(--banner-height)) !important;
   }
 </style>
 
-<div id="version-banner">
-  This is the <strong>&nbsp;development version&nbsp;</strong> of the MUSE2 documentation.
-</div>
+<div id="version-banner"></div>
 
 <script>
   (function () {
-    var match = /\/release\/(v[\d.]+)\//.exec(window.location.pathname);
-    if (!match) return;
-
-    var version = match[1];
+    var path = window.location.pathname;
     var banner = document.getElementById("version-banner");
 
-    banner.innerHTML =
-      "You are viewing docs for <strong>\u00a0" + version + "\u00a0</strong> of MUSE2. " +
-      "This is not the latest version.";
+    var isStable = /\/release\/stable\//.test(path);
+    if (isStable) return;
 
-    banner.style.backgroundColor = "#f8d7da";
-    banner.style.borderBottomColor = "#f5c2c7";
-    banner.style.color = "#842029";
+    var versionMatch = /\/release\/(v[\d.]+)\//.exec(path);
+    var isDev = !versionMatch;
 
-    // Override the !important colour rule by injecting a higher-specificity style
+    if (isDev) {
+      banner.innerHTML =
+        "This is the <strong>\u00a0development version\u00a0</strong> of the MUSE2 documentation.";
+      banner.style.backgroundColor = "#fff3cd";
+      banner.style.borderBottom = "1px solid #ffc107";
+      banner.style.color = "#664d03";
+    } else {
+      var version = versionMatch[1];
+      banner.innerHTML =
+        "You are viewing docs for <strong>\u00a0" + version + "\u00a0</strong> of MUSE2. " +
+        "This is not the latest version.";
+      banner.style.backgroundColor = "#f8d7da";
+      banner.style.borderBottom = "1px solid #f5c2c7";
+      banner.style.color = "#842029";
+    }
+
+    banner.style.display = "flex";
+
     var s = document.createElement("style");
-    s.textContent = "#version-banner, #version-banner * { color: #842029 !important; }";
+    s.textContent =
+      "body { padding-top: var(--banner-height); }" +
+      "#mdbook-menu-bar.sticky { top: var(--banner-height) !important; }" +
+      "#mdbook-sidebar { top: var(--banner-height) !important; height: calc(100vh - var(--banner-height)) !important; }";
     document.head.appendChild(s);
   })();
 </script>


### PR DESCRIPTION
# Description

This PR adds a banner to the docs as a warning for all non-stable versions of the docs. It includes an amber banner for the dev version and a red banner for old versions. There is no banner for the stable version.

This is achieved by including a `header.hbs` file, which is a html snippet that MdBook inserts into the generated docs. There is some CSS for stying the banner and some JavaScript to dynamically determine the contents of the banner depending on the version of the docs (determined by the url path). I relied on LLM agents for much of this component.

I have added a stable version of the docs that is built alongside the "old" docs. This is simply a copy of the most recent release. One drawback is that the release corresponding to this stable one (currently v2.1.0) includes the red banner, whereas the stable one does not. This is slightly misleading.

I have also developed a version selector widget, but I have put that in a separate PR because it includes some more executive decisions that I have made about the docs.
- [ ] #1356

Fixes #1188 

Assisted-by: Claude Sonnet 4.6

## Type of change

- [ ] Bug fix (non-breaking change to fix an issue)
- [ ] New feature (non-breaking change to add functionality)
- [ ] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [ ] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`
- [ ] Update release notes for the latest release if this PR adds a new feature or fixes a bug
      present in the previous release

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
