### PR TITLE
Enable capacity growth constraints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1623,9 +1623,9 @@ dependencies = [
 
 [[package]]
 name = "value-bag"
-version = "1.13.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dd4ec1eb1d240636e354a30110a1dfcb37047169a4d9bd6d9d3469df574b5c4"
+checksum = "ef73bfbaf3216cb59c205d7176bee1194e0d84348979da31f4a71fefe3c2054e"
 
 [[package]]
 name = "vcpkg"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -877,6 +877,19 @@ name = "log"
 version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+dependencies = [
+ "value-bag",
+]
+
+[[package]]
+name = "logtest"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb3e43a8657c1d64516dcc9db8ca03826a4aceaf89d5ce1b37b59f6ff0e43026"
+dependencies = [
+ "lazy_static",
+ "log",
+]
 
 [[package]]
 name = "map-macro"
@@ -930,6 +943,7 @@ dependencies = [
  "indexmap",
  "itertools 0.15.0",
  "log",
+ "logtest",
  "map-macro",
  "ordered-float",
  "petgraph",
@@ -1606,6 +1620,12 @@ checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
 dependencies = [
  "getrandom 0.4.2",
 ]
+
+[[package]]
+name = "value-bag"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dd4ec1eb1d240636e354a30110a1dfcb37047169a4d9bd6d9d3469df574b5c4"
 
 [[package]]
 name = "vcpkg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ documented = "0.9.2"
 dirs = "6.0.0"
 edit = "0.1.5"
 erased-serde = "0.4.10"
+logtest = "2.0.0"
 
 [dev-dependencies]
 assert_cmd = "2.2.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,11 +36,11 @@ documented = "0.9.2"
 dirs = "6.0.0"
 edit = "0.1.5"
 erased-serde = "0.4.10"
-logtest = "2.0.0"
 
 [dev-dependencies]
 assert_cmd = "2.2.2"
 colored = "3.0.0"
+logtest = "2.0.0"
 map-macro = "0.3.0"
 ordered-float = "5.1.0"
 rstest = {version = "0.26.1", default-features = false, features = ["crate-name"]}

--- a/examples/muse1_default/process_investment_constraints.csv
+++ b/examples/muse1_default/process_investment_constraints.csv
@@ -1,6 +1,6 @@
-process_id,regions,commission_years,addition_limit,total_capacity_limit
-gassupply1,R1,all,10,100
-gasCCGT,R1,all,10,100
-windturbine,R1,all,10,100
-gasboiler,R1,all,10,100
-heatpump,R1,all,10,100
+process_id,regions,commission_years,addition_limit,capacity_growth_limit,total_capacity_limit
+gassupply1,R1,all,10,0.5,100
+gasCCGT,R1,all,10,0.5,100
+windturbine,R1,all,10,0.5,100
+gasboiler,R1,all,10,0.5,100
+heatpump,R1,all,10,0.5,100

--- a/schemas/input/process_investment_constraints.yaml
+++ b/schemas/input/process_investment_constraints.yaml
@@ -26,6 +26,12 @@ fields:
     notes: |
       The addition limit is allocated evenly between all agents using their proportion of the
       process's primary commodity demand.
+  - name: capacity_growth_limit
+    type: number
+    description: |
+      The constraint on fractional growth per year, based on the available stock in a year, per
+      region and technology. E.g 0.1 -> max 10% growth allowed.
+    notes: This is currently unused.
   - name: total_capacity_limit
     type: number
     description: The hard upper limit on the amount agents can invest in the process

--- a/schemas/input/process_investment_constraints.yaml
+++ b/schemas/input/process_investment_constraints.yaml
@@ -32,6 +32,12 @@ fields:
       The constraint on fractional growth per year, based on the available stock in a year, per
       region and technology. E.g 0.1 -> max 10% growth allowed.
     notes: This is currently unused.
+  - name: growth_seed
+    type: number
+    description: |
+      A parameter to scale the initial capacity value used in the capacity growth calculation,
+      allowing growth to initiate when capacity is low/zero. Defaults to 1 if unspecified.
+    notes: This is currently unused.
   - name: total_capacity_limit
     type: number
     description: The hard upper limit on the amount agents can invest in the process

--- a/src/input/process/investment_constraints.rs
+++ b/src/input/process/investment_constraints.rs
@@ -26,6 +26,7 @@ struct ProcessInvestmentConstraintRaw {
     commission_years: String,
     addition_limit: CapacityPerYear,
     capacity_growth_limit: Option<Dimensionless>,
+    growth_seed: Option<Dimensionless>,
     total_capacity_limit: Option<Capacity>,
 }
 
@@ -54,6 +55,15 @@ impl ProcessInvestmentConstraintRaw {
                     limit * Dimensionless(100.0)
                 );
             }
+        }
+
+        // Validate growth seed: must be in range [1, inf)
+        if let Some(growth_seed) = self.growth_seed {
+            ensure!(
+                growth_seed.is_finite() && growth_seed >= Dimensionless(1.0),
+                "Invalid value for growth seed: '{growth_seed}'; must be greater than or equal to \
+                 1, and finite.",
+            );
         }
 
         // Validate total_capacity_limit: must be in range [0, inf)
