### PR TITLE
Allow asset selection to continue with unmet demand

### DIFF
--- a/src/simulation/investment.rs
+++ b/src/simulation/investment.rs
@@ -865,21 +865,11 @@ fn select_best_assets(
         // able to meet the full demands with assets selected so far, so we continue anyway with a
         // warning.
         if outputs_for_opts.is_empty() {
-            let remaining_demands: Vec<_> = demand
-                .iter()
-                .filter(|(_, flow)| **flow > Flow(0.0))
-                .map(|(time_slice, flow)| format!("{} : {:e}", time_slice, flow.value()))
-                .collect();
             warn!(
                 "Investment appraisal completed with unmet demand for commodity '{}', region '{}', \
                 year '{}', agent '{}'. No additional feasible investments were identified. \
-                The unmet demand reported below may still be satisfied during the full system \
-                dispatch:\n{}",
-                &commodity.id,
-                region_id,
-                year,
-                agent.id,
-                remaining_demands.join("\n")
+                This unmet demand may still be satisfied during the full system dispatch.",
+                &commodity.id, region_id, year, agent.id,
             );
             break;
         }

--- a/src/simulation/investment.rs
+++ b/src/simulation/investment.rs
@@ -872,7 +872,7 @@ fn select_best_assets(
                 .collect();
             warn!(
                 "Investment appraisal completed with unmet demand for commodity '{}', region '{}', \
-                year '{}', agent '{}'. No additional profitable investments were identified. \
+                year '{}', agent '{}'. No additional feasible investments were identified. \
                 The unmet demand reported below may still be satisfied during the full system \
                 dispatch:\n{}",
                 &commodity.id,

--- a/src/simulation/investment.rs
+++ b/src/simulation/investment.rs
@@ -9,10 +9,10 @@ use crate::region::RegionID;
 use crate::simulation::prices::Prices;
 use crate::time_slice::{TimeSliceID, TimeSliceInfo, TimeSliceLevel};
 use crate::units::{ActivityPerCapacity, Capacity, Dimensionless, Flow, FlowPerCapacity};
-use anyhow::{Context, Result, bail, ensure};
+use anyhow::{Context, Result, ensure};
 use indexmap::IndexMap;
 use itertools::{Itertools, chain};
-use log::debug;
+use log::{debug, warn};
 use std::collections::{HashMap, HashSet};
 use std::fmt::Display;
 use strum::IntoEnumIterator;
@@ -861,25 +861,27 @@ fn select_best_assets(
         // Sort by investment priority and discard non-feasible options
         sort_and_filter_appraisal_outputs(&mut outputs_for_opts);
 
-        // Check if there are any remaining options. If not, we cannot meet demand, so have to bail
-        // out.
+        // If none of the remaining options are feasible, we terminate the loop. We may still be
+        // able to meet the full demands with assets selected so far, so we continue anyway with a
+        // warning.
         if outputs_for_opts.is_empty() {
             let remaining_demands: Vec<_> = demand
                 .iter()
                 .filter(|(_, flow)| **flow > Flow(0.0))
                 .map(|(time_slice, flow)| format!("{} : {:e}", time_slice, flow.value()))
                 .collect();
-
-            bail!(
-                "No feasible investment options left for \
-                commodity '{}', region '{}', year '{}', agent '{}' after appraisal.\n\
-                Remaining unmet demand (time_slice : flow):\n{}",
+            warn!(
+                "Investment appraisal completed with unmet demand for commodity '{}', region '{}', \
+                year '{}', agent '{}'. No additional profitable investments were identified. \
+                The unmet demand reported below may still be satisfied during the full system \
+                dispatch:\n{}",
                 &commodity.id,
                 region_id,
                 year,
                 agent.id,
                 remaining_demands.join("\n")
             );
+            break;
         }
 
         // Warn if there are multiple equally good assets


### PR DESCRIPTION
# Description

As discussed in #1363, it's possible that, even if asset selection runs out of options, the assets already selected may still be able to meet the full commodity demands in the context of a system dispatch with supply constraints. This at least gives it a chance to try. If it can't, you'll get the warning added here, followed by the usual message about unmet demand from the dispatch, which hopefully should be clear enough.

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change to fix an issue)
- [ ] New feature (non-breaking change to add functionality)
- [ ] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [ ] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`
- [ ] Update release notes for the latest release if this PR adds a new feature or fixes a bug
      present in the previous release

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
