### PR TITLE
Fix clippy errors

### DIFF
--- a/src/asset.rs
+++ b/src/asset.rs
@@ -260,7 +260,7 @@ impl Asset {
                 format!(
                     "No process availabilities supplied for process {} in region {} in year {}. \
                     You should update process_availabilities.csv.",
-                    &process.id, region_id, commission_year
+                    process.id, region_id, commission_year
                 )
             })?
             .clone();
@@ -271,7 +271,7 @@ impl Asset {
                 format!(
                     "No commodity flows supplied for process {} in region {} in year {}. \
                     You should update process_flows.csv.",
-                    &process.id, region_id, commission_year
+                    process.id, region_id, commission_year
                 )
             })?
             .clone();
@@ -282,7 +282,7 @@ impl Asset {
                 format!(
                     "No process parameters supplied for process {} in region {} in year {}. \
                     You should update process_parameters.csv.",
-                    &process.id, region_id, commission_year
+                    process.id, region_id, commission_year
                 )
             })?
             .clone();

--- a/src/asset/capacity.rs
+++ b/src/asset/capacity.rs
@@ -291,7 +291,7 @@ mod tests {
         #[case] right: AssetCapacity,
     ) {
         assert_eq!(left.partial_cmp(&right), None);
-        assert!(left != right);
+        assert_ne!(left, right);
     }
 
     #[rstest]

--- a/src/input/agent/search_space.rs
+++ b/src/input/agent/search_space.rs
@@ -118,7 +118,7 @@ where
                             producers.iter().any(|producer| producer.id == process.id),
                             "Process '{}' does not produce commodity '{commodity_id}' in region \
                             '{region_id}' in year {year}",
-                            &process.id
+                            process.id
                         );
                     }
 

--- a/src/input/process/availability.rs
+++ b/src/input/process/availability.rs
@@ -35,7 +35,7 @@ impl ProcessAvailabilityRaw {
     fn to_bounds(&self, length: Year) -> Result<RangeInclusive<Dimensionless>> {
         // Parse availability_range string
         let availability_range = parse_range(&self.limits, Dimensionless(0.0)..=Dimensionless(1.0))
-            .with_context(|| format!("Could not parse availabilities range: {}", &self.limits))?;
+            .with_context(|| format!("Could not parse availabilities range: {}", self.limits))?;
 
         // Convert to bounds based on fraction of the year covered
         let ts_frac = length / Year(1.0);

--- a/src/process.rs
+++ b/src/process.rs
@@ -1021,9 +1021,9 @@ mod tests {
             cost: MoneyPerFlow(0.0),
         };
 
-        assert!(flow_in.direction() == FlowDirection::Input);
-        assert!(flow_out.direction() == FlowDirection::Output);
-        assert!(flow_zero.direction() == FlowDirection::Zero);
+        assert_eq!(flow_in.direction(), FlowDirection::Input);
+        assert_eq!(flow_out.direction(), FlowDirection::Output);
+        assert_eq!(flow_zero.direction(), FlowDirection::Zero);
     }
 
     #[rstest]

--- a/src/simulation/investment.rs
+++ b/src/simulation/investment.rs
@@ -348,7 +348,7 @@ pub fn select_best_assets(
             !opt_assets.is_empty(),
             "Failed to meet demand for commodity '{}' in region '{}' with provided investment \
             options. This may be due to overly restrictive process investment constraints.",
-            &commodity.id,
+            commodity.id,
             region_id
         );
 
@@ -406,7 +406,7 @@ pub fn select_best_assets(
         // Save appraisal results
         writer.write_appraisal_debug_info(
             year,
-            &format!("{} {} round {}", &commodity.id, &agent.id, round),
+            &format!("{} {} round {}", commodity.id, agent.id, round),
             &outputs_for_opts,
             &demand,
         )?;
@@ -422,7 +422,7 @@ pub fn select_best_assets(
                 "Investment appraisal completed with unmet demand for commodity '{}', region '{}', \
                 year '{}', agent '{}'. {} non-feasible investments were not considered. \
                 This unmet demand may still be satisfied during the full system dispatch.",
-                &commodity.id, region_id, year, agent.id, num_nonfeasible
+                commodity.id, region_id, year, agent.id, num_nonfeasible
             );
             break;
         }
@@ -435,8 +435,8 @@ pub fn select_best_assets(
         // Log the selected asset
         debug!(
             "Selected {} asset '{}' (capacity: {})",
-            &best_output.asset.state(),
-            &best_output.asset.process_id(),
+            best_output.asset.state(),
+            best_output.asset.process_id(),
             best_output.asset.capacity().total_capacity()
         );
 

--- a/src/simulation/investment/appraisal.rs
+++ b/src/simulation/investment/appraisal.rs
@@ -653,9 +653,9 @@ mod tests {
 
         // Commissioned assets should be prioritised first
         assert!(outputs[0].asset.is_commissioned());
-        assert!(outputs[0].asset.commission_year() == 2020);
+        assert_eq!(outputs[0].asset.commission_year(), 2020);
         assert!(outputs[1].asset.is_commissioned());
-        assert!(outputs[1].asset.commission_year() == 2015);
+        assert_eq!(outputs[1].asset.commission_year(), 2015);
 
         // Non-commissioned assets should come after
         assert!(!outputs[2].asset.is_commissioned());

--- a/src/simulation/market.rs
+++ b/src/simulation/market.rs
@@ -168,7 +168,7 @@ pub fn select_assets_for_single_market(
     {
         debug!(
             "Running asset selection for agent '{}' in market '{}|{}'",
-            &agent.id, commodity_id, region_id
+            agent.id, commodity_id, region_id
         );
 
         // Get demand portion for this market for this agent in this year

--- a/tests/regression.rs
+++ b/tests/regression.rs
@@ -81,7 +81,7 @@ fn compare_output_dirs(cur_output_dir1: &Path, test_data_dir: &Path, debug_model
     let file_names2 = get_csv_file_names(test_data_dir);
 
     // Check that output files haven't been added/removed
-    assert!(file_names1 == file_names2);
+    assert_eq!(file_names1, file_names2);
 
     let mut errors = Vec::new();
     for file_name in file_names1 {


### PR DESCRIPTION
# Description

There are a few clippy errors after updating the rust toolchain in #1410. Each had a suggested change, so I've just gone through and done what it's suggested. Specifically:
- removing some unnecessary `&`s
- using the `assert_eq!` and `assert_ne!` macros

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change to fix an issue)
- [ ] New feature (non-breaking change to add functionality)
- [ ] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [ ] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`
- [ ] Update release notes for the latest release if this PR adds a new feature or fixes a bug
      present in the previous release

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
