### PR TITLE
Include secondary edges in investment graphs

### DIFF
--- a/src/graph/investment.rs
+++ b/src/graph/investment.rs
@@ -80,7 +80,7 @@ fn init_investment_graph_for_year(
                         kind,
                         CommodityType::ServiceDemand | CommodityType::SupplyEqualsDemand
                     )
-                    .then_some(GraphNode::Commodity(cid.clone()))
+                    .then(|| GraphNode::Commodity(cid.clone()))
                 }
                 _ => None,
             },

--- a/src/graph/investment.rs
+++ b/src/graph/investment.rs
@@ -20,7 +20,7 @@ type InvestmentGraph = Graph<InvestmentSet, GraphEdge, Directed>;
 ///
 /// Steps:
 /// 1. Initialise an `InvestmentGraph` from the set of original `CommodityGraph`s for the given
-///    year, filtering to only include SVD/SED commodities and primary edges. `CommodityGraph`s from
+///    year, filtering to only include SVD/SED commodities. `CommodityGraph`s from
 ///    all regions are combined into a single `InvestmentGraph`. TODO: at present there can be no
 ///    edges between regions; in future we will want to implement trade as edges between regions,
 ///    but this will have no impact on the following steps.
@@ -59,9 +59,9 @@ fn solve_investment_order_for_year(
 
 /// Initialise an `InvestmentGraph` for the given year from a set of `CommodityGraph`s
 ///
-/// Commodity graphs for each region are first filtered to only include SVD/SED commodities and
-/// primary edges. Each commodity node is then added to a global investment graph as an
-/// `InvestmentSet::Single`, with edges preserved from the original commodity graphs.
+/// Commodity graphs for each region are first filtered to only include SVD/SED commodities. Each
+/// commodity node is then added to a global investment graph as an `InvestmentSet::Single`, with
+/// edges preserved from the original commodity graphs.
 fn init_investment_graph_for_year(
     graphs: &IndexMap<(RegionID, u32), CommoditiesGraph>,
     year: u32,
@@ -71,7 +71,7 @@ fn init_investment_graph_for_year(
 
     // Iterate over the graphs for the given year
     for ((region_id, _), graph) in graphs.iter().filter(|((_, y), _)| *y == year) {
-        // Filter the graph to only include SVD/SED commodities and primary edges
+        // Filter the graph to only include SVD/SED commodities
         let filtered = graph.filter_map(
             |_, n| match n {
                 GraphNode::Commodity(cid) => {
@@ -84,7 +84,7 @@ fn init_investment_graph_for_year(
                 }
                 _ => None,
             },
-            |_, e| matches!(e, GraphEdge::Primary(_)).then_some(e.clone()),
+            |_, e| Some(e.clone()),
         );
 
         // Add nodes to the combined graph


### PR DESCRIPTION
# Description

We use (what we're currently calling) `InvestmentGraph`s for two purposes:
- to solve the order of investments
- to solve the order of commodity price calculations

Both of these orders are based on the same topological sorting of `InvestmentGraph`s, just in reverse (investment are calculated for _downstream_ commodities first, prices are calculated for _upstream_ commodities first). At the moment, we exclude non-primary flows from these graphs (i.e. flows that don't contribute to production of the primary commodity). This made sense when we were only using these graphs to solve the investment order, since investments (for now) only target demands of primary output commodities. However, it doesn't make sense for price calculations as we _do_ want secondary outputs to be able to contribute to prices (kind of making an assumption here, but it would feel strange/inconsistent if they couldn't). I don't want to have to create different graphs for investments/price calculations, so the simplest solution is just to no longer exclude non-primary flows from `InvestmentGraph`s.

This does have some implications for investments, but I think they're small:
- markets that would once have been in the same `Layer`, could now be pushed to separate `Layer`s if there's a secondary flow between them. I _think_ the only implication of this is a potential performance cost (could require more dispatch rounds). Since investments still only target primary outputs, I don't think there's any functional change.
- Secondary flows may introduce `Cycle`s that weren't there before. This could change results as these go through an extra "cycle balancing" step to equilibrate demands/supply. If anything, I think this could result in excess capacity invested in as a result of ignoring secondary outputs being "trimmed away", which may be a good thing anyway.

Fixes #1331 

## Type of change

- [ ] Bug fix (non-breaking change to fix an issue)
- [ ] New feature (non-breaking change to add functionality)
- [ ] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [ ] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`
- [ ] Update release notes for the latest release if this PR adds a new feature or fixes a bug
      present in the previous release

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