@@ -187,6 +197,7 @@ mod tests {
     fn validate_raw_constraint(
         addition_limit: CapacityPerYear,
         capacity_growth_limit: Option<Dimensionless>,
+        growth_seed: Option<Dimensionless>,
         total_capacity_limit: Option<Capacity>,
     ) -> Result<()> {
         let constraint = ProcessInvestmentConstraintRaw {
@@ -195,6 +206,7 @@ mod tests {
             commission_years: "2030".into(),
             addition_limit,
             capacity_growth_limit,
+            growth_seed,
             total_capacity_limit,
         };
         constraint.validate()
@@ -211,6 +223,7 @@ mod tests {
             commission_years: "ALL".into(), // Should apply to milestone years [2012, 2016]
             addition_limit: CapacityPerYear(100.0),
             capacity_growth_limit: Some(Dimensionless(0.5)),
+            growth_seed: Some(Dimensionless(1.0)),
             total_capacity_limit: Some(Capacity(100.0)),
         }];
 
@@ -259,6 +272,7 @@ mod tests {
                 commission_years: "2010".into(),
                 addition_limit: CapacityPerYear(100.0),
                 capacity_growth_limit: Some(Dimensionless(0.5)),
+                growth_seed: Some(Dimensionless(1.0)),
                 total_capacity_limit: Some(Capacity(100.0)),
             },
             ProcessInvestmentConstraintRaw {
@@ -267,6 +281,7 @@ mod tests {
                 commission_years: "2015".into(),
                 addition_limit: CapacityPerYear(200.0),
                 capacity_growth_limit: Some(Dimensionless(0.5)),
+                growth_seed: Some(Dimensionless(1.0)),
                 total_capacity_limit: Some(Capacity(100.0)),
             },
             ProcessInvestmentConstraintRaw {
@@ -275,6 +290,7 @@ mod tests {
                 commission_years: "2020".into(),
                 addition_limit: CapacityPerYear(50.0),
                 capacity_growth_limit: Some(Dimensionless(0.5)),
+                growth_seed: Some(Dimensionless(1.0)),
                 total_capacity_limit: Some(Capacity(100.0)),
             },
         ];
@@ -336,6 +352,7 @@ mod tests {
             commission_years: "ALL".into(),
             addition_limit: CapacityPerYear(75.0),
             capacity_growth_limit: Some(Dimensionless(0.5)),
+            growth_seed: Some(Dimensionless(1.0)),
             total_capacity_limit: Some(Capacity(100.0)),
         }];
 
@@ -386,6 +403,7 @@ mod tests {
             commission_years: "2025".into(), // Outside milestone years (2010-2020)
             addition_limit: CapacityPerYear(100.0),
             capacity_growth_limit: Some(Dimensionless(0.5)),
+            growth_seed: Some(Dimensionless(1.0)),
             total_capacity_limit: Some(Capacity(100.0)),
         }];
 
@@ -402,36 +420,65 @@ mod tests {
     }
 
     #[rstest]
-    #[case(CapacityPerYear(10.0), None, None)]
-    #[case(CapacityPerYear(0.0), None, None)]
-    #[case(CapacityPerYear(10.0), Some(Dimensionless(0.5)), None)]
-    #[case(CapacityPerYear(10.0), Some(Dimensionless(0.0)), None)]
-    #[case(CapacityPerYear(10.0), None, Some(Capacity(100.0)))]
-    #[case(CapacityPerYear(10.0), None, Some(Capacity(0.0)))]
+    #[case(CapacityPerYear(10.0), None, None, None)]
+    #[case(CapacityPerYear(0.0), None, None, None)]
+    #[case(CapacityPerYear(10.0), Some(Dimensionless(0.5)), None, None)]
+    #[case(CapacityPerYear(10.0), Some(Dimensionless(0.0)), None, None)]
+    #[case(CapacityPerYear(10.0), None, None, Some(Capacity(100.0)))]
+    #[case(CapacityPerYear(10.0), None, None, Some(Capacity(0.0)))]
     fn validate_constraints_valid(
         #[case] addition_limit: CapacityPerYear,
         #[case] capacity_growth_limit: Option<Dimensionless>,
+        #[case] growth_seed: Option<Dimensionless>,
         #[case] total_capacity_limit: Option<Capacity>,
     ) {
-        // Valid: capacity constraints with values >= 0, and capacity_growth_limit and total_capacity_limit as None
-        let valid =
-            validate_raw_constraint(addition_limit, capacity_growth_limit, total_capacity_limit);
+        // Valid: capacity constraints with values >= 0, and capacity_growth_limit and
+        // total_capacity_limit as None
+        let valid = validate_raw_constraint(
+            addition_limit,
+            capacity_growth_limit,
+            growth_seed,
+            total_capacity_limit,
+        );
         valid.unwrap();
     }
 
     #[rstest]
-    #[case(CapacityPerYear(-10.0), None, None, "Invalid value for addition constraint: '-10'; must be non-negative and finite.")]
-    #[case(CapacityPerYear(10.0), Some(Dimensionless(-0.5)), None, "Invalid value for capacity growth constraint: '-0.5'; must be non-negative and finite.")]
-    #[case(CapacityPerYear(10.0), None, Some(Capacity(-100.0)), "Invalid value for total capacity constraint: '-100'; must be non-negative and finite.")]
+    #[case(
+        CapacityPerYear(-10.0),
+        None,
+        None,
+        None,
+        "Invalid value for addition constraint: '-10'; must be non-negative and finite."
+    )]
+    #[case(
+        CapacityPerYear(10.0),
+        Some(Dimensionless(-0.5)),
+        None,
+        None,
+        "Invalid value for capacity growth constraint: '-0.5'; must be non-negative and finite."
+    )]
+    #[case(
+        CapacityPerYear(10.0),
+        None,
+        None,
+        Some(Capacity(-100.0)),
+        "Invalid value for total capacity constraint: '-100'; must be non-negative and finite."
+    )]
     fn validate_constraints_rejects_negative(
         #[case] addition_limit: CapacityPerYear,
         #[case] capacity_growth_limit: Option<Dimensionless>,
+        #[case] growth_seed: Option<Dimensionless>,
         #[case] total_capacity_limit: Option<Capacity>,
         #[case] error_msg: &str,
     ) {
         // Not valid: capacity constraints with negative value
-        let invalid =
-            validate_raw_constraint(addition_limit, capacity_growth_limit, total_capacity_limit);
+        let invalid = validate_raw_constraint(
+            addition_limit,
+            capacity_growth_limit,
+            growth_seed,
+            total_capacity_limit,
+        );
         assert_error!(invalid, error_msg);
     }
 
