### PR TITLE
Revert "Fix link not rendered properly"

### DIFF
--- a/schemas/input/model.yaml
+++ b/schemas/input/model.yaml
@@ -64,7 +64,9 @@ properties:
     description: |
       Used for setting custom HiGHS options. As this is unsafe, it requires setting
       `please_give_me_broken_results` to true. For more information, see the relevant [section of
-      the developer documentation](https://energysystemsmodellinglab.github.io/MUSE2/developer_guide/custom_highs_options.html).
+      the developer documentation][highs-opts-docs].
+
+      [highs-opts-docs]: https://energysystemsmodellinglab.github.io/MUSE2/developer_guide/custom_highs_options.html
     properties:
       global_options:
         type: object


### PR DESCRIPTION
Reverts EnergySystemsModellingLab/MUSE2#1404, as the change is better implemented in https://github.com/EnergySystemsModellingLab/MUSE2/pull/1366