### PR TITLE
Improve error messages when deserialising enums

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -940,7 +940,6 @@ dependencies = [
  "strum 0.28.0",
  "tempfile",
  "toml",
- "unicase",
  "yaml-rust2",
 ]
 
@@ -1574,12 +1573,6 @@ name = "typeid"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
-
-[[package]]
-name = "unicase"
-version = "2.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-ident"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -936,7 +936,6 @@ dependencies = [
  "platform-info",
  "rstest",
  "serde",
- "serde_string_enum",
  "similar",
  "strum 0.28.0",
  "tempfile",
@@ -1373,19 +1372,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
-]
-
-[[package]]
-name = "serde_string_enum"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc057e156c7ee0eecf104019415e2089fe55f4e8fc92d49059bcb22548b97028"
-dependencies = [
- "proc-macro2",
- "quote",
- "serde",
- "syn",
- "unicase",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,6 @@ itertools = "0.15.0"
 serde = {version = "1.0.228", features = ["derive", "rc"]}
 tempfile = "3.27.0"
 toml = "1.1.2"
-unicase = "2.9.0"
 fern = {version = "0.7.1", features = ["chrono", "colored"]}
 chrono = "0.4"
 clap = {version = "4.6.1", features = ["cargo", "derive"]}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,6 @@ log = "0.4.32"
 float-cmp = "0.10.0"
 itertools = "0.15.0"
 serde = {version = "1.0.228", features = ["derive", "rc"]}
-serde_string_enum = "0.2.1"
 tempfile = "3.27.0"
 toml = "1.1.2"
 unicase = "2.9.0"

--- a/docs/release_notes/upcoming.md
+++ b/docs/release_notes/upcoming.md
@@ -24,6 +24,9 @@ ready to be released, carry out the following steps:
 - Changed the default `pricing_strategy` for SED/SVD commodities from "shadow" to "full_average" ([#1281])
 - The `agent_search_space.csv` input file has been renamed to `agent_search_spaces.csv` for
   consistency ([#1293])
+- Due to an internal change, some options in CSV files are now case sensitive (e.g. you must put
+  `lcox` rather than `LCOX`). The error message you see if it does not match will now be more
+  informative, however. ([#1376])
 
 ## Bug fixes
 
@@ -39,3 +42,4 @@ ready to be released, carry out the following steps:
 [#1293]: https://github.com/EnergySystemsModellingLab/MUSE2/pull/1293
 [#1319]: https://github.com/EnergySystemsModellingLab/MUSE2/pull/1319
 [#1349]: https://github.com/EnergySystemsModellingLab/MUSE2/pull/1349
+[#1376]: https://github.com/EnergySystemsModellingLab/MUSE2/pull/1376

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -6,7 +6,7 @@ use crate::process::Process;
 use crate::region::RegionID;
 use crate::units::Dimensionless;
 use indexmap::{IndexMap, IndexSet};
-use serde_string_enum::DeserializeLabeledStringEnum;
+use serde::Deserialize;
 use std::collections::HashMap;
 use std::rc::Rc;
 
@@ -79,12 +79,12 @@ pub enum DecisionRule {
 }
 
 /// The type of objective for the agent
-#[derive(Debug, Clone, Copy, PartialEq, DeserializeLabeledStringEnum)]
+#[derive(Debug, Clone, Copy, PartialEq, Deserialize)]
 pub enum ObjectiveType {
     /// Average cost of one unit of output commodity over its lifetime
-    #[string = "lcox"]
+    #[serde(rename = "lcox")]
     LevelisedCostOfX,
     /// Net present value
-    #[string = "npv"]
+    #[serde(rename = "npv")]
     NetPresentValue,
 }

--- a/src/commodity.rs
+++ b/src/commodity.rs
@@ -5,7 +5,6 @@ use crate::time_slice::{TimeSliceID, TimeSliceLevel, TimeSliceSelection};
 use crate::units::{Flow, MoneyPerFlow};
 use indexmap::IndexMap;
 use serde::Deserialize;
-use serde_string_enum::DeserializeLabeledStringEnum;
 use std::collections::HashMap;
 use std::rc::Rc;
 
@@ -61,32 +60,32 @@ pub struct Commodity {
 define_id_getter! {Commodity, CommodityID}
 
 /// Type of balance for application of cost
-#[derive(Eq, PartialEq, Clone, Debug, DeserializeLabeledStringEnum, Hash)]
+#[derive(Eq, PartialEq, Clone, Debug, Deserialize, Hash)]
 pub enum BalanceType {
     /// Applies to production, with an equal and opposite levy/incentive on consumption
-    #[string = "net"]
+    #[serde(rename = "net")]
     Net,
     /// Applies to consumption only
-    #[string = "cons"]
+    #[serde(rename = "cons")]
     Consumption,
     /// Applies to production only
-    #[string = "prod"]
+    #[serde(rename = "prod")]
     Production,
 }
 
 /// Commodity balance type
-#[derive(PartialEq, Debug, DeserializeLabeledStringEnum, Clone)]
+#[derive(PartialEq, Debug, Deserialize, Clone)]
 pub enum CommodityType {
     /// Supply and demand of this commodity must be balanced
-    #[string = "sed"]
+    #[serde(rename = "sed")]
     SupplyEqualsDemand,
     /// Specifies a demand (specified in input files) which must be met by the simulation
-    #[string = "svd"]
+    #[serde(rename = "svd")]
     ServiceDemand,
     /// Either an input or an output to the simulation.
     ///
     /// This represents a commodity which can either be produced or consumed, but not both.
-    #[string = "oth"]
+    #[serde(rename = "oth")]
     Other,
 }
 

--- a/src/process.rs
+++ b/src/process.rs
@@ -11,7 +11,7 @@ use crate::units::{
 use anyhow::{Result, ensure};
 use indexmap::{IndexMap, IndexSet};
 use itertools::Itertools;
-use serde_string_enum::DeserializeLabeledStringEnum;
+use serde::Deserialize;
 use std::collections::HashMap;
 use std::ops::RangeInclusive;
 use std::rc::Rc;
@@ -458,15 +458,15 @@ impl ProcessFlow {
 }
 
 /// Type of commodity flow (see [`ProcessFlow`])
-#[derive(PartialEq, Default, Debug, Clone, DeserializeLabeledStringEnum)]
+#[derive(PartialEq, Default, Debug, Clone, Deserialize)]
 pub enum FlowType {
     /// The input to output flow ratio is fixed
     #[default]
-    #[string = "fixed"]
+    #[serde(rename = "fixed")]
     Fixed,
     /// The flow ratio can vary, subject to overall flow of a specified group of commodities whose
     /// input/output ratio must be as per user input data
-    #[string = "flexible"]
+    #[serde(rename = "flexible")]
     Flexible,
 }
 

--- a/src/time_slice.rs
+++ b/src/time_slice.rs
@@ -9,7 +9,6 @@ use indexmap::{IndexMap, IndexSet};
 use itertools::Itertools;
 use serde::de::Error;
 use serde::{Deserialize, Serialize};
-use serde_string_enum::DeserializeLabeledStringEnum;
 use std::iter;
 
 define_id_type! {Season, "season"}
@@ -191,26 +190,16 @@ impl TimeSliceSelection {
 }
 
 /// The time granularity for a particular operation
-#[derive(
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Copy,
-    Clone,
-    Debug,
-    DeserializeLabeledStringEnum,
-    strum::EnumIter,
-)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Copy, Clone, Debug, Deserialize, strum::EnumIter)]
 pub enum TimeSliceLevel {
     /// Treat individual time slices separately
-    #[string = "daynight"]
+    #[serde(rename = "daynight")]
     DayNight,
     /// Whole seasons
-    #[string = "season"]
+    #[serde(rename = "season")]
     Season,
     /// The whole year
-    #[string = "annual"]
+    #[serde(rename = "annual")]
     Annual,
 }
 


### PR DESCRIPTION
# Description

The error messages you get when deserialising an enum fails are currently not very informative, e.g.:

```
[12:10:54 ERROR muse2] Failed to load model.

Caused by:
    0: Error reading /tmp/.tmpohiso5/simple/agent_objectives.csv
    1: CSV deserialize error: record 1 (line: 2, byte: 68): invalid value: string "lcoe", expected a valid ObjectiveType string value
```

We use the [`serde_string_enum`](https://crates.io/crates/serde_string_enum) crate for performing this deserialisation, but it turns out you can just use vanilla `serde` to do basically the same thing, by annotating enum variants with `#[serde(rename = ...`, e.g.:

```rs
/// The type of objective for the agent
#[derive(Debug, Clone, Copy, PartialEq, Deserialize)]
pub enum ObjectiveType {
    /// Average cost of one unit of output commodity over its lifetime
    #[serde(rename = "lcox")]
    LevelisedCostOfX,
    /// Net present value
    #[serde(rename = "npv")]
    NetPresentValue,
}
```

And you get much nicer error messages!

```
[12:14:35 ERROR muse2] Failed to load model.

Caused by:
    0: Error reading /tmp/.tmp5QWJ5M/simple/agent_objectives.csv
    1: CSV deserialize error: record 1 (line: 2, byte: 68): unknown variant `lcoe`, expected `lcox` or `npv`
```

There is **one** downside to this alternative approach, namely that it doesn't match the string in a case insensitve manner, so where `LCOX` would have matched before, now only `lcox` will match. If this does happen though, at least the user will get an informative message about it :smile:. You can add other variants that are accepted, so we could accept both `lcox` and `LCOX` (`Lcox` would still be rejected), but I'm not sure it's worth it.

I first introduced the `serde_string_enum` dependency in #105 and didn't mention the case-insensitive thing there, so it presumably wasn't a big consideration (incidentally, it hasn't been updated since).

I think the trade-off is worth it for better error messages. We can also drop two dependencies this way, which is also nice.

Closes #848.

## Type of change

- [ ] Bug fix (non-breaking change to fix an issue)
- [ ] New feature (non-breaking change to add functionality)
- [x] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [x] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [x] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`
- [ ] Update release notes for the latest release if this PR adds a new feature or fixes a bug
      present in the previous release

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