@@ -440,16 +487,19 @@ mod tests {
         CapacityPerYear(f64::INFINITY),
         None,
         None,
+        None,
         "Invalid value for addition constraint: 'inf'; must be non-negative and finite."
     )]
     #[case(
         CapacityPerYear(10.0),
         Some(Dimensionless(f64::INFINITY)),
         None,
+        None,
         "Invalid value for capacity growth constraint: 'inf'; must be non-negative and finite."
     )]
     #[case(
         CapacityPerYear(10.0),
+        None,
         None,
         Some(Capacity(f64::INFINITY)),
         "Invalid value for total capacity constraint: 'inf'; must be non-negative and finite."
@@ -457,12 +507,17 @@ mod tests {
     fn validate_constraints_rejects_infinite(
         #[case] addition_limit: CapacityPerYear,
         #[case] capacity_growth_limit: Option<Dimensionless>,
+        #[case] growth_seed: Option<Dimensionless>,
         #[case] total_capacity_limit: Option<Capacity>,
         #[case] error_msg: &str,
     ) {
         // Not valid: capacity constraints with infinite value
-        let invalid =
-            validate_raw_constraint(addition_limit, capacity_growth_limit, total_capacity_limit);
+        let invalid = validate_raw_constraint(
+            addition_limit,
+            capacity_growth_limit,
+            growth_seed,
+            total_capacity_limit,
+        );
         assert_error!(invalid, error_msg);
     }
 
@@ -471,16 +526,19 @@ mod tests {
         CapacityPerYear(f64::NAN),
         None,
         None,
+        None,
         "Invalid value for addition constraint: 'NaN'; must be non-negative and finite."
     )]
     #[case(
         CapacityPerYear(10.0),
         Some(Dimensionless(f64::NAN)),
         None,
