### PR TITLE
Rename investmentset marketset

### DIFF
--- a/src/graph/investment.rs
+++ b/src/graph/investment.rs
@@ -2,7 +2,7 @@
 use super::{CommoditiesGraph, GraphEdge, GraphNode};
 use crate::commodity::{CommodityMap, CommodityType};
 use crate::region::RegionID;
-use crate::simulation::investment::InvestmentSet;
+use crate::simulation::market::InvestmentSet;
 use highs::{Col, HighsModelStatus, RowProblem, Sense};
 use indexmap::IndexMap;
 use log::warn;

--- a/src/graph/investment.rs
+++ b/src/graph/investment.rs
@@ -238,13 +238,13 @@ fn order_sccs(
 ) {
     const EXTERNAL_BIAS: f64 = 0.1;
 
-    // Map each investment set back to the node index in the original graph so we can inspect edges.
+    // Map each market set back to the node index in the original graph so we can inspect edges.
     let node_lookup: HashMap<MarketSet, NodeIndex> = original_graph
         .node_indices()
         .map(|idx| (original_graph.node_weight(idx).unwrap().clone(), idx))
         .collect();
 
-    // Work through each SCC; groups with just one investment set don't need to be ordered.
+    // Work through each SCC; groups with just one market set don't need to be ordered.
     for group in condensed_graph.node_indices() {
         let scc = condensed_graph.node_weight_mut(group).unwrap();
         let n = scc.len();
@@ -252,7 +252,7 @@ fn order_sccs(
             continue;
         }
 
-        // Capture current order and resolve each investment set back to its original graph index.
+        // Capture current order and resolve each market set back to its original graph index.
         let original_order = scc.clone();
         let original_indices = original_order
             .iter()
@@ -387,7 +387,7 @@ fn order_sccs(
     }
 }
 
-/// Compute layers of investment sets from the topological order
+/// Compute layers of market sets from the topological order
 ///
 /// This function works by computing the rank of each node in the graph based on the longest path
 /// from any root node to that node. Any nodes with the same rank are independent and can be solved
@@ -397,9 +397,9 @@ fn order_sccs(
 /// This function computes the ranks of each node, groups nodes by rank, and then produces a final
 /// ordered Vec of `MarketSet`s which gives the order in which to solve the investment decisions.
 ///
-/// Investment sets with the same rank (i.e., can be solved in parallel) are grouped into
-/// `MarketSet::Layer`. Investment sets that are alone in their rank remain as-is (i.e. either
-/// `Single` or `Cycle`). `Layer`s can contain a mix of `Single` and `Cycle` investment sets.
+/// Market sets with the same rank (i.e., can be solved in parallel) are grouped into
+/// `MarketSet::Layer`. Market sets that are alone in their rank remain as-is (i.e. either
+/// `Single` or `Cycle`). `Layer`s can contain a mix of `Single` and `Cycle` market sets.
 ///
 /// For example, given the following graph:
 ///
@@ -569,7 +569,7 @@ mod tests {
         let result = solve_investment_order_for_year(&graphs, &commodities, 2020);
 
         // Expected order: C, B, A (leaf nodes first)
-        // No cycles or layers, so all investment sets should be `Single`
+        // No cycles or layers, so all market sets should be `Single`
         assert_eq!(result.len(), 3);
         assert_eq!(result[0], MarketSet::Single(("C".into(), "GBR".into())));
         assert_eq!(result[1], MarketSet::Single(("B".into(), "GBR".into())));
@@ -596,7 +596,7 @@ mod tests {
         let graphs = IndexMap::from([(("GBR".into(), 2020), graph)]);
         let result = solve_investment_order_for_year(&graphs, &commodities, 2020);
 
-        // Should be a single `Cycle` investment set containing both commodities
+        // Should be a single `Cycle` market set containing both commodities
         assert_eq!(result.len(), 1);
         assert_eq!(
             result[0],

--- a/src/graph/investment.rs
+++ b/src/graph/investment.rs
@@ -2,7 +2,7 @@
 use super::{CommoditiesGraph, GraphEdge, GraphNode};
 use crate::commodity::{CommodityMap, CommodityType};
 use crate::region::RegionID;
-use crate::simulation::market::InvestmentSet;
+use crate::simulation::market::MarketSet;
 use highs::{Col, HighsModelStatus, RowProblem, Sense};
 use indexmap::IndexMap;
 use log::warn;
@@ -13,7 +13,7 @@ use petgraph::visit::EdgeRef;
 use petgraph::{Directed, Direction};
 use std::collections::HashMap;
 
-type InvestmentGraph = Graph<InvestmentSet, GraphEdge, Directed>;
+type InvestmentGraph = Graph<MarketSet, GraphEdge, Directed>;
 
 /// Analyse the commodity graphs for a given year to determine the order in which investment
 /// decisions should be made.
@@ -24,10 +24,10 @@ type InvestmentGraph = Graph<InvestmentSet, GraphEdge, Directed>;
 ///    all regions are combined into a single `InvestmentGraph`. TODO: at present there can be no
 ///    edges between regions; in future we will want to implement trade as edges between regions,
 ///    but this will have no impact on the following steps.
-/// 2. Condense strongly connected components (cycles) into `InvestmentSet::Cycle` nodes.
+/// 2. Condense strongly connected components (cycles) into `MarketSet::Cycle` nodes.
 /// 3. Perform a topological sort on the condensed graph.
 /// 4. Compute layers for investment based on the topological order, grouping independent sets into
-///    `InvestmentSet::Layer`s.
+///    `MarketSet::Layer`s.
 ///
 /// Arguments:
 /// * `graphs` - Commodity graphs for each region and year, outputted from `build_commodity_graphs_for_model`
@@ -35,13 +35,13 @@ type InvestmentGraph = Graph<InvestmentSet, GraphEdge, Directed>;
 /// * `year` - The year to solve the investment order for
 ///
 /// # Returns
-/// A Vec of `InvestmentSet`s in the order they should be solved, with cycles grouped into
-/// `InvestmentSet::Cycle`s and independent sets grouped into `InvestmentSet::Layer`s.
+/// A Vec of `MarketSet`s in the order they should be solved, with cycles grouped into
+/// `MarketSet::Cycle`s and independent sets grouped into `MarketSet::Layer`s.
 fn solve_investment_order_for_year(
     graphs: &IndexMap<(RegionID, u32), CommoditiesGraph>,
     commodities: &CommodityMap,
     year: u32,
-) -> Vec<InvestmentSet> {
+) -> Vec<MarketSet> {
     // Initialise InvestmentGraph for this year from the set of original `CommodityGraph`s
     let mut investment_graph = init_investment_graph_for_year(graphs, year, commodities);
 
@@ -60,7 +60,7 @@ fn solve_investment_order_for_year(
 /// Initialise an `InvestmentGraph` for the given year from a set of `CommodityGraph`s
 ///
 /// Commodity graphs for each region are first filtered to only include SVD/SED commodities. Each
-/// commodity node is then added to a global investment graph as an `InvestmentSet::Single`, with
+/// commodity node is then added to a global investment graph as an `MarketSet::Single`, with
 /// edges preserved from the original commodity graphs.
 fn init_investment_graph_for_year(
     graphs: &IndexMap<(RegionID, u32), CommoditiesGraph>,
@@ -96,7 +96,7 @@ fn init_investment_graph_for_year(
                 };
                 (
                     ni,
-                    combined.add_node(InvestmentSet::Single((cid.clone(), region_id.clone()))),
+                    combined.add_node(MarketSet::Single((cid.clone(), region_id.clone()))),
                 )
             })
             .collect();
@@ -114,7 +114,7 @@ fn init_investment_graph_for_year(
     combined
 }
 
-/// Compresses cycles into `InvestmentSet::Cycle` nodes
+/// Compresses cycles into `MarketSet::Cycle` nodes
 fn compress_cycles(graph: &InvestmentGraph) -> InvestmentGraph {
     // Detect strongly connected components
     let mut condensed_graph = condensation(graph.clone(), true);
@@ -124,12 +124,12 @@ fn compress_cycles(graph: &InvestmentGraph) -> InvestmentGraph {
 
     // Map to a new InvestmentGraph
     condensed_graph.map(
-        // Map nodes to InvestmentSet
+        // Map nodes to MarketSet
         // If only one member, keep as-is; if multiple members, create Cycle
         |_, node_weight| match node_weight.len() {
             0 => unreachable!("Condensed graph node must have at least one member"),
             1 => node_weight[0].clone(),
-            _ => InvestmentSet::Cycle(
+            _ => MarketSet::Cycle(
                 node_weight
                     .iter()
                     .flat_map(|s| s.iter_markets())
@@ -145,7 +145,7 @@ fn compress_cycles(graph: &InvestmentGraph) -> InvestmentGraph {
 /// Order the members of each strongly connected component using a mixed-integer linear program.
 ///
 /// `condensed_graph` contains the SCCs detected in the original investment graph, stored as
-/// `Vec<InvestmentSet>` node weights. Single-element components are already acyclic, but components
+/// `Vec<MarketSet>` node weights. Single-element components are already acyclic, but components
 /// with multiple members require an internal ordering so that the investment algorithm can treat
 /// them as near-acyclic chains, minimising potential disruption.
 ///
@@ -229,17 +229,17 @@ fn compress_cycles(graph: &InvestmentGraph) -> InvestmentGraph {
 /// * As with any SCC, at least one pairwise violation is guaranteed. In this ordering, the only
 ///   pairwise violation is between B and C, as C is solved before B, but B may consume C.
 ///
-/// The resulting order replaces the original `InvestmentSet::Cycle` entry inside the condensed
+/// The resulting order replaces the original `MarketSet::Cycle` entry inside the condensed
 /// graph, providing a deterministic processing sequence for downstream logic.
 #[allow(clippy::too_many_lines)]
 fn order_sccs(
-    condensed_graph: &mut Graph<Vec<InvestmentSet>, GraphEdge>,
+    condensed_graph: &mut Graph<Vec<MarketSet>, GraphEdge>,
     original_graph: &InvestmentGraph,
 ) {
     const EXTERNAL_BIAS: f64 = 0.1;
 
     // Map each investment set back to the node index in the original graph so we can inspect edges.
-    let node_lookup: HashMap<InvestmentSet, NodeIndex> = original_graph
+    let node_lookup: HashMap<MarketSet, NodeIndex> = original_graph
         .node_indices()
         .map(|idx| (original_graph.node_weight(idx).unwrap().clone(), idx))
         .collect();
@@ -395,10 +395,10 @@ fn order_sccs(
 /// to lowest rank (root nodes).
 ///
 /// This function computes the ranks of each node, groups nodes by rank, and then produces a final
-/// ordered Vec of `InvestmentSet`s which gives the order in which to solve the investment decisions.
+/// ordered Vec of `MarketSet`s which gives the order in which to solve the investment decisions.
 ///
 /// Investment sets with the same rank (i.e., can be solved in parallel) are grouped into
-/// `InvestmentSet::Layer`. Investment sets that are alone in their rank remain as-is (i.e. either
+/// `MarketSet::Layer`. Investment sets that are alone in their rank remain as-is (i.e. either
 /// `Single` or `Cycle`). `Layer`s can contain a mix of `Single` and `Cycle` investment sets.
 ///
 /// For example, given the following graph:
@@ -411,11 +411,11 @@ fn order_sccs(
 /// D   E   F
 /// ```
 ///
-/// Rank 0: A -> `InvestmentSet::Single`
-/// Rank 1: B, C -> `InvestmentSet::Layer`
-/// Rank 2: D, E, F -> `InvestmentSet::Layer`
+/// Rank 0: A -> `MarketSet::Single`
+/// Rank 1: B, C -> `MarketSet::Layer`
+/// Rank 2: D, E, F -> `MarketSet::Layer`
 ///
-/// These are returned as a `Vec<InvestmentSet>` from highest rank to lowest (i.e. the D, E, F layer
+/// These are returned as a `Vec<MarketSet>` from highest rank to lowest (i.e. the D, E, F layer
 /// first, then the B, C layer, then the singleton A).
 ///
 /// Arguments:
@@ -425,9 +425,9 @@ fn order_sccs(
 /// * `order` - The topological order of the graph nodes. Computed using `petgraph::algo::toposort`.
 ///
 /// Returns:
-/// A Vec of `InvestmentSet`s in the order they should be solved, with independent sets grouped into
-/// `InvestmentSet::Layer`s.
-fn compute_layers(graph: &InvestmentGraph, order: &[NodeIndex]) -> Vec<InvestmentSet> {
+/// A Vec of `MarketSet`s in the order they should be solved, with independent sets grouped into
+/// `MarketSet::Layer`s.
+fn compute_layers(graph: &InvestmentGraph, order: &[NodeIndex]) -> Vec<MarketSet> {
     // Initialize all ranks to 0
     let mut ranks: HashMap<_, usize> = graph.node_indices().map(|n| (n, 0)).collect();
 
@@ -445,27 +445,27 @@ fn compute_layers(graph: &InvestmentGraph, order: &[NodeIndex]) -> Vec<Investmen
 
     // Group nodes by rank
     let max_rank = ranks.values().copied().max().unwrap_or(0);
-    let mut groups: Vec<Vec<InvestmentSet>> = vec![Vec::new(); max_rank + 1];
+    let mut groups: Vec<Vec<MarketSet>> = vec![Vec::new(); max_rank + 1];
     for node_idx in order {
         let rank = ranks[node_idx];
         let w = graph.node_weight(*node_idx).unwrap().clone();
         groups[rank].push(w);
     }
 
-    // Produce final ordered Vec<InvestmentSet>: ranks descending (leaf-first),
-    // compressing equal-rank nodes into an InvestmentSet::Layer.
+    // Produce final ordered Vec<MarketSet>: ranks descending (leaf-first),
+    // compressing equal-rank nodes into an MarketSet::Layer.
     let mut result = Vec::new();
     for mut items in groups.into_iter().rev() {
         if items.is_empty() {
             unreachable!("Should be no gaps in the ranking")
         }
-        // If only one InvestmentSet in the group, we do not need to compress into a layer, so just
+        // If only one MarketSet in the group, we do not need to compress into a layer, so just
         // push the single item (this item may be a `Single` or `Cycle`).
         if items.len() == 1 {
             result.push(items.remove(0));
         // Otherwise, create a layer. The items within the layer may be a mix of `Single` or `Cycle`.
         } else {
-            result.push(InvestmentSet::Layer(items));
+            result.push(MarketSet::Layer(items));
         }
     }
 
@@ -481,14 +481,14 @@ fn compute_layers(graph: &InvestmentGraph, order: &[NodeIndex]) -> Vec<Investmen
 ///
 /// # Returns
 ///
-/// A map from `year` to the ordered list of `InvestmentSet`s for investment decisions. The
-/// ordering ensures that leaf-node `InvestmentSet`s (those with no outgoing edges) are solved
+/// A map from `year` to the ordered list of `MarketSet`s for investment decisions. The
+/// ordering ensures that leaf-node `MarketSet`s (those with no outgoing edges) are solved
 /// first.
 pub fn solve_investment_order_for_model(
     commodity_graphs: &IndexMap<(RegionID, u32), CommoditiesGraph>,
     commodities: &CommodityMap,
     years: &[u32],
-) -> HashMap<u32, Vec<InvestmentSet>> {
+) -> HashMap<u32, Vec<MarketSet>> {
     let mut investment_orders = HashMap::new();
     for year in years {
         let order = solve_investment_order_for_year(commodity_graphs, commodities, *year);
@@ -508,7 +508,7 @@ mod tests {
 
     #[test]
     fn order_sccs_simple_cycle() {
-        let markets = ["A", "B", "C"].map(|id| InvestmentSet::Single((id.into(), "GBR".into())));
+        let markets = ["A", "B", "C"].map(|id| MarketSet::Single((id.into(), "GBR".into())));
 
         // Create graph with cycle edges plus an extra dependency B ← D (see doc comment)
         let mut original = InvestmentGraph::new();
@@ -524,7 +524,7 @@ mod tests {
             );
         }
         // External market receiving exports from C; encourages C to appear early.
-        let external = original.add_node(InvestmentSet::Single(("X".into(), "GBR".into())));
+        let external = original.add_node(MarketSet::Single(("X".into(), "GBR".into())));
         original.add_edge(
             node_indices[2],
             external,
@@ -532,7 +532,7 @@ mod tests {
         );
 
         // Single SCC containing all markets.
-        let mut condensed: Graph<Vec<InvestmentSet>, GraphEdge> = Graph::new();
+        let mut condensed: Graph<Vec<MarketSet>, GraphEdge> = Graph::new();
         let component = condensed.add_node(markets.to_vec());
 
         order_sccs(&mut condensed, &original);
@@ -540,7 +540,7 @@ mod tests {
         // Expected order corresponds to the example in the doc comment.
         // Note that C should be first, as it has an outgoing edge to the external market.
         let expected = ["C", "A", "B"]
-            .map(|id| InvestmentSet::Single((id.into(), "GBR".into())))
+            .map(|id| MarketSet::Single((id.into(), "GBR".into())))
             .to_vec();
 
         assert_eq!(condensed.node_weight(component).unwrap(), &expected);
@@ -571,9 +571,9 @@ mod tests {
         // Expected order: C, B, A (leaf nodes first)
         // No cycles or layers, so all investment sets should be `Single`
         assert_eq!(result.len(), 3);
-        assert_eq!(result[0], InvestmentSet::Single(("C".into(), "GBR".into())));
-        assert_eq!(result[1], InvestmentSet::Single(("B".into(), "GBR".into())));
-        assert_eq!(result[2], InvestmentSet::Single(("A".into(), "GBR".into())));
+        assert_eq!(result[0], MarketSet::Single(("C".into(), "GBR".into())));
+        assert_eq!(result[1], MarketSet::Single(("B".into(), "GBR".into())));
+        assert_eq!(result[2], MarketSet::Single(("A".into(), "GBR".into())));
     }
 
     #[rstest]
@@ -600,7 +600,7 @@ mod tests {
         assert_eq!(result.len(), 1);
         assert_eq!(
             result[0],
-            InvestmentSet::Cycle(vec![("A".into(), "GBR".into()), ("B".into(), "GBR".into())])
+            MarketSet::Cycle(vec![("A".into(), "GBR".into()), ("B".into(), "GBR".into())])
         );
     }
 
@@ -637,15 +637,15 @@ mod tests {
 
         // Expected order: D, Layer(B, C), A
         assert_eq!(result.len(), 3);
-        assert_eq!(result[0], InvestmentSet::Single(("D".into(), "GBR".into())));
+        assert_eq!(result[0], MarketSet::Single(("D".into(), "GBR".into())));
         assert_eq!(
             result[1],
-            InvestmentSet::Layer(vec![
-                InvestmentSet::Single(("B".into(), "GBR".into())),
-                InvestmentSet::Single(("C".into(), "GBR".into()))
+            MarketSet::Layer(vec![
+                MarketSet::Single(("B".into(), "GBR".into())),
+                MarketSet::Single(("C".into(), "GBR".into()))
             ])
         );
-        assert_eq!(result[2], InvestmentSet::Single(("A".into(), "GBR".into())));
+        assert_eq!(result[2], MarketSet::Single(("A".into(), "GBR".into())));
     }
 
     #[rstest]
@@ -678,23 +678,23 @@ mod tests {
         assert_eq!(result.len(), 3);
         assert_eq!(
             result[0],
-            InvestmentSet::Layer(vec![
-                InvestmentSet::Single(("C".into(), "GBR".into())),
-                InvestmentSet::Single(("C".into(), "FRA".into()))
+            MarketSet::Layer(vec![
+                MarketSet::Single(("C".into(), "GBR".into())),
+                MarketSet::Single(("C".into(), "FRA".into()))
             ])
         );
         assert_eq!(
             result[1],
-            InvestmentSet::Layer(vec![
-                InvestmentSet::Single(("B".into(), "GBR".into())),
-                InvestmentSet::Single(("B".into(), "FRA".into()))
+            MarketSet::Layer(vec![
+                MarketSet::Single(("B".into(), "GBR".into())),
+                MarketSet::Single(("B".into(), "FRA".into()))
             ])
         );
         assert_eq!(
             result[2],
-            InvestmentSet::Layer(vec![
-                InvestmentSet::Single(("A".into(), "GBR".into())),
-                InvestmentSet::Single(("A".into(), "FRA".into()))
+            MarketSet::Layer(vec![
+                MarketSet::Single(("A".into(), "GBR".into())),
+                MarketSet::Single(("A".into(), "FRA".into()))
             ])
         );
     }

--- a/src/model.rs
+++ b/src/model.rs
@@ -4,7 +4,7 @@ use crate::asset::UserAsset;
 use crate::commodity::{CommodityID, CommodityMap};
 use crate::process::ProcessMap;
 use crate::region::{Region, RegionID, RegionMap};
-use crate::simulation::market::InvestmentSet;
+use crate::simulation::market::MarketSet;
 use crate::time_slice::TimeSliceInfo;
 use std::collections::HashMap;
 use std::path::PathBuf;
@@ -33,7 +33,7 @@ pub struct Model {
     /// User-defined assets
     pub user_assets: Vec<UserAsset>,
     /// Commodity ordering for each milestone year
-    pub investment_order: HashMap<u32, Vec<InvestmentSet>>,
+    pub investment_order: HashMap<u32, Vec<MarketSet>>,
 }
 
 impl Model {

--- a/src/model.rs
+++ b/src/model.rs
@@ -4,7 +4,7 @@ use crate::asset::UserAsset;
 use crate::commodity::{CommodityID, CommodityMap};
 use crate::process::ProcessMap;
 use crate::region::{Region, RegionID, RegionMap};
-use crate::simulation::investment::InvestmentSet;
+use crate::simulation::market::InvestmentSet;
 use crate::time_slice::TimeSliceInfo;
 use std::collections::HashMap;
 use std::path::PathBuf;

--- a/src/simulation.rs
+++ b/src/simulation.rs
@@ -14,6 +14,7 @@ pub mod optimisation;
 use optimisation::{DispatchRun, FlowMap};
 pub mod investment;
 use investment::perform_agent_investment;
+pub mod market;
 pub mod prices;
 pub use prices::PriceMap;
 

--- a/src/simulation/investment.rs
+++ b/src/simulation/investment.rs
@@ -1,7 +1,7 @@
 //! Code for performing agent investment.
 use super::optimisation::{DispatchRun, FlowMap};
 use crate::agent::{Agent, AgentID};
-use crate::asset::{Asset, AssetCapacity, AssetIterator, AssetRef, AssetState};
+use crate::asset::{Asset, AssetCapacity, AssetRef, AssetState};
 use crate::commodity::{Commodity, CommodityID, CommodityMap};
 use crate::model::Model;
 use crate::output::DataWriter;
@@ -11,7 +11,7 @@ use crate::time_slice::{TimeSliceID, TimeSliceInfo, TimeSliceLevel};
 use crate::units::{ActivityPerCapacity, Capacity, Dimensionless, Flow, FlowPerCapacity};
 use anyhow::{Result, ensure};
 use indexmap::IndexMap;
-use itertools::{Itertools, chain};
+use itertools::Itertools;
 use log::{debug, warn};
 use std::collections::{HashMap, HashSet};
 use strum::IntoEnumIterator;
@@ -24,10 +24,10 @@ use appraisal::{
 };
 
 /// A map of demand across time slices for a specific market
-type DemandMap = IndexMap<TimeSliceID, Flow>;
+pub type DemandMap = IndexMap<TimeSliceID, Flow>;
 
 /// Demand for a given combination of commodity, region and time slice
-type AllDemandMap = IndexMap<(CommodityID, RegionID, TimeSliceID), Flow>;
+pub type AllDemandMap = IndexMap<(CommodityID, RegionID, TimeSliceID), Flow>;
 
 /// Perform agent investment to determine capacity investment of new assets for next milestone year.
 ///
@@ -209,7 +209,7 @@ pub fn update_net_demand_map(demand: &mut AllDemandMap, flows: &FlowMap, assets:
 ///
 /// Selections whose maximum supply is zero are ignored. Such selections would otherwise imply an
 /// infinite capacity requirement and therefore provide no useful lower bound.
-fn get_demand_limiting_capacity(
+pub fn get_demand_limiting_capacity(
     time_slice_info: &TimeSliceInfo,
     asset: &Asset,
     commodity: &Commodity,
@@ -279,71 +279,6 @@ fn get_demand_limiting_capacity(
     capacity
 }
 
-/// Get options from existing and potential assets for the given parameters
-#[allow(clippy::too_many_arguments)]
-pub fn get_asset_options<'a>(
-    time_slice_info: &'a TimeSliceInfo,
-    all_existing_assets: &'a [AssetRef],
-    demand: &'a DemandMap,
-    agent: &'a Agent,
-    commodity: &'a Commodity,
-    region_id: &'a RegionID,
-    year: u32,
-    capacity_limit_factor: Dimensionless,
-) -> impl Iterator<Item = AssetRef> + 'a {
-    // Get existing assets which produce the commodity of interest
-    let existing_assets = all_existing_assets
-        .iter()
-        .filter_agent(&agent.id)
-        .filter_region(region_id)
-        .filter_primary_producers_of(&commodity.id)
-        .cloned();
-
-    // Get candidates assets which produce the commodity of interest
-    let candidate_assets = get_candidate_assets(
-        time_slice_info,
-        demand,
-        agent,
-        region_id,
-        commodity,
-        year,
-        capacity_limit_factor,
-    );
-
-    chain(existing_assets, candidate_assets)
-}
-
-/// Get candidate assets which produce a particular commodity for a given agent
-///
-/// Capacities of candidate assets are set to the demand-limiting capacity for the given market,
-/// scaled by the `capacity_limit_factor`.
-fn get_candidate_assets<'a>(
-    time_slice_info: &'a TimeSliceInfo,
-    demand: &'a DemandMap,
-    agent: &'a Agent,
-    region_id: &'a RegionID,
-    commodity: &'a Commodity,
-    year: u32,
-    capacity_limit_factor: Dimensionless,
-) -> impl Iterator<Item = AssetRef> + 'a {
-    agent
-        .iter_search_space(region_id, &commodity.id, year)
-        .map(move |process| {
-            let mut asset =
-                Asset::new_candidate(process.clone(), region_id.clone(), Capacity(0.0), year)
-                    .unwrap();
-
-            // Set capacity based on demand
-            // This will serve as the upper limit when appraising the asset
-            let capacity = get_demand_limiting_capacity(time_slice_info, &asset, commodity, demand);
-            let asset_capacity = AssetCapacity::from_capacity(capacity, asset.unit_size())
-                .apply_limit_factor(capacity_limit_factor);
-            asset.set_capacity(asset_capacity);
-
-            asset.into()
-        })
-}
-
 /// Print debug message if there are multiple equally good outputs
 fn log_on_equal_appraisal_outputs(
     outputs: &[AppraisalOutput],
@@ -379,24 +314,6 @@ fn log_on_equal_appraisal_outputs(
             Region: {region_id}. Options: [{asset_details}]. Selecting first option.",
         );
     }
-}
-
-/// Investment limits are based on any annual addition limits specified by the process, scaled
-/// according to the agent's portion of the commodity demand and the number of years elapsed since
-/// the previous milestone year.
-pub fn collect_investment_limits_for_candidates(
-    opt_assets: &[AssetRef],
-    commodity_portion: Dimensionless,
-) -> HashMap<AssetRef, AssetCapacity> {
-    opt_assets
-        .iter()
-        .filter(|asset| !asset.is_commissioned())
-        .filter_map(|asset| {
-            asset
-                .max_installable_capacity(commodity_portion)
-                .map(|limit_capacity| (asset.clone(), limit_capacity))
-        })
-        .collect()
 }
 
 /// Get the best assets for meeting demand for the given commodity
@@ -606,11 +523,7 @@ mod tests {
         asset, process, process_activity_limits_map, process_flows_map, process_parameter_map,
         region_id, svd_commodity, time_slice, time_slice_info, time_slice_info2,
     };
-    use crate::process::{
-        ActivityLimits, FlowType, Process, ProcessActivityLimitsMap, ProcessFlow, ProcessFlowsMap,
-        ProcessInvestmentConstraint, ProcessInvestmentConstraintsMap, ProcessParameterMap,
-    };
-    use crate::region::RegionID;
+    use crate::process::{ActivityLimits, FlowType, Process, ProcessFlow};
     use crate::time_slice::{TimeSliceID, TimeSliceInfo, TimeSliceSelection};
     use crate::units::Dimensionless;
     use crate::units::{ActivityPerCapacity, Flow, FlowPerActivity, MoneyPerFlow};
@@ -761,90 +674,5 @@ mod tests {
             get_demand_limiting_capacity(&time_slice_info2, &asset, &commodity_rc, &demand);
 
         assert_eq!(result, Capacity(20.0));
-    }
-
-    #[rstest]
-    fn collect_investment_limits_for_candidates_empty_list() {
-        let result = collect_investment_limits_for_candidates(&[], Dimensionless(1.0));
-        assert!(result.is_empty());
-    }
-
-    #[fixture]
-    fn commissioned_asset(asset: Asset) -> AssetRef {
-        asset.into()
-    }
-
-    #[fixture]
-    fn uncommissioned_asset_without_limit(process: Process, region_id: RegionID) -> AssetRef {
-        Asset::new_candidate(Rc::new(process), region_id, Capacity(10.0), 2015)
-            .unwrap()
-            .into()
-    }
-
-    #[fixture]
-    fn uncommissioned_asset_with_limit(
-        region_id: RegionID,
-        process_activity_limits_map: ProcessActivityLimitsMap,
-        process_flows_map: ProcessFlowsMap,
-        process_parameter_map: ProcessParameterMap,
-    ) -> AssetRef {
-        let region_ids: IndexSet<RegionID> = [region_id.clone()].into();
-
-        let mut constraints = ProcessInvestmentConstraintsMap::new();
-
-        constraints.insert(
-            (region_id.clone(), 2015),
-            Rc::new(ProcessInvestmentConstraint {
-                addition_limit: Some(Capacity(10.0)),
-            }),
-        );
-
-        let process = Process {
-            id: "constrained_process".into(),
-            description: String::new(),
-            years: 2010..=2020,
-            activity_limits: process_activity_limits_map,
-            flows: process_flows_map,
-            parameters: process_parameter_map,
-            regions: region_ids,
-            primary_output: None,
-            capacity_to_activity: ActivityPerCapacity(1.0),
-            investment_constraints: constraints,
-            unit_size: None,
-        };
-
-        Asset::new_candidate(Rc::new(process), region_id, Capacity(15.0), 2015)
-            .unwrap()
-            .into()
-    }
-
-    #[rstest]
-    fn commissioned_assets_are_excluded(commissioned_asset: AssetRef) {
-        let result = collect_investment_limits_for_candidates(
-            from_ref(&commissioned_asset),
-            Dimensionless(1.0),
-        );
-
-        assert!(!result.contains_key(&commissioned_asset));
-    }
-
-    #[rstest]
-    fn candidate_assets_without_limits_are_excluded(uncommissioned_asset_without_limit: AssetRef) {
-        let result = collect_investment_limits_for_candidates(
-            from_ref(&uncommissioned_asset_without_limit),
-            Dimensionless(1.0),
-        );
-
-        assert!(!result.contains_key(&uncommissioned_asset_without_limit));
-    }
-
-    #[rstest]
-    fn candidate_assets_with_limits_are_included(uncommissioned_asset_with_limit: AssetRef) {
-        let result = collect_investment_limits_for_candidates(
-            from_ref(&uncommissioned_asset_with_limit),
-            Dimensionless(1.0),
-        );
-
-        assert!(result.contains_key(&uncommissioned_asset_with_limit));
     }
 }

--- a/src/simulation/investment.rs
+++ b/src/simulation/investment.rs
@@ -69,10 +69,10 @@ pub fn perform_agent_investment(
     // markets that have been seen so far.
     let mut seen_markets = Vec::new();
 
-    // Iterate over investment sets in the investment order for this year
-    for investment_set in investment_order {
-        // Select assets for this investment set
-        let selected_assets = investment_set.select_assets(
+    // Iterate over market sets in the investment order for this year
+    for market_set in investment_order {
+        // Select assets for this market set
+        let selected_assets = market_set.select_assets(
             model,
             year,
             &net_demand,
@@ -84,7 +84,7 @@ pub fn perform_agent_investment(
         )?;
 
         // Update our list of seen markets
-        for market in investment_set.iter_markets() {
+        for market in market_set.iter_markets() {
             seen_markets.push(market.clone());
         }
 
@@ -92,7 +92,7 @@ pub fn perform_agent_investment(
         // **TODO**: this probably means there's no demand for the market, which we could
         // presumably preempt
         if selected_assets.is_empty() {
-            debug!("No assets selected for '{investment_set}'");
+            debug!("No assets selected for '{market_set}'");
             continue;
         }
 
@@ -102,14 +102,14 @@ pub fn perform_agent_investment(
         // Perform dispatch optimisation with assets that have been selected so far
         // **TODO**: presumably we only need to do this for selected_assets, as assets added in
         // previous iterations should not change
-        debug!("Running post-investment dispatch for '{investment_set}'");
+        debug!("Running post-investment dispatch for '{market_set}'");
 
         // As upstream markets by definition will not yet have producers, we explicitly set
         // their prices using external values so that they don't appear free
         let solution = DispatchRun::new(model, &all_selected_assets, year)
             .with_market_balance_subset(&seen_markets)
             .with_input_prices(&prices.shadow)
-            .run(&format!("post {investment_set} investment"), writer)?;
+            .run(&format!("post {market_set} investment"), writer)?;
 
         // Update demand map with flows from newly added assets
         update_net_demand_map(

--- a/src/simulation/investment.rs
+++ b/src/simulation/investment.rs
@@ -9,12 +9,11 @@ use crate::region::RegionID;
 use crate::simulation::prices::Prices;
 use crate::time_slice::{TimeSliceID, TimeSliceInfo, TimeSliceLevel};
 use crate::units::{ActivityPerCapacity, Capacity, Dimensionless, Flow, FlowPerCapacity};
-use anyhow::{Context, Result, ensure};
+use anyhow::{Result, ensure};
 use indexmap::IndexMap;
 use itertools::{Itertools, chain};
 use log::{debug, warn};
 use std::collections::{HashMap, HashSet};
-use std::fmt::Display;
 use strum::IntoEnumIterator;
 
 pub mod appraisal;
@@ -29,132 +28,6 @@ type DemandMap = IndexMap<TimeSliceID, Flow>;
 
 /// Demand for a given combination of commodity, region and time slice
 type AllDemandMap = IndexMap<(CommodityID, RegionID, TimeSliceID), Flow>;
-
-/// Represents a set of markets which are invested in together.
-#[derive(PartialEq, Debug, Clone, Eq, Hash)]
-pub enum InvestmentSet {
-    /// Assets are selected for a single market using `select_assets_for_single_market`
-    Single((CommodityID, RegionID)),
-    /// Assets are selected for a group of markets which forms a cycle.
-    /// Experimental: handled by `select_assets_for_cycle` and guarded by the broken options
-    /// parameter.
-    Cycle(Vec<(CommodityID, RegionID)>),
-    /// Assets are selected for a layer of independent `InvestmentSet`s
-    Layer(Vec<InvestmentSet>),
-}
-
-impl InvestmentSet {
-    /// Recursively iterate over all markets contained in this `InvestmentSet`.
-    pub fn iter_markets<'a>(
-        &'a self,
-    ) -> Box<dyn Iterator<Item = &'a (CommodityID, RegionID)> + 'a> {
-        match self {
-            InvestmentSet::Single(market) => Box::new(std::iter::once(market)),
-            InvestmentSet::Cycle(markets) => Box::new(markets.iter()),
-            InvestmentSet::Layer(set) => Box::new(set.iter().flat_map(|s| s.iter_markets())),
-        }
-    }
-
-    /// Selects assets for this investment set variant and passes through the shared
-    /// context needed by single-market, cycle, or layered selection.
-    ///
-    /// # Arguments
-    ///
-    /// * `model` – Simulation model supplying parameters, processes, and dispatch.
-    /// * `year` – Planning year being solved.
-    /// * `demand` – Net demand profiles available to all markets before selection.
-    /// * `existing_assets` – Assets already commissioned in the system.
-    /// * `prices` – Commodity price assumptions to use when valuing investments.
-    /// * `seen_markets` – Markets for which investments have already been settled.
-    /// * `previously_selected_assets` – Assets chosen in earlier investment sets.
-    /// * `writer` – Data sink used to log optimisation artefacts.
-    #[allow(clippy::too_many_arguments)]
-    fn select_assets(
-        &self,
-        model: &Model,
-        year: u32,
-        demand: &AllDemandMap,
-        existing_assets: &[AssetRef],
-        prices: &Prices,
-        seen_markets: &[(CommodityID, RegionID)],
-        previously_selected_assets: &[AssetRef],
-        writer: &mut DataWriter,
-    ) -> Result<Vec<AssetRef>> {
-        match self {
-            InvestmentSet::Single((commodity_id, region_id)) => select_assets_for_single_market(
-                model,
-                commodity_id,
-                region_id,
-                year,
-                demand,
-                existing_assets,
-                prices,
-                writer,
-            ),
-            InvestmentSet::Cycle(markets) => {
-                debug!("Starting investment for cycle '{self}'");
-                select_assets_for_cycle(
-                    model,
-                    markets,
-                    year,
-                    demand,
-                    existing_assets,
-                    prices,
-                    seen_markets,
-                    previously_selected_assets,
-                    writer,
-                )
-                .with_context(|| {
-                    format!(
-                        "Investments failed for market set {self} with cyclical dependencies. \
-                         Please note that the investment algorithm is currently experimental for \
-                         models with circular commodity dependencies and may not be able to find \
-                         a solution in all cases."
-                    )
-                })
-            }
-            InvestmentSet::Layer(investment_sets) => {
-                debug!("Starting asset selection for layer '{self}'");
-                let mut all_assets = Vec::new();
-                for investment_set in investment_sets {
-                    let assets = investment_set.select_assets(
-                        model,
-                        year,
-                        demand,
-                        existing_assets,
-                        prices,
-                        seen_markets,
-                        previously_selected_assets,
-                        writer,
-                    )?;
-                    all_assets.extend(assets);
-                }
-                debug!("Completed asset selection for layer '{self}'");
-                Ok(all_assets)
-            }
-        }
-    }
-}
-
-impl Display for InvestmentSet {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            InvestmentSet::Single((commodity_id, region_id)) => {
-                write!(f, "{commodity_id}|{region_id}")
-            }
-            InvestmentSet::Cycle(markets) => {
-                write!(
-                    f,
-                    "({})",
-                    markets.iter().map(|(c, r)| format!("{c}|{r}")).join(", ")
-                )
-            }
-            InvestmentSet::Layer(ids) => {
-                write!(f, "[{}]", ids.iter().join(", "))
-            }
-        }
-    }
-}
 
 /// Perform agent investment to determine capacity investment of new assets for next milestone year.
 ///
@@ -249,211 +122,6 @@ pub fn perform_agent_investment(
     Ok(all_selected_assets)
 }
 
-/// Select assets for a single market in a given year
-///
-/// Returns a list of assets that are selected for investment for this market in this year.
-#[allow(clippy::too_many_arguments)]
-fn select_assets_for_single_market(
-    model: &Model,
-    commodity_id: &CommodityID,
-    region_id: &RegionID,
-    year: u32,
-    demand: &AllDemandMap,
-    existing_assets: &[AssetRef],
-    prices: &Prices,
-    writer: &mut DataWriter,
-) -> Result<Vec<AssetRef>> {
-    let commodity = &model.commodities[commodity_id];
-
-    let mut selected_assets = Vec::new();
-    for (agent, commodity_portion) in
-        get_responsible_agents(model.agents.values(), commodity_id, region_id, year)
-    {
-        debug!(
-            "Running asset selection for agent '{}' in market '{}|{}'",
-            &agent.id, commodity_id, region_id
-        );
-
-        // Get demand portion for this market for this agent in this year
-        let demand_portion_for_market = get_demand_portion_for_market(
-            &model.time_slice_info,
-            demand,
-            commodity_id,
-            region_id,
-            commodity_portion,
-        );
-
-        // Existing and candidate assets from which to choose
-        let opt_assets = get_asset_options(
-            &model.time_slice_info,
-            existing_assets,
-            &demand_portion_for_market,
-            agent,
-            commodity,
-            region_id,
-            year,
-            model.parameters.capacity_limit_factor,
-        )
-        .collect::<Vec<_>>();
-
-        // Calculate investment limits for candidate assets
-        let investment_limits =
-            collect_investment_limits_for_candidates(&opt_assets, commodity_portion);
-
-        // Choose assets from among existing pool and candidates
-        let best_assets = select_best_assets(
-            model,
-            opt_assets,
-            investment_limits,
-            commodity,
-            agent,
-            region_id,
-            prices,
-            demand_portion_for_market,
-            year,
-            writer,
-        )?;
-        selected_assets.extend(best_assets);
-    }
-
-    Ok(selected_assets)
-}
-
-/// Iterates through the a pre-ordered set of markets forming a cycle, selecting assets for each
-/// market in turn.
-///
-/// Dispatch optimisation is performed after each market is visited to rebalance demand.
-/// While dispatching, newly selected (`Ready`) assets are given flexible capacity (bounded by
-/// `capacity_margin`) so small demand shifts caused by later markets can be absorbed. After all
-/// markets have been visited once, the final set of assets is returned, applying any capacity
-/// adjustments from the final full-system dispatch optimisation.
-///
-/// Dispatch may fail at any point if new demands are encountered for previously visited markets,
-/// and the `capacity_margin` is not sufficient to absorb the demand shift. At this point, the
-/// simulation is terminated with an error prompting the user to increase the `capacity_margin`.
-/// A longer-term solution (TODO) may be to trigger re-investment for the affected markets. Other
-/// yet-to-implement features may also help to stabilise the cycle, such as capacity growth limits.
-#[allow(clippy::too_many_arguments)]
-fn select_assets_for_cycle(
-    model: &Model,
-    markets: &[(CommodityID, RegionID)],
-    year: u32,
-    demand: &AllDemandMap,
-    existing_assets: &[AssetRef],
-    prices: &Prices,
-    seen_markets: &[(CommodityID, RegionID)],
-    previously_selected_assets: &[AssetRef],
-    writer: &mut DataWriter,
-) -> Result<Vec<AssetRef>> {
-    // Precompute a joined string for logging
-    let markets_str = markets.iter().map(|(c, r)| format!("{c}|{r}")).join(", ");
-
-    // Iterate over the markets to select assets
-    let mut current_demand = demand.clone();
-    let mut assets_for_cycle = IndexMap::new();
-    let mut last_solution = None;
-    for (idx, (commodity_id, region_id)) in markets.iter().enumerate() {
-        // Select assets for this market
-        let assets = select_assets_for_single_market(
-            model,
-            commodity_id,
-            region_id,
-            year,
-            &current_demand,
-            existing_assets,
-            prices,
-            writer,
-        )?;
-        assets_for_cycle.insert((commodity_id.clone(), region_id.clone()), assets);
-
-        // Assemble full list of assets for dispatch (previously selected + all chosen so far)
-        let mut all_assets = previously_selected_assets.to_vec();
-        let assets_for_cycle_flat: Vec<_> = assets_for_cycle
-            .values()
-            .flat_map(|v| v.iter().cloned())
-            .collect();
-        all_assets.extend_from_slice(&assets_for_cycle_flat);
-
-        // We balance all previously seen markets plus all cycle markets up to and including this one
-        let mut markets_to_balance = seen_markets.to_vec();
-        markets_to_balance.extend_from_slice(&markets[0..=idx]);
-
-        // We allow all `Ready` state assets to have flexible capacity
-        let flexible_capacity_assets: Vec<_> = assets_for_cycle_flat
-            .iter()
-            .filter(|asset| matches!(asset.state(), AssetState::Ready { .. }))
-            .cloned()
-            .collect();
-
-        // Retrieve installable capacity limits for flexible capacity assets.
-        let mut agent_share_cache = HashMap::new();
-        let capacity_limits = flexible_capacity_assets
-            .iter()
-            .filter_map(|asset| {
-                let agent_id = asset.agent_id().unwrap();
-                let commodity_id = asset.primary_output_commodity().unwrap();
-                let agent_share = *agent_share_cache
-                    .entry((agent_id, commodity_id))
-                    .or_insert_with(|| {
-                        model.agents[agent_id].commodity_portions[&(commodity_id.clone(), year)]
-                    });
-                asset
-                    .max_installable_capacity(agent_share)
-                    .map(|max_capacity| (asset.clone(), max_capacity))
-            })
-            .collect::<HashMap<_, _>>();
-
-        // Run dispatch
-        let solution = DispatchRun::new(model, &all_assets, year)
-            .with_market_balance_subset(&markets_to_balance)
-            .with_flexible_capacity_assets(
-                &flexible_capacity_assets,
-                Some(&capacity_limits),
-                // Gives newly selected cycle assets limited capacity wiggle-room; existing assets stay fixed.
-                model.parameters.capacity_margin,
-            )
-            .run(
-                &format!("cycle ({markets_str}) post {commodity_id}|{region_id} investment"),
-                writer,
-            )
-            .with_context(|| {
-                format!(
-                    "Cycle balancing failed for cycle ({markets_str}), capacity_margin: {}. \
-                     Try increasing the capacity_margin.",
-                    model.parameters.capacity_margin
-                )
-            })?;
-
-        // Calculate new net demand map with all assets selected so far
-        current_demand.clone_from(demand);
-        update_net_demand_map(
-            &mut current_demand,
-            &solution.create_flow_map(),
-            &assets_for_cycle_flat,
-        );
-        last_solution = Some(solution);
-    }
-
-    // Finally, update flexible capacity assets based on the final solution
-    let mut all_cycle_assets: Vec<_> = assets_for_cycle.into_values().flatten().collect();
-    if let Some(solution) = last_solution {
-        let new_capacities: HashMap<_, _> = solution.iter_capacity().collect();
-        for asset in &mut all_cycle_assets {
-            if let Some(new_capacity) = new_capacities.get(asset) {
-                debug!(
-                    "Capacity of asset '{}' modified during cycle balancing ({} to {})",
-                    asset.process_id(),
-                    asset.total_capacity(),
-                    new_capacity.total_capacity()
-                );
-                asset.make_mut().set_capacity(*new_capacity);
-            }
-        }
-    }
-
-    Ok(all_cycle_assets)
-}
-
 /// Flatten the preset commodity demands for a given year into a map of commodity, region and
 /// time slice to demand.
 ///
@@ -501,7 +169,7 @@ fn flatten_preset_demands_for_year(
 ///
 /// TODO: this is a very flawed approach. The proper solution might be for agents to consider
 /// multiple commodities simultaneously, but that would require substantial work to implement.
-fn update_net_demand_map(demand: &mut AllDemandMap, flows: &FlowMap, assets: &[AssetRef]) {
+pub fn update_net_demand_map(demand: &mut AllDemandMap, flows: &FlowMap, assets: &[AssetRef]) {
     for ((asset, commodity_id, time_slice), flow) in flows {
         if assets.contains(asset) {
             let key = (
@@ -528,50 +196,6 @@ fn update_net_demand_map(demand: &mut AllDemandMap, flows: &FlowMap, assets: &[A
 }
 
 /// Get a portion of the demand profile for this market
-fn get_demand_portion_for_market(
-    time_slice_info: &TimeSliceInfo,
-    demand: &AllDemandMap,
-    commodity_id: &CommodityID,
-    region_id: &RegionID,
-    commodity_portion: Dimensionless,
-) -> DemandMap {
-    time_slice_info
-        .iter_ids()
-        .map(|time_slice| {
-            (
-                time_slice.clone(),
-                commodity_portion
-                    * *demand
-                        .get(&(commodity_id.clone(), region_id.clone(), time_slice.clone()))
-                        .unwrap_or(&Flow(0.0)),
-            )
-        })
-        .collect()
-}
-
-/// Get the agents responsible for a given market in a given year along with the commodity
-/// portion for which they are responsible
-fn get_responsible_agents<'a, I>(
-    agents: I,
-    commodity_id: &'a CommodityID,
-    region_id: &'a RegionID,
-    year: u32,
-) -> impl Iterator<Item = (&'a Agent, Dimensionless)>
-where
-    I: Iterator<Item = &'a Agent>,
-{
-    agents.filter_map(move |agent| {
-        if !agent.regions.contains(region_id) {
-            return None;
-        }
-        let portion = agent
-            .commodity_portions
-            .get(&(commodity_id.clone(), year))?;
-
-        Some((agent, *portion))
-    })
-}
-
 /// Returns the minimum installed capacity required for `asset` to satisfy the demand that it can
 /// potentially serve, accounting for its activity constraints.
 ///
@@ -657,7 +281,7 @@ fn get_demand_limiting_capacity(
 
 /// Get options from existing and potential assets for the given parameters
 #[allow(clippy::too_many_arguments)]
-fn get_asset_options<'a>(
+pub fn get_asset_options<'a>(
     time_slice_info: &'a TimeSliceInfo,
     all_existing_assets: &'a [AssetRef],
     demand: &'a DemandMap,
@@ -760,7 +384,7 @@ fn log_on_equal_appraisal_outputs(
 /// Investment limits are based on any annual addition limits specified by the process, scaled
 /// according to the agent's portion of the commodity demand and the number of years elapsed since
 /// the previous milestone year.
-fn collect_investment_limits_for_candidates(
+pub fn collect_investment_limits_for_candidates(
     opt_assets: &[AssetRef],
     commodity_portion: Dimensionless,
 ) -> HashMap<AssetRef, AssetCapacity> {
@@ -777,7 +401,7 @@ fn collect_investment_limits_for_candidates(
 
 /// Get the best assets for meeting demand for the given commodity
 #[allow(clippy::too_many_arguments)]
-fn select_best_assets(
+pub fn select_best_assets(
     model: &Model,
     mut opt_assets: Vec<AssetRef>,
     investment_limits: HashMap<AssetRef, AssetCapacity>,

--- a/src/simulation/investment.rs
+++ b/src/simulation/investment.rs
@@ -520,17 +520,16 @@ mod tests {
     use super::*;
     use crate::commodity::Commodity;
     use crate::fixture::{
-        asset, process, process_activity_limits_map, process_flows_map, process_parameter_map,
-        region_id, svd_commodity, time_slice, time_slice_info, time_slice_info2,
+        asset, process, process_activity_limits_map, process_flows_map, svd_commodity, time_slice,
+        time_slice_info, time_slice_info2,
     };
     use crate::process::{ActivityLimits, FlowType, Process, ProcessFlow};
     use crate::time_slice::{TimeSliceID, TimeSliceInfo, TimeSliceSelection};
     use crate::units::Dimensionless;
-    use crate::units::{ActivityPerCapacity, Flow, FlowPerActivity, MoneyPerFlow};
-    use indexmap::{IndexSet, indexmap};
-    use rstest::{fixture, rstest};
+    use crate::units::{Flow, FlowPerActivity, MoneyPerFlow};
+    use indexmap::indexmap;
+    use rstest::rstest;
     use std::rc::Rc;
-    use std::slice::from_ref;
 
     #[rstest]
     fn get_demand_limiting_capacity_works(

--- a/src/simulation/market.rs
+++ b/src/simulation/market.rs
@@ -1,31 +1,24 @@
 //! Code for creating sets of markets.
 use super::optimisation::DispatchRun;
 use crate::agent::Agent;
-use crate::asset::{AssetRef, AssetState};
-use crate::commodity::CommodityID;
+use crate::asset::{Asset, AssetCapacity, AssetIterator, AssetRef, AssetState};
+use crate::commodity::{Commodity, CommodityID};
 use crate::model::Model;
 use crate::output::DataWriter;
 use crate::region::RegionID;
+use crate::simulation::investment::{
+    AllDemandMap, DemandMap, get_demand_limiting_capacity, select_best_assets,
+    update_net_demand_map,
+};
 use crate::simulation::prices::Prices;
-use crate::time_slice::{TimeSliceID, TimeSliceInfo};
-use crate::units::{Dimensionless, Flow};
+use crate::time_slice::TimeSliceInfo;
+use crate::units::{Capacity, Dimensionless, Flow};
 use anyhow::{Context, Result};
 use indexmap::IndexMap;
-use itertools::Itertools;
+use itertools::{Itertools, chain};
 use log::debug;
 use std::collections::HashMap;
 use std::fmt::Display;
-
-use crate::simulation::investment::{
-    collect_investment_limits_for_candidates, get_asset_options, select_best_assets,
-    update_net_demand_map,
-};
-
-/// A map of demand across time slices for a specific market
-type DemandMap = IndexMap<TimeSliceID, Flow>;
-
-/// Demand for a given combination of commodity, region and time slice
-type AllDemandMap = IndexMap<(CommodityID, RegionID, TimeSliceID), Flow>;
 
 /// Represents a set of markets which are invested in together.
 #[derive(PartialEq, Debug, Clone, Eq, Hash)]
@@ -150,6 +143,89 @@ impl Display for MarketSet {
             }
         }
     }
+}
+
+/// Investment limits are based on any annual addition limits specified by the process, scaled
+/// according to the agent's portion of the commodity demand and the number of years elapsed since
+/// the previous milestone year.
+pub fn collect_investment_limits_for_candidates(
+    opt_assets: &[AssetRef],
+    commodity_portion: Dimensionless,
+) -> HashMap<AssetRef, AssetCapacity> {
+    opt_assets
+        .iter()
+        .filter(|asset| !asset.is_commissioned())
+        .filter_map(|asset| {
+            asset
+                .max_installable_capacity(commodity_portion)
+                .map(|limit_capacity| (asset.clone(), limit_capacity))
+        })
+        .collect()
+}
+
+/// Get candidate assets which produce a particular commodity for a given agent
+///
+/// Capacities of candidate assets are set to the demand-limiting capacity for the given market,
+/// scaled by the `capacity_limit_factor`.
+fn get_candidate_assets<'a>(
+    time_slice_info: &'a TimeSliceInfo,
+    demand: &'a DemandMap,
+    agent: &'a Agent,
+    region_id: &'a RegionID,
+    commodity: &'a Commodity,
+    year: u32,
+    capacity_limit_factor: Dimensionless,
+) -> impl Iterator<Item = AssetRef> + 'a {
+    agent
+        .iter_search_space(region_id, &commodity.id, year)
+        .map(move |process| {
+            let mut asset =
+                Asset::new_candidate(process.clone(), region_id.clone(), Capacity(0.0), year)
+                    .unwrap();
+
+            // Set capacity based on demand
+            // This will serve as the upper limit when appraising the asset
+            let capacity = get_demand_limiting_capacity(time_slice_info, &asset, commodity, demand);
+            let asset_capacity = AssetCapacity::from_capacity(capacity, asset.unit_size())
+                .apply_limit_factor(capacity_limit_factor);
+            asset.set_capacity(asset_capacity);
+
+            asset.into()
+        })
+}
+
+/// Get options from existing and potential assets for the given parameters
+#[allow(clippy::too_many_arguments)]
+fn get_asset_options<'a>(
+    time_slice_info: &'a TimeSliceInfo,
+    all_existing_assets: &'a [AssetRef],
+    demand: &'a DemandMap,
+    agent: &'a Agent,
+    commodity: &'a Commodity,
+    region_id: &'a RegionID,
+    year: u32,
+    capacity_limit_factor: Dimensionless,
+) -> impl Iterator<Item = AssetRef> + 'a {
+    // Get existing assets which produce the commodity of interest
+    let existing_assets = all_existing_assets
+        .iter()
+        .filter_agent(&agent.id)
+        .filter_region(region_id)
+        .filter_primary_producers_of(&commodity.id)
+        .cloned();
+
+    // Get candidates assets which produce the commodity of interest
+    let candidate_assets = get_candidate_assets(
+        time_slice_info,
+        demand,
+        agent,
+        region_id,
+        commodity,
+        year,
+        capacity_limit_factor,
+    );
+
+    chain(existing_assets, candidate_assets)
 }
 
 /// Select assets for a single market in a given year
@@ -399,4 +475,110 @@ where
 
         Some((agent, *portion))
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::agent::AgentID;
+    use crate::fixture::{
+        agent_id, process, process_activity_limits_map, process_flows_map,
+        process_investment_constraints, process_parameter_map, region_id,
+    };
+    use crate::process::{
+        Process, ProcessActivityLimitsMap, ProcessFlowsMap, ProcessInvestmentConstraint,
+        ProcessInvestmentConstraintsMap, ProcessParameterMap,
+    };
+    use crate::region::RegionID;
+    use crate::units::Dimensionless;
+    use crate::units::{ActivityPerCapacity, Capacity};
+    use indexmap::IndexSet;
+    use rstest::rstest;
+    use std::rc::Rc;
+
+
+    #[rstest]
+    fn collect_investment_limits_for_candidates_empty_list() {
+        let result = collect_investment_limits_for_candidates(&[], Dimensionless(1.0));
+        assert!(result.is_empty());
+    }
+
+    #[fixture]
+    fn commissioned_asset(asset: Asset) -> AssetRef {
+        asset.into()
+    }
+
+    #[fixture]
+    fn uncommissioned_asset_without_limit(process: Process, region_id: RegionID) -> AssetRef {
+        Asset::new_candidate(Rc::new(process), region_id, Capacity(10.0), 2015)
+            .unwrap()
+            .into()
+    }
+
+    #[fixture]
+    fn uncommissioned_asset_with_limit(
+        region_id: RegionID,
+        process_activity_limits_map: ProcessActivityLimitsMap,
+        process_flows_map: ProcessFlowsMap,
+        process_parameter_map: ProcessParameterMap,
+    ) -> AssetRef {
+        let region_ids: IndexSet<RegionID> = [region_id.clone()].into();
+
+        let mut constraints = ProcessInvestmentConstraintsMap::new();
+
+        constraints.insert(
+            (region_id.clone(), 2015),
+            Rc::new(ProcessInvestmentConstraint {
+                addition_limit: Some(Capacity(10.0)),
+            }),
+        );
+
+        let process = Process {
+            id: "constrained_process".into(),
+            description: String::new(),
+            years: 2010..=2020,
+            activity_limits: process_activity_limits_map,
+            flows: process_flows_map,
+            parameters: process_parameter_map,
+            regions: region_ids,
+            primary_output: None,
+            capacity_to_activity: ActivityPerCapacity(1.0),
+            investment_constraints: constraints,
+            unit_size: None,
+        };
+
+        Asset::new_candidate(Rc::new(process), region_id, Capacity(15.0), 2015)
+            .unwrap()
+            .into()
+    }
+
+    #[rstest]
+    fn commissioned_assets_are_excluded(commissioned_asset: AssetRef) {
+        let result = collect_investment_limits_for_candidates(
+            from_ref(&commissioned_asset),
+            Dimensionless(1.0),
+        );
+
+        assert!(!result.contains_key(&commissioned_asset));
+    }
+
+    #[rstest]
+    fn candidate_assets_without_limits_are_excluded(uncommissioned_asset_without_limit: AssetRef) {
+        let result = collect_investment_limits_for_candidates(
+            from_ref(&uncommissioned_asset_without_limit),
+            Dimensionless(1.0),
+        );
+
+        assert!(!result.contains_key(&uncommissioned_asset_without_limit));
+    }
+
+    #[rstest]
+    fn candidate_assets_with_limits_are_included(uncommissioned_asset_with_limit: AssetRef) {
+        let result = collect_investment_limits_for_candidates(
+            from_ref(&uncommissioned_asset_with_limit),
+            Dimensionless(1.0),
+        );
+
+        assert!(result.contains_key(&uncommissioned_asset_with_limit));
+    }
 }

--- a/src/simulation/market.rs
+++ b/src/simulation/market.rs
@@ -26,7 +26,8 @@ pub enum MarketSet {
     /// Assets are selected for a single market using [`select_assets_for_single_market`]
     Single((CommodityID, RegionID)),
     /// Assets are selected for a group of markets which forms a cycle.
-    /// Experimental: handled by [`select_assets_for_cycle`]. May not work in every case.
+    /// Experimental: handled by [`select_assets_for_cycle`] and guarded by the broken options
+    /// parameter.
     Cycle(Vec<(CommodityID, RegionID)>),
     /// Assets are selected for a layer of independent [`MarketSet`]s
     Layer(Vec<MarketSet>),
@@ -232,7 +233,7 @@ fn get_asset_options<'a>(
 ///
 /// Returns a list of assets that are selected for investment for this market in this year.
 #[allow(clippy::too_many_arguments)]
-fn select_assets_for_single_market(
+pub fn select_assets_for_single_market(
     model: &Model,
     commodity_id: &CommodityID,
     region_id: &RegionID,
@@ -313,7 +314,7 @@ fn select_assets_for_single_market(
 /// A longer-term solution (TODO) may be to trigger re-investment for the affected markets. Other
 /// yet-to-implement features may also help to stabilise the cycle, such as capacity growth limits.
 #[allow(clippy::too_many_arguments)]
-fn select_assets_for_cycle(
+pub fn select_assets_for_cycle(
     model: &Model,
     markets: &[(CommodityID, RegionID)],
     year: u32,
@@ -480,10 +481,9 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::agent::AgentID;
     use crate::fixture::{
-        agent_id, process, process_activity_limits_map, process_flows_map,
-        process_investment_constraints, process_parameter_map, region_id,
+        asset, process, process_activity_limits_map, process_flows_map, process_parameter_map,
+        region_id,
     };
     use crate::process::{
         Process, ProcessActivityLimitsMap, ProcessFlowsMap, ProcessInvestmentConstraint,
@@ -493,9 +493,9 @@ mod tests {
     use crate::units::Dimensionless;
     use crate::units::{ActivityPerCapacity, Capacity};
     use indexmap::IndexSet;
-    use rstest::rstest;
+    use rstest::{fixture, rstest};
     use std::rc::Rc;
-
+    use std::slice::from_ref;
 
     #[rstest]
     fn collect_investment_limits_for_candidates_empty_list() {

--- a/src/simulation/market.rs
+++ b/src/simulation/market.rs
@@ -146,89 +146,6 @@ impl Display for MarketSet {
     }
 }
 
-/// Investment limits are based on any annual addition limits specified by the process, scaled
-/// according to the agent's portion of the commodity demand and the number of years elapsed since
-/// the previous milestone year.
-pub fn collect_investment_limits_for_candidates(
-    opt_assets: &[AssetRef],
-    commodity_portion: Dimensionless,
-) -> HashMap<AssetRef, AssetCapacity> {
-    opt_assets
-        .iter()
-        .filter(|asset| !asset.is_commissioned())
-        .filter_map(|asset| {
-            asset
-                .max_installable_capacity(commodity_portion)
-                .map(|limit_capacity| (asset.clone(), limit_capacity))
-        })
-        .collect()
-}
-
-/// Get candidate assets which produce a particular commodity for a given agent
-///
-/// Capacities of candidate assets are set to the demand-limiting capacity for the given market,
-/// scaled by the `capacity_limit_factor`.
-fn get_candidate_assets<'a>(
-    time_slice_info: &'a TimeSliceInfo,
-    demand: &'a DemandMap,
-    agent: &'a Agent,
-    region_id: &'a RegionID,
-    commodity: &'a Commodity,
-    year: u32,
-    capacity_limit_factor: Dimensionless,
-) -> impl Iterator<Item = AssetRef> + 'a {
-    agent
-        .iter_search_space(region_id, &commodity.id, year)
-        .map(move |process| {
-            let mut asset =
-                Asset::new_candidate(process.clone(), region_id.clone(), Capacity(0.0), year)
-                    .unwrap();
-
-            // Set capacity based on demand
-            // This will serve as the upper limit when appraising the asset
-            let capacity = get_demand_limiting_capacity(time_slice_info, &asset, commodity, demand);
-            let asset_capacity = AssetCapacity::from_capacity(capacity, asset.unit_size())
-                .apply_limit_factor(capacity_limit_factor);
-            asset.set_capacity(asset_capacity);
-
-            asset.into()
-        })
-}
-
-/// Get options from existing and potential assets for the given parameters
-#[allow(clippy::too_many_arguments)]
-fn get_asset_options<'a>(
-    time_slice_info: &'a TimeSliceInfo,
-    all_existing_assets: &'a [AssetRef],
-    demand: &'a DemandMap,
-    agent: &'a Agent,
-    commodity: &'a Commodity,
-    region_id: &'a RegionID,
-    year: u32,
-    capacity_limit_factor: Dimensionless,
-) -> impl Iterator<Item = AssetRef> + 'a {
-    // Get existing assets which produce the commodity of interest
-    let existing_assets = all_existing_assets
-        .iter()
-        .filter_agent(&agent.id)
-        .filter_region(region_id)
-        .filter_primary_producers_of(&commodity.id)
-        .cloned();
-
-    // Get candidates assets which produce the commodity of interest
-    let candidate_assets = get_candidate_assets(
-        time_slice_info,
-        demand,
-        agent,
-        region_id,
-        commodity,
-        year,
-        capacity_limit_factor,
-    );
-
-    chain(existing_assets, candidate_assets)
-}
-
 /// Select assets for a single market in a given year
 ///
 /// Returns a list of assets that are selected for investment for this market in this year.
@@ -476,6 +393,89 @@ where
 
         Some((agent, *portion))
     })
+}
+
+/// Get options from existing and potential assets for the given parameters
+#[allow(clippy::too_many_arguments)]
+fn get_asset_options<'a>(
+    time_slice_info: &'a TimeSliceInfo,
+    all_existing_assets: &'a [AssetRef],
+    demand: &'a DemandMap,
+    agent: &'a Agent,
+    commodity: &'a Commodity,
+    region_id: &'a RegionID,
+    year: u32,
+    capacity_limit_factor: Dimensionless,
+) -> impl Iterator<Item = AssetRef> + 'a {
+    // Get existing assets which produce the commodity of interest
+    let existing_assets = all_existing_assets
+        .iter()
+        .filter_agent(&agent.id)
+        .filter_region(region_id)
+        .filter_primary_producers_of(&commodity.id)
+        .cloned();
+
+    // Get candidates assets which produce the commodity of interest
+    let candidate_assets = get_candidate_assets(
+        time_slice_info,
+        demand,
+        agent,
+        region_id,
+        commodity,
+        year,
+        capacity_limit_factor,
+    );
+
+    chain(existing_assets, candidate_assets)
+}
+
+/// Get candidate assets which produce a particular commodity for a given agent
+///
+/// Capacities of candidate assets are set to the demand-limiting capacity for the given market,
+/// scaled by the `capacity_limit_factor`.
+fn get_candidate_assets<'a>(
+    time_slice_info: &'a TimeSliceInfo,
+    demand: &'a DemandMap,
+    agent: &'a Agent,
+    region_id: &'a RegionID,
+    commodity: &'a Commodity,
+    year: u32,
+    capacity_limit_factor: Dimensionless,
+) -> impl Iterator<Item = AssetRef> + 'a {
+    agent
+        .iter_search_space(region_id, &commodity.id, year)
+        .map(move |process| {
+            let mut asset =
+                Asset::new_candidate(process.clone(), region_id.clone(), Capacity(0.0), year)
+                    .unwrap();
+
+            // Set capacity based on demand
+            // This will serve as the upper limit when appraising the asset
+            let capacity = get_demand_limiting_capacity(time_slice_info, &asset, commodity, demand);
+            let asset_capacity = AssetCapacity::from_capacity(capacity, asset.unit_size())
+                .apply_limit_factor(capacity_limit_factor);
+            asset.set_capacity(asset_capacity);
+
+            asset.into()
+        })
+}
+
+/// Investment limits are based on any annual addition limits specified by the process, scaled
+/// according to the agent's portion of the commodity demand and the number of years elapsed since
+/// the previous milestone year.
+pub fn collect_investment_limits_for_candidates(
+    opt_assets: &[AssetRef],
+    commodity_portion: Dimensionless,
+) -> HashMap<AssetRef, AssetCapacity> {
+    opt_assets
+        .iter()
+        .filter(|asset| !asset.is_commissioned())
+        .filter_map(|asset| {
+            asset
+                .max_installable_capacity(commodity_portion)
+                .map(|limit_capacity| (asset.clone(), limit_capacity))
+        })
+        .collect()
 }
 
 #[cfg(test)]

--- a/src/simulation/market.rs
+++ b/src/simulation/market.rs
@@ -30,13 +30,12 @@ type AllDemandMap = IndexMap<(CommodityID, RegionID, TimeSliceID), Flow>;
 /// Represents a set of markets which are invested in together.
 #[derive(PartialEq, Debug, Clone, Eq, Hash)]
 pub enum MarketSet {
-    /// Assets are selected for a single market using `select_assets_for_single_market`
+    /// Assets are selected for a single market using [`select_assets_for_single_market`]
     Single((CommodityID, RegionID)),
     /// Assets are selected for a group of markets which forms a cycle.
-    /// Experimental: handled by `select_assets_for_cycle` and guarded by the broken options
-    /// parameter.
+    /// Experimental: handled by [`select_assets_for_cycle`]. May not work in every case.
     Cycle(Vec<(CommodityID, RegionID)>),
-    /// Assets are selected for a layer of independent `MarketSet`s
+    /// Assets are selected for a layer of independent [`MarketSet`]s
     Layer(Vec<MarketSet>),
 }
 

--- a/src/simulation/market.rs
+++ b/src/simulation/market.rs
@@ -1,0 +1,403 @@
+//! Code for creating sets of markets.
+use super::optimisation::DispatchRun;
+use crate::agent::Agent;
+use crate::asset::{AssetRef, AssetState};
+use crate::commodity::CommodityID;
+use crate::model::Model;
+use crate::output::DataWriter;
+use crate::region::RegionID;
+use crate::simulation::prices::Prices;
+use crate::time_slice::{TimeSliceID, TimeSliceInfo};
+use crate::units::{Dimensionless, Flow};
+use anyhow::{Context, Result};
+use indexmap::IndexMap;
+use itertools::Itertools;
+use log::debug;
+use std::collections::HashMap;
+use std::fmt::Display;
+
+use crate::simulation::investment::{
+    collect_investment_limits_for_candidates, get_asset_options, select_best_assets,
+    update_net_demand_map,
+};
+
+/// A map of demand across time slices for a specific market
+type DemandMap = IndexMap<TimeSliceID, Flow>;
+
+/// Demand for a given combination of commodity, region and time slice
+type AllDemandMap = IndexMap<(CommodityID, RegionID, TimeSliceID), Flow>;
+
+/// Represents a set of markets which are invested in together.
+#[derive(PartialEq, Debug, Clone, Eq, Hash)]
+pub enum InvestmentSet {
+    /// Assets are selected for a single market using `select_assets_for_single_market`
+    Single((CommodityID, RegionID)),
+    /// Assets are selected for a group of markets which forms a cycle.
+    /// Experimental: handled by `select_assets_for_cycle` and guarded by the broken options
+    /// parameter.
+    Cycle(Vec<(CommodityID, RegionID)>),
+    /// Assets are selected for a layer of independent `InvestmentSet`s
+    Layer(Vec<InvestmentSet>),
+}
+
+impl InvestmentSet {
+    /// Recursively iterate over all markets contained in this `InvestmentSet`.
+    pub fn iter_markets<'a>(
+        &'a self,
+    ) -> Box<dyn Iterator<Item = &'a (CommodityID, RegionID)> + 'a> {
+        match self {
+            InvestmentSet::Single(market) => Box::new(std::iter::once(market)),
+            InvestmentSet::Cycle(markets) => Box::new(markets.iter()),
+            InvestmentSet::Layer(set) => Box::new(set.iter().flat_map(|s| s.iter_markets())),
+        }
+    }
+
+    /// Selects assets for this investment set variant and passes through the shared
+    /// context needed by single-market, cycle, or layered selection.
+    ///
+    /// # Arguments
+    ///
+    /// * `model` – Simulation model supplying parameters, processes, and dispatch.
+    /// * `year` – Planning year being solved.
+    /// * `demand` – Net demand profiles available to all markets before selection.
+    /// * `existing_assets` – Assets already commissioned in the system.
+    /// * `prices` – Commodity price assumptions to use when valuing investments.
+    /// * `seen_markets` – Markets for which investments have already been settled.
+    /// * `previously_selected_assets` – Assets chosen in earlier investment sets.
+    /// * `writer` – Data sink used to log optimisation artefacts.
+    #[allow(clippy::too_many_arguments)]
+    pub fn select_assets(
+        &self,
+        model: &Model,
+        year: u32,
+        demand: &AllDemandMap,
+        existing_assets: &[AssetRef],
+        prices: &Prices,
+        seen_markets: &[(CommodityID, RegionID)],
+        previously_selected_assets: &[AssetRef],
+        writer: &mut DataWriter,
+    ) -> Result<Vec<AssetRef>> {
+        match self {
+            InvestmentSet::Single((commodity_id, region_id)) => select_assets_for_single_market(
+                model,
+                commodity_id,
+                region_id,
+                year,
+                demand,
+                existing_assets,
+                prices,
+                writer,
+            ),
+            InvestmentSet::Cycle(markets) => {
+                debug!("Starting investment for cycle '{self}'");
+                select_assets_for_cycle(
+                    model,
+                    markets,
+                    year,
+                    demand,
+                    existing_assets,
+                    prices,
+                    seen_markets,
+                    previously_selected_assets,
+                    writer,
+                )
+                .with_context(|| {
+                    format!(
+                        "Investments failed for market set {self} with cyclical dependencies. \
+                         Please note that the investment algorithm is currently experimental for \
+                         models with circular commodity dependencies and may not be able to find \
+                         a solution in all cases."
+                    )
+                })
+            }
+            InvestmentSet::Layer(investment_sets) => {
+                debug!("Starting asset selection for layer '{self}'");
+                let mut all_assets = Vec::new();
+                for investment_set in investment_sets {
+                    let assets = investment_set.select_assets(
+                        model,
+                        year,
+                        demand,
+                        existing_assets,
+                        prices,
+                        seen_markets,
+                        previously_selected_assets,
+                        writer,
+                    )?;
+                    all_assets.extend(assets);
+                }
+                debug!("Completed asset selection for layer '{self}'");
+                Ok(all_assets)
+            }
+        }
+    }
+}
+
+impl Display for InvestmentSet {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            InvestmentSet::Single((commodity_id, region_id)) => {
+                write!(f, "{commodity_id}|{region_id}")
+            }
+            InvestmentSet::Cycle(markets) => {
+                write!(
+                    f,
+                    "({})",
+                    markets.iter().map(|(c, r)| format!("{c}|{r}")).join(", ")
+                )
+            }
+            InvestmentSet::Layer(ids) => {
+                write!(f, "[{}]", ids.iter().join(", "))
+            }
+        }
+    }
+}
+
+/// Select assets for a single market in a given year
+///
+/// Returns a list of assets that are selected for investment for this market in this year.
+#[allow(clippy::too_many_arguments)]
+fn select_assets_for_single_market(
+    model: &Model,
+    commodity_id: &CommodityID,
+    region_id: &RegionID,
+    year: u32,
+    demand: &AllDemandMap,
+    existing_assets: &[AssetRef],
+    prices: &Prices,
+    writer: &mut DataWriter,
+) -> Result<Vec<AssetRef>> {
+    let commodity = &model.commodities[commodity_id];
+
+    let mut selected_assets = Vec::new();
+    for (agent, commodity_portion) in
+        get_responsible_agents(model.agents.values(), commodity_id, region_id, year)
+    {
+        debug!(
+            "Running asset selection for agent '{}' in market '{}|{}'",
+            &agent.id, commodity_id, region_id
+        );
+
+        // Get demand portion for this market for this agent in this year
+        let demand_portion_for_market = get_demand_portion_for_market(
+            &model.time_slice_info,
+            demand,
+            commodity_id,
+            region_id,
+            commodity_portion,
+        );
+
+        // Existing and candidate assets from which to choose
+        let opt_assets = get_asset_options(
+            &model.time_slice_info,
+            existing_assets,
+            &demand_portion_for_market,
+            agent,
+            commodity,
+            region_id,
+            year,
+            model.parameters.capacity_limit_factor,
+        )
+        .collect::<Vec<_>>();
+
+        // Calculate investment limits for candidate assets
+        let investment_limits =
+            collect_investment_limits_for_candidates(&opt_assets, commodity_portion);
+
+        // Choose assets from among existing pool and candidates
+        let best_assets = select_best_assets(
+            model,
+            opt_assets,
+            investment_limits,
+            commodity,
+            agent,
+            region_id,
+            prices,
+            demand_portion_for_market,
+            year,
+            writer,
+        )?;
+        selected_assets.extend(best_assets);
+    }
+
+    Ok(selected_assets)
+}
+
+/// Iterates through the a pre-ordered set of markets forming a cycle, selecting assets for each
+/// market in turn.
+///
+/// Dispatch optimisation is performed after each market is visited to rebalance demand.
+/// While dispatching, newly selected (`Ready`) assets are given flexible capacity (bounded by
+/// `capacity_margin`) so small demand shifts caused by later markets can be absorbed. After all
+/// markets have been visited once, the final set of assets is returned, applying any capacity
+/// adjustments from the final full-system dispatch optimisation.
+///
+/// Dispatch may fail at any point if new demands are encountered for previously visited markets,
+/// and the `capacity_margin` is not sufficient to absorb the demand shift. At this point, the
+/// simulation is terminated with an error prompting the user to increase the `capacity_margin`.
+/// A longer-term solution (TODO) may be to trigger re-investment for the affected markets. Other
+/// yet-to-implement features may also help to stabilise the cycle, such as capacity growth limits.
+#[allow(clippy::too_many_arguments)]
+fn select_assets_for_cycle(
+    model: &Model,
+    markets: &[(CommodityID, RegionID)],
+    year: u32,
+    demand: &AllDemandMap,
+    existing_assets: &[AssetRef],
+    prices: &Prices,
+    seen_markets: &[(CommodityID, RegionID)],
+    previously_selected_assets: &[AssetRef],
+    writer: &mut DataWriter,
+) -> Result<Vec<AssetRef>> {
+    // Precompute a joined string for logging
+    let markets_str = markets.iter().map(|(c, r)| format!("{c}|{r}")).join(", ");
+
+    // Iterate over the markets to select assets
+    let mut current_demand = demand.clone();
+    let mut assets_for_cycle = IndexMap::new();
+    let mut last_solution = None;
+    for (idx, (commodity_id, region_id)) in markets.iter().enumerate() {
+        // Select assets for this market
+        let assets = select_assets_for_single_market(
+            model,
+            commodity_id,
+            region_id,
+            year,
+            &current_demand,
+            existing_assets,
+            prices,
+            writer,
+        )?;
+        assets_for_cycle.insert((commodity_id.clone(), region_id.clone()), assets);
+
+        // Assemble full list of assets for dispatch (previously selected + all chosen so far)
+        let mut all_assets = previously_selected_assets.to_vec();
+        let assets_for_cycle_flat: Vec<_> = assets_for_cycle
+            .values()
+            .flat_map(|v| v.iter().cloned())
+            .collect();
+        all_assets.extend_from_slice(&assets_for_cycle_flat);
+
+        // We balance all previously seen markets plus all cycle markets up to and including this one
+        let mut markets_to_balance = seen_markets.to_vec();
+        markets_to_balance.extend_from_slice(&markets[0..=idx]);
+
+        // We allow all `Ready` state assets to have flexible capacity
+        let flexible_capacity_assets: Vec<_> = assets_for_cycle_flat
+            .iter()
+            .filter(|asset| matches!(asset.state(), AssetState::Ready { .. }))
+            .cloned()
+            .collect();
+
+        // Retrieve installable capacity limits for flexible capacity assets.
+        let mut agent_share_cache = HashMap::new();
+        let capacity_limits = flexible_capacity_assets
+            .iter()
+            .filter_map(|asset| {
+                let agent_id = asset.agent_id().unwrap();
+                let commodity_id = asset.primary_output_commodity().unwrap();
+                let agent_share = *agent_share_cache
+                    .entry((agent_id, commodity_id))
+                    .or_insert_with(|| {
+                        model.agents[agent_id].commodity_portions[&(commodity_id.clone(), year)]
+                    });
+                asset
+                    .max_installable_capacity(agent_share)
+                    .map(|max_capacity| (asset.clone(), max_capacity))
+            })
+            .collect::<HashMap<_, _>>();
+
+        // Run dispatch
+        let solution = DispatchRun::new(model, &all_assets, year)
+            .with_market_balance_subset(&markets_to_balance)
+            .with_flexible_capacity_assets(
+                &flexible_capacity_assets,
+                Some(&capacity_limits),
+                // Gives newly selected cycle assets limited capacity wiggle-room; existing assets stay fixed.
+                model.parameters.capacity_margin,
+            )
+            .run(
+                &format!("cycle ({markets_str}) post {commodity_id}|{region_id} investment"),
+                writer,
+            )
+            .with_context(|| {
+                format!(
+                    "Cycle balancing failed for cycle ({markets_str}), capacity_margin: {}. \
+                     Try increasing the capacity_margin.",
+                    model.parameters.capacity_margin
+                )
+            })?;
+
+        // Calculate new net demand map with all assets selected so far
+        current_demand.clone_from(demand);
+        update_net_demand_map(
+            &mut current_demand,
+            &solution.create_flow_map(),
+            &assets_for_cycle_flat,
+        );
+        last_solution = Some(solution);
+    }
+
+    // Finally, update flexible capacity assets based on the final solution
+    let mut all_cycle_assets: Vec<_> = assets_for_cycle.into_values().flatten().collect();
+    if let Some(solution) = last_solution {
+        let new_capacities: HashMap<_, _> = solution.iter_capacity().collect();
+        for asset in &mut all_cycle_assets {
+            if let Some(new_capacity) = new_capacities.get(asset) {
+                debug!(
+                    "Capacity of asset '{}' modified during cycle balancing ({} to {})",
+                    asset.process_id(),
+                    asset.total_capacity(),
+                    new_capacity.total_capacity()
+                );
+                asset.make_mut().set_capacity(*new_capacity);
+            }
+        }
+    }
+
+    Ok(all_cycle_assets)
+}
+
+fn get_demand_portion_for_market(
+    time_slice_info: &TimeSliceInfo,
+    demand: &AllDemandMap,
+    commodity_id: &CommodityID,
+    region_id: &RegionID,
+    commodity_portion: Dimensionless,
+) -> DemandMap {
+    time_slice_info
+        .iter_ids()
+        .map(|time_slice| {
+            (
+                time_slice.clone(),
+                commodity_portion
+                    * *demand
+                        .get(&(commodity_id.clone(), region_id.clone(), time_slice.clone()))
+                        .unwrap_or(&Flow(0.0)),
+            )
+        })
+        .collect()
+}
+
+/// Get the agents responsible for a given market in a given year along with the commodity
+/// portion for which they are responsible
+fn get_responsible_agents<'a, I>(
+    agents: I,
+    commodity_id: &'a CommodityID,
+    region_id: &'a RegionID,
+    year: u32,
+) -> impl Iterator<Item = (&'a Agent, Dimensionless)>
+where
+    I: Iterator<Item = &'a Agent>,
+{
+    agents.filter_map(move |agent| {
+        if !agent.regions.contains(region_id) {
+            return None;
+        }
+        let portion = agent
+            .commodity_portions
+            .get(&(commodity_id.clone(), year))?;
+
+        Some((agent, *portion))
+    })
+}

--- a/src/simulation/market.rs
+++ b/src/simulation/market.rs
@@ -29,26 +29,26 @@ type AllDemandMap = IndexMap<(CommodityID, RegionID, TimeSliceID), Flow>;
 
 /// Represents a set of markets which are invested in together.
 #[derive(PartialEq, Debug, Clone, Eq, Hash)]
-pub enum InvestmentSet {
+pub enum MarketSet {
     /// Assets are selected for a single market using `select_assets_for_single_market`
     Single((CommodityID, RegionID)),
     /// Assets are selected for a group of markets which forms a cycle.
     /// Experimental: handled by `select_assets_for_cycle` and guarded by the broken options
     /// parameter.
     Cycle(Vec<(CommodityID, RegionID)>),
-    /// Assets are selected for a layer of independent `InvestmentSet`s
-    Layer(Vec<InvestmentSet>),
+    /// Assets are selected for a layer of independent `MarketSet`s
+    Layer(Vec<MarketSet>),
 }
 
-impl InvestmentSet {
-    /// Recursively iterate over all markets contained in this `InvestmentSet`.
+impl MarketSet {
+    /// Recursively iterate over all markets contained in this `MarketSet`.
     pub fn iter_markets<'a>(
         &'a self,
     ) -> Box<dyn Iterator<Item = &'a (CommodityID, RegionID)> + 'a> {
         match self {
-            InvestmentSet::Single(market) => Box::new(std::iter::once(market)),
-            InvestmentSet::Cycle(markets) => Box::new(markets.iter()),
-            InvestmentSet::Layer(set) => Box::new(set.iter().flat_map(|s| s.iter_markets())),
+            MarketSet::Single(market) => Box::new(std::iter::once(market)),
+            MarketSet::Cycle(markets) => Box::new(markets.iter()),
+            MarketSet::Layer(set) => Box::new(set.iter().flat_map(|s| s.iter_markets())),
         }
     }
 
@@ -78,7 +78,7 @@ impl InvestmentSet {
         writer: &mut DataWriter,
     ) -> Result<Vec<AssetRef>> {
         match self {
-            InvestmentSet::Single((commodity_id, region_id)) => select_assets_for_single_market(
+            MarketSet::Single((commodity_id, region_id)) => select_assets_for_single_market(
                 model,
                 commodity_id,
                 region_id,
@@ -88,7 +88,7 @@ impl InvestmentSet {
                 prices,
                 writer,
             ),
-            InvestmentSet::Cycle(markets) => {
+            MarketSet::Cycle(markets) => {
                 debug!("Starting investment for cycle '{self}'");
                 select_assets_for_cycle(
                     model,
@@ -110,7 +110,7 @@ impl InvestmentSet {
                     )
                 })
             }
-            InvestmentSet::Layer(investment_sets) => {
+            MarketSet::Layer(investment_sets) => {
                 debug!("Starting asset selection for layer '{self}'");
                 let mut all_assets = Vec::new();
                 for investment_set in investment_sets {
@@ -133,20 +133,20 @@ impl InvestmentSet {
     }
 }
 
-impl Display for InvestmentSet {
+impl Display for MarketSet {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            InvestmentSet::Single((commodity_id, region_id)) => {
+            MarketSet::Single((commodity_id, region_id)) => {
                 write!(f, "{commodity_id}|{region_id}")
             }
-            InvestmentSet::Cycle(markets) => {
+            MarketSet::Cycle(markets) => {
                 write!(
                     f,
                     "({})",
                     markets.iter().map(|(c, r)| format!("{c}|{r}")).join(", ")
                 )
             }
-            InvestmentSet::Layer(ids) => {
+            MarketSet::Layer(ids) => {
                 write!(f, "[{}]", ids.iter().join(", "))
             }
         }

--- a/src/simulation/market.rs
+++ b/src/simulation/market.rs
@@ -44,7 +44,7 @@ impl MarketSet {
         }
     }
 
-    /// Selects assets for this investment set variant and passes through the shared
+    /// Selects assets for this market set variant and passes through the shared
     /// context needed by single-market, cycle, or layered selection.
     ///
     /// # Arguments
@@ -55,7 +55,7 @@ impl MarketSet {
     /// * `existing_assets` – Assets already commissioned in the system.
     /// * `prices` – Commodity price assumptions to use when valuing investments.
     /// * `seen_markets` – Markets for which investments have already been settled.
-    /// * `previously_selected_assets` – Assets chosen in earlier investment sets.
+    /// * `previously_selected_assets` – Assets chosen in earlier market sets.
     /// * `writer` – Data sink used to log optimisation artefacts.
     #[allow(clippy::too_many_arguments)]
     pub fn select_assets(

--- a/src/simulation/prices.rs
+++ b/src/simulation/prices.rs
@@ -96,10 +96,10 @@ pub fn calculate_prices(
     // Lazily computed only if at least one FullCost market is encountered.
     let mut annual_activities: Option<HashMap<AssetRef, Activity>> = None;
 
-    // Iterate over investment sets in reverse order
-    for investment_set in model.investment_order[&year].iter().rev() {
-        price_investment_set(
-            investment_set,
+    // Iterate over market sets in reverse order
+    for market_set in model.investment_order[&year].iter().rev() {
+        price_market_set(
+            market_set,
             model,
             solution_without_candidates,
             solution_with_candidates,
@@ -116,10 +116,10 @@ pub fn calculate_prices(
     })
 }
 
-/// Calculate prices for the markets in an investment set, updating `market_prices`.
+/// Calculate prices for the markets in an market set, updating `market_prices`.
 #[allow(clippy::too_many_arguments)]
-fn price_investment_set(
-    investment_set: &MarketSet,
+fn price_market_set(
+    market_set: &MarketSet,
     model: &Model,
     solution_without_candidates: &Solution,
     solution_with_candidates: &Solution,
@@ -128,7 +128,7 @@ fn price_investment_set(
     annual_activities: &mut Option<HashMap<AssetRef, Activity>>,
     market_prices: &mut PriceMap,
 ) {
-    match investment_set {
+    match market_set {
         MarketSet::Single(market) => {
             price_markets(
                 model,
@@ -153,9 +153,9 @@ fn price_investment_set(
                 market_prices,
             );
         }
-        MarketSet::Layer(investment_sets) => {
-            for set in investment_sets {
-                price_investment_set(
+        MarketSet::Layer(market_sets) => {
+            for set in market_sets {
+                price_market_set(
                     set,
                     model,
                     solution_without_candidates,

--- a/src/simulation/prices.rs
+++ b/src/simulation/prices.rs
@@ -5,7 +5,7 @@ use crate::asset::AssetRef;
 use crate::commodity::{CommodityID, CommodityMap, PricingStrategy};
 use crate::model::Model;
 use crate::region::RegionID;
-use crate::simulation::investment::InvestmentSet;
+use crate::simulation::market::InvestmentSet;
 use crate::simulation::optimisation::Solution;
 use crate::time_slice::{TimeSliceID, TimeSliceInfo, TimeSliceSelection};
 use crate::units::{Activity, Dimensionless, Flow, MoneyPerActivity, MoneyPerFlow, UnitType, Year};

--- a/src/simulation/prices.rs
+++ b/src/simulation/prices.rs
@@ -5,7 +5,7 @@ use crate::asset::AssetRef;
 use crate::commodity::{CommodityID, CommodityMap, PricingStrategy};
 use crate::model::Model;
 use crate::region::RegionID;
-use crate::simulation::market::InvestmentSet;
+use crate::simulation::market::MarketSet;
 use crate::simulation::optimisation::Solution;
 use crate::time_slice::{TimeSliceID, TimeSliceInfo, TimeSliceSelection};
 use crate::units::{Activity, Dimensionless, Flow, MoneyPerActivity, MoneyPerFlow, UnitType, Year};
@@ -119,7 +119,7 @@ pub fn calculate_prices(
 /// Calculate prices for the markets in an investment set, updating `market_prices`.
 #[allow(clippy::too_many_arguments)]
 fn price_investment_set(
-    investment_set: &InvestmentSet,
+    investment_set: &MarketSet,
     model: &Model,
     solution_without_candidates: &Solution,
     solution_with_candidates: &Solution,
@@ -129,7 +129,7 @@ fn price_investment_set(
     market_prices: &mut PriceMap,
 ) {
     match investment_set {
-        InvestmentSet::Single(market) => {
+        MarketSet::Single(market) => {
             price_markets(
                 model,
                 solution_without_candidates,
@@ -141,7 +141,7 @@ fn price_investment_set(
                 market_prices,
             );
         }
-        InvestmentSet::Cycle(markets) => {
+        MarketSet::Cycle(markets) => {
             price_cycle(
                 model,
                 solution_without_candidates,
@@ -153,7 +153,7 @@ fn price_investment_set(
                 market_prices,
             );
         }
-        InvestmentSet::Layer(investment_sets) => {
+        MarketSet::Layer(investment_sets) => {
             for set in investment_sets {
                 price_investment_set(
                     set,


### PR DESCRIPTION
# Description

This PR:

1. Moves `InvestmentSet` and associated functions out of the `investment` module into a new `market` module (with some (un)educated guesses at which functions should be moved, and which functions should remain but be made public))
2. Renames `InvestmentSet` to `MarketSet`
3. Updates `graph::investment` to reflect these changes (also with some guesswork at which terminology should be updated)


Fixes #1337

## Type of change

- [ ] Bug fix (non-breaking change to fix an issue)
- [ ] New feature (non-breaking change to add functionality)
- [x] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [X] All tests pass: `$ cargo test`
- [X] The documentation builds and looks OK: `$ cargo doc`
- [ ] Update release notes for the latest release if this PR adds a new feature or fixes a bug
      present in the previous release

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
