### PR TITLE
Fix cargo lock updater workflow

### DIFF
--- a/.github/workflows/cargo-update.yml
+++ b/.github/workflows/cargo-update.yml
@@ -29,6 +29,7 @@ jobs:
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Create a branch for the update
+        id: branch-creator
         run: |
           git switch --force-create update-cargo-lock
           git add Cargo.lock
@@ -38,7 +39,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Open a pull request
-        if: steps.checker.outputs.success != 'true'
+        if: steps.branch-creator.outputs.success != 'true'
         uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.GH_TOKEN_FOR_UPDATES }}

--- a/.github/workflows/cargo-update.yml
+++ b/.github/workflows/cargo-update.yml
@@ -39,7 +39,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Open a pull request
-        if: steps.branch-creator.outputs.success != 'true'
+        if: steps.branch-creator.outputs.success != 'false'
         uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.GH_TOKEN_FOR_UPDATES }}


### PR DESCRIPTION
# Description

This PR fixes the workflow to update Cargo.lock weekly. At present, the workflow creates a new branch with an updated Cargo.lock, but doesn't create a PR for that branch.

- This PR creation step uses a variable from the branch creation step, and this variable was not being accessed correctly since that step did not have an `id`. 
- That step now _does_ have an `id`, which is now referenced to obtain the success/fail outcome of branch creation.
- The PR creation was set to run if `success != true`, but it is now set to run if `success != false` (i.e. `success == true`).

Fixes #1380 

## Type of change

- [X] Bug fix (non-breaking change to fix an issue)
- [ ] New feature (non-breaking change to add functionality)
- [ ] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [ ] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`
- [ ] Update release notes for the latest release if this PR adds a new feature or fixes a bug
      present in the previous release

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