+        None,
         "Invalid value for capacity growth constraint: 'NaN'; must be non-negative and finite."
     )]
     #[case(
         CapacityPerYear(10.0),
+        None,
         None,
         Some(Capacity(f64::NAN)),
         "Invalid value for total capacity constraint: 'NaN'; must be non-negative and finite."
@@ -488,12 +546,17 @@ mod tests {
     fn validate_constraints_rejects_nan(
         #[case] addition_limit: CapacityPerYear,
         #[case] capacity_growth_limit: Option<Dimensionless>,
+        #[case] growth_seed: Option<Dimensionless>,
         #[case] total_capacity_limit: Option<Capacity>,
         #[case] error_msg: &str,
     ) {
         // Not valid: capacity constraints with NaN value
-        let invalid =
-            validate_raw_constraint(addition_limit, capacity_growth_limit, total_capacity_limit);
+        let invalid = validate_raw_constraint(
+            addition_limit,
+            capacity_growth_limit,
+            growth_seed,
+            total_capacity_limit,
+        );
         assert_error!(invalid, error_msg);
     }
 
@@ -501,10 +564,77 @@ mod tests {
     fn validate_capacity_growth_limit_warning() {
         // Check warning raised if value above 1 provided
         let mut logger = Logger::start();
-        let _ = validate_raw_constraint(CapacityPerYear(10.0), Some(Dimensionless(5.0)), None);
+        let _ =
+            validate_raw_constraint(CapacityPerYear(10.0), Some(Dimensionless(5.0)), None, None);
         assert_eq!(
             logger.pop().unwrap().args(),
             "Interpreting capacity growth constraint '5' as 500%"
         );
+    }
+
+    #[rstest]
+    #[case(CapacityPerYear(10.0), None, None, None)]
+    #[case(CapacityPerYear(10.0), None, Some(Dimensionless(1.0)), None)]
+    #[case(CapacityPerYear(10.0), None, Some(Dimensionless(42.0)), None)]
+    fn validate_growth_seed_valid(
+        #[case] addition_limit: CapacityPerYear,
+        #[case] capacity_growth_limit: Option<Dimensionless>,
+        #[case] growth_seed: Option<Dimensionless>,
+        #[case] total_capacity_limit: Option<Capacity>,
+    ) {
+        // Valid: growth seed with finite values >= 1, or None
+        let valid = validate_raw_constraint(
+            addition_limit,
+            capacity_growth_limit,
+            growth_seed,
+            total_capacity_limit,
+        );
+        valid.unwrap();
+    }
+
+    #[rstest]
+    #[case(
+        CapacityPerYear(10.0),
+        None,
+        Some(Dimensionless(0.9)),
+        None,
+        "Invalid value for growth seed: '0.9'; must be greater than or equal to 1, and finite."
+    )]
+    #[case(
+        CapacityPerYear(10.0),
+        None,
+        Some(Dimensionless(-42.0)),
+        None,
+        "Invalid value for growth seed: '-42'; must be greater than or equal to 1, and finite.",
+    )]
+    #[case(
+        CapacityPerYear(10.0),
+        None,
+        Some(Dimensionless(f64::NAN)),
+        None,
+        "Invalid value for growth seed: 'NaN'; must be greater than or equal to 1, and finite."
+    )]
+    #[case(
+        CapacityPerYear(10.0),
+        None,
+        Some(Dimensionless(f64::INFINITY)),
+        None,
+        "Invalid value for growth seed: 'inf'; must be greater than or equal to 1, and finite."
+    )]
+    fn validate_growth_seed_invvalid(
+        #[case] addition_limit: CapacityPerYear,
+        #[case] capacity_growth_limit: Option<Dimensionless>,
+        #[case] growth_seed: Option<Dimensionless>,
+        #[case] total_capacity_limit: Option<Capacity>,
+        #[case] error_msg: &str,
+    ) {
+        // Invalid: growth seed with values < 1, NaN or inf
+        let invalid = validate_raw_constraint(
+            addition_limit,
+            capacity_growth_limit,
+            growth_seed,
+            total_capacity_limit,
+        );
+        assert_error!(invalid, error_msg);
     }
 }

