### PR TITLE
Fix link not rendered properly

### DIFF
--- a/schemas/input/model.yaml
+++ b/schemas/input/model.yaml
@@ -64,9 +64,7 @@ properties:
     description: |
       Used for setting custom HiGHS options. As this is unsafe, it requires setting
       `please_give_me_broken_results` to true. For more information, see the relevant [section of
-      the developer documentation][highs-opts-docs].
-
-      [highs-opts-docs]: https://energysystemsmodellinglab.github.io/MUSE2/developer_guide/custom_highs_options.html
+      the developer documentation](https://energysystemsmodellinglab.github.io/MUSE2/developer_guide/custom_highs_options.html).
     properties:
       global_options:
         type: object


### PR DESCRIPTION
# Description

Two things were happening:

- first, for the reusable links in markdown to work, the target link must be in the top level of the document, and not within a table or list, as it was the case.
- second, even if that were not the case, the format of the link was wrong.

With the fixes above, now the link seems to render properly:

<img width="800" height="224" alt="image" src="https://github.com/user-attachments/assets/6015b141-76ab-476e-b885-473ebb877565" />

Fixes #1400

## Type of change

- [ ] Bug fix (non-breaking change to fix an issue)
- [ ] New feature (non-breaking change to add functionality)
- [ ] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [x] Documentation (improve or add documentation)

## Key checklist

- [x] All tests pass: `$ cargo test`
- [x] The documentation builds and looks OK: `$ cargo doc`
- [x] Update release notes for the latest release if this PR adds a new feature or fixes a bug
      present in the previous release

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