--- a/src/input/process/investment_constraints.rs
+++ b/src/input/process/investment_constraints.rs
@@ -7,7 +7,7 @@ use crate::process::{
     ProcessID, ProcessInvestmentConstraint, ProcessInvestmentConstraintsMap, ProcessMap,
 };
 use crate::region::parse_region_str;
-use crate::units::{Capacity, CapacityPerYear, Year};
+use crate::units::{Capacity, CapacityPerYear, Dimensionless, Year};
 use anyhow::{Context, Result, ensure};
 use itertools::iproduct;
 use serde::Deserialize;
@@ -24,6 +24,7 @@ struct ProcessInvestmentConstraintRaw {
     regions: String,
     commission_years: String,
     addition_limit: CapacityPerYear,
+    capacity_growth_limit: Option<Dimensionless>,
     total_capacity_limit: Option<Capacity>,
 }
 
@@ -36,6 +37,14 @@ impl ProcessInvestmentConstraintRaw {
             "Invalid value for addition constraint: '{}'; must be non-negative and finite.",
             self.addition_limit
         );
+
+        // Validate capacity_growth_limit: must be in range [0, inf)
+        if let Some(limit) = self.capacity_growth_limit {
+            ensure!(
+                limit.is_finite() && limit >= Dimensionless(0.0),
+                "Invalid value for capacity growth constraint: '{limit}'; must be non-negative and finite.",
+            );
+        }
 
         // Validate total_capacity_limit: must be in range [0, inf)
         if let Some(limit) = self.total_capacity_limit {
@@ -166,6 +175,7 @@ mod tests {
 
     fn validate_raw_constraint(
         addition_limit: CapacityPerYear,
+        capacity_growth_limit: Option<Dimensionless>,
         total_capacity_limit: Option<Capacity>,
     ) -> Result<()> {
         let constraint = ProcessInvestmentConstraintRaw {
@@ -173,6 +183,7 @@ mod tests {
             regions: "ALL".into(),
             commission_years: "2030".into(),
             addition_limit,
+            capacity_growth_limit,
             total_capacity_limit,
         };
         constraint.validate()
@@ -188,6 +199,7 @@ mod tests {
             regions: "GBR".into(),
             commission_years: "ALL".into(), // Should apply to milestone years [2012, 2016]
             addition_limit: CapacityPerYear(100.0),
+            capacity_growth_limit: Some(Dimensionless(0.5)),
             total_capacity_limit: Some(Capacity(100.0)),
         }];
 
@@ -235,6 +247,7 @@ mod tests {
                 regions: "GBR".into(),
                 commission_years: "2010".into(),
                 addition_limit: CapacityPerYear(100.0),
+                capacity_growth_limit: Some(Dimensionless(0.5)),
                 total_capacity_limit: Some(Capacity(100.0)),
             },
             ProcessInvestmentConstraintRaw {
@@ -242,6 +255,7 @@ mod tests {
                 regions: "ALL".into(),
                 commission_years: "2015".into(),
                 addition_limit: CapacityPerYear(200.0),
+                capacity_growth_limit: Some(Dimensionless(0.5)),
                 total_capacity_limit: Some(Capacity(100.0)),
             },
             ProcessInvestmentConstraintRaw {
@@ -249,6 +263,7 @@ mod tests {
                 regions: "USA".into(),
                 commission_years: "2020".into(),
                 addition_limit: CapacityPerYear(50.0),
+                capacity_growth_limit: Some(Dimensionless(0.5)),
                 total_capacity_limit: Some(Capacity(100.0)),
             },
         ];
@@ -309,6 +324,7 @@ mod tests {
             regions: "ALL".into(),
             commission_years: "ALL".into(),
             addition_limit: CapacityPerYear(75.0),
+            capacity_growth_limit: Some(Dimensionless(0.5)),
             total_capacity_limit: Some(Capacity(100.0)),
         }];
 
@@ -358,6 +374,7 @@ mod tests {
             regions: "GBR".into(),
             commission_years: "2025".into(), // Outside milestone years (2010-2020)
             addition_limit: CapacityPerYear(100.0),
+            capacity_growth_limit: Some(Dimensionless(0.5)),
             total_capacity_limit: Some(Capacity(100.0)),
         }];
 
@@ -374,29 +391,36 @@ mod tests {
     }
 
     #[rstest]
-    #[case(CapacityPerYear(10.0), None)]
-    #[case(CapacityPerYear(0.0), None)]
-    #[case(CapacityPerYear(10.0), Some(Capacity(100.0)))]
-    #[case(CapacityPerYear(10.0), Some(Capacity(0.0)))]
+    #[case(CapacityPerYear(10.0), None, None)]
+    #[case(CapacityPerYear(0.0), None, None)]
+    #[case(CapacityPerYear(10.0), Some(Dimensionless(0.5)), None)]
+    #[case(CapacityPerYear(10.0), Some(Dimensionless(0.0)), None)]
+    #[case(CapacityPerYear(10.0), None, Some(Capacity(100.0)))]
+    #[case(CapacityPerYear(10.0), None, Some(Capacity(0.0)))]
     fn validate_constraints_valid(
         #[case] addition_limit: CapacityPerYear,
+        #[case] capacity_growth_limit: Option<Dimensionless>,
         #[case] total_capacity_limit: Option<Capacity>,
     ) {
-        // Valid: capacity constraints with values >= 0, and total_capacity_limit as None
-        let valid = validate_raw_constraint(addition_limit, total_capacity_limit);
+        // Valid: capacity constraints with values >= 0, and capacity_growth_limit and total_capacity_limit as None
+        let valid =
+            validate_raw_constraint(addition_limit, capacity_growth_limit, total_capacity_limit);
         valid.unwrap();
     }
 
     #[rstest]
-    #[case(CapacityPerYear(-10.0), None, "Invalid value for addition constraint: '-10'; must be non-negative and finite.")]
-    #[case(CapacityPerYear(10.0), Some(Capacity(-100.0)), "Invalid value for total capacity constraint: '-100'; must be non-negative and finite.")]
+    #[case(CapacityPerYear(-10.0), None, None, "Invalid value for addition constraint: '-10'; must be non-negative and finite.")]
+    #[case(CapacityPerYear(10.0), Some(Dimensionless(-0.5)), None, "Invalid value for capacity growth constraint: '-0.5'; must be non-negative and finite.")]
+    #[case(CapacityPerYear(10.0), None, Some(Capacity(-100.0)), "Invalid value for total capacity constraint: '-100'; must be non-negative and finite.")]
     fn validate_constraints_rejects_negative(
         #[case] addition_limit: CapacityPerYear,
+        #[case] capacity_growth_limit: Option<Dimensionless>,
         #[case] total_capacity_limit: Option<Capacity>,
         #[case] error_msg: &str,
     ) {
         // Not valid: capacity constraints with negative value
-        let invalid = validate_raw_constraint(addition_limit, total_capacity_limit);
+        let invalid =
+            validate_raw_constraint(addition_limit, capacity_growth_limit, total_capacity_limit);
         assert_error!(invalid, error_msg);
     }
 
@@ -404,20 +428,30 @@ mod tests {
     #[case(
         CapacityPerYear(f64::INFINITY),
         None,
+        None,
         "Invalid value for addition constraint: 'inf'; must be non-negative and finite."
     )]
     #[case(
         CapacityPerYear(10.0),
+        Some(Dimensionless(f64::INFINITY)),
+        None,
+        "Invalid value for capacity growth constraint: 'inf'; must be non-negative and finite."
+    )]
+    #[case(
+        CapacityPerYear(10.0),
+        None,
         Some(Capacity(f64::INFINITY)),
         "Invalid value for total capacity constraint: 'inf'; must be non-negative and finite."
     )]
     fn validate_constraints_rejects_infinite(
         #[case] addition_limit: CapacityPerYear,
+        #[case] capacity_growth_limit: Option<Dimensionless>,
         #[case] total_capacity_limit: Option<Capacity>,
         #[case] error_msg: &str,
     ) {
         // Not valid: capacity constraints with infinite value
-        let invalid = validate_raw_constraint(addition_limit, total_capacity_limit);
+        let invalid =
+            validate_raw_constraint(addition_limit, capacity_growth_limit, total_capacity_limit);
         assert_error!(invalid, error_msg);
     }
 
@@ -425,20 +459,30 @@ mod tests {
     #[case(
         CapacityPerYear(f64::NAN),
         None,
+        None,
         "Invalid value for addition constraint: 'NaN'; must be non-negative and finite."
     )]
     #[case(
         CapacityPerYear(10.0),
+        Some(Dimensionless(f64::NAN)),
+        None,
+        "Invalid value for capacity growth constraint: 'NaN'; must be non-negative and finite."
+    )]
+    #[case(
+        CapacityPerYear(10.0),
+        None,
         Some(Capacity(f64::NAN)),
         "Invalid value for total capacity constraint: 'NaN'; must be non-negative and finite."
     )]
     fn validate_constraints_rejects_nan(
         #[case] addition_limit: CapacityPerYear,
+        #[case] capacity_growth_limit: Option<Dimensionless>,
         #[case] total_capacity_limit: Option<Capacity>,
         #[case] error_msg: &str,
     ) {
         // Not valid: capacity constraints with NaN value
-        let invalid = validate_raw_constraint(addition_limit, total_capacity_limit);
+        let invalid =
+            validate_raw_constraint(addition_limit, capacity_growth_limit, total_capacity_limit);
         assert_error!(invalid, error_msg);
     }
 }

--- a/src/input/process/investment_constraints.rs
+++ b/src/input/process/investment_constraints.rs
@@ -10,6 +10,7 @@ use crate::region::parse_region_str;
 use crate::units::{Capacity, CapacityPerYear, Dimensionless, Year};
 use anyhow::{Context, Result, ensure};
 use itertools::iproduct;
+use log::warn;
 use serde::Deserialize;
 use std::collections::HashMap;
 use std::path::Path;
@@ -38,12 +39,21 @@ impl ProcessInvestmentConstraintRaw {
             self.addition_limit
         );
 
-        // Validate capacity_growth_limit: must be in range [0, inf)
+        // Validate capacity_growth_limit
         if let Some(limit) = self.capacity_growth_limit {
+            // Must be in range [0, inf)
             ensure!(
                 limit.is_finite() && limit >= Dimensionless(0.0),
                 "Invalid value for capacity growth constraint: '{limit}'; must be non-negative and finite.",
             );
+
+            // Warn user they may have specified limit as percentage, rather than fraction
+            if limit > Dimensionless(1.0) {
+                warn!(
+                    "Interpreting capacity growth constraint '{limit}' as {}%",
+                    limit * Dimensionless(100.0)
+                );
+            }
         }
 
         // Validate total_capacity_limit: must be in range [0, inf)
@@ -171,6 +181,7 @@ mod tests {
     use crate::fixture::{assert_error, processes};
     use crate::region::RegionID;
     use crate::units::Capacity;
+    use logtest::Logger;
     use rstest::rstest;
 
     fn validate_raw_constraint(
@@ -484,5 +495,16 @@ mod tests {
         let invalid =
             validate_raw_constraint(addition_limit, capacity_growth_limit, total_capacity_limit);
         assert_error!(invalid, error_msg);
+    }
+
+    #[test]
+    fn validate_capacity_growth_limit_warning() {
+        // Check warning raised if value above 1 provided
+        let mut logger = Logger::start();
+        let _ = validate_raw_constraint(CapacityPerYear(10.0), Some(Dimensionless(5.0)), None);
+        assert_eq!(
+            logger.pop().unwrap().args(),
+            "Interpreting capacity growth constraint '5' as 500%"
+        );
     }
 }


### PR DESCRIPTION
# Description

This PR enables the option to provide capacity growth constraints.

- The csv reader looks for an optional `capacity_growth_limit` column
- If present, these values are then stored in a new `capacity_growth_limit` field of the `ProcessInvestmentConstraintRaw` struct.
- Simple input validation takes place to check that the values, if not `None`, are non-negative and finite. I've also added a check during validation that logs a warning if a fraction greater than 1 (i.e. a percentage greater than 100%) is provided.
  - Tests have been added for this validation
- Capacity growth constraints for the MUSE1 default example have been added to `examples/muse1_default/process_investment_constraints.csv`
- The schema for `process_investment_constraints.csv` input files has been updated with details of this new column

Fixes #1415

## Type of change

- [ ] Bug fix (non-breaking change to fix an issue)
- [X] New feature (non-breaking change to add functionality)
- [ ] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [X] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`
- [ ] Update release notes for the latest release if this PR adds a new feature or fixes a bug
      present in the previous release

## Further checks

- [X] Code is commented, particularly in hard-to-understand areas
- [X] Tests added that prove fix is effective or that feature works
