### PR TITLE
Enable capacity growth with seed parameter

### DIFF
--- a/schemas/input/process_investment_constraints.yaml
+++ b/schemas/input/process_investment_constraints.yaml
@@ -32,6 +32,12 @@ fields:
       The constraint on fractional growth per year, based on the available stock in a year, per
       region and technology. E.g 0.1 -> max 10% growth allowed.
     notes: This is currently unused.
+  - name: growth_seed
+    type: number
+    description: |
+      A parameter to scale the initial capacity value used in the capacity growth calculation,
+      allowing growth to initiate when capacity is low/zero. Defaults to 1 if unspecified.
+    notes: This is currently unused.
   - name: total_capacity_limit
     type: number
     description: The hard upper limit on the amount agents can invest in the process

--- a/src/input/process/investment_constraints.rs
+++ b/src/input/process/investment_constraints.rs
@@ -26,6 +26,7 @@ struct ProcessInvestmentConstraintRaw {
     commission_years: String,
     addition_limit: CapacityPerYear,
     capacity_growth_limit: Option<Dimensionless>,
+    growth_seed: Option<Dimensionless>,
     total_capacity_limit: Option<Capacity>,
 }
 
@@ -54,6 +55,15 @@ impl ProcessInvestmentConstraintRaw {
                     limit * Dimensionless(100.0)
                 );
             }
+        }
+
+        // Validate growth seed: must be in range [1, inf)
+        if let Some(growth_seed) = self.growth_seed {
+            ensure!(
+                growth_seed.is_finite() && growth_seed >= Dimensionless(1.0),
+                "Invalid value for growth seed: '{growth_seed}'; must be greater than or equal to \
+                 1, and finite.",
+            );
         }
 
         // Validate total_capacity_limit: must be in range [0, inf)
@@ -187,6 +197,7 @@ mod tests {
     fn validate_raw_constraint(
         addition_limit: CapacityPerYear,
         capacity_growth_limit: Option<Dimensionless>,
+        growth_seed: Option<Dimensionless>,
         total_capacity_limit: Option<Capacity>,
     ) -> Result<()> {
         let constraint = ProcessInvestmentConstraintRaw {
@@ -195,6 +206,7 @@ mod tests {
             commission_years: "2030".into(),
             addition_limit,
             capacity_growth_limit,
+            growth_seed,
             total_capacity_limit,
         };
         constraint.validate()
@@ -211,6 +223,7 @@ mod tests {
             commission_years: "ALL".into(), // Should apply to milestone years [2012, 2016]
             addition_limit: CapacityPerYear(100.0),
             capacity_growth_limit: Some(Dimensionless(0.5)),
+            growth_seed: Some(Dimensionless(1.0)),
             total_capacity_limit: Some(Capacity(100.0)),
         }];
 
@@ -259,6 +272,7 @@ mod tests {
                 commission_years: "2010".into(),
                 addition_limit: CapacityPerYear(100.0),
                 capacity_growth_limit: Some(Dimensionless(0.5)),
+                growth_seed: Some(Dimensionless(1.0)),
                 total_capacity_limit: Some(Capacity(100.0)),
             },
             ProcessInvestmentConstraintRaw {
@@ -267,6 +281,7 @@ mod tests {
                 commission_years: "2015".into(),
                 addition_limit: CapacityPerYear(200.0),
                 capacity_growth_limit: Some(Dimensionless(0.5)),
+                growth_seed: Some(Dimensionless(1.0)),
                 total_capacity_limit: Some(Capacity(100.0)),
             },
             ProcessInvestmentConstraintRaw {
@@ -275,6 +290,7 @@ mod tests {
                 commission_years: "2020".into(),
                 addition_limit: CapacityPerYear(50.0),
                 capacity_growth_limit: Some(Dimensionless(0.5)),
+                growth_seed: Some(Dimensionless(1.0)),
                 total_capacity_limit: Some(Capacity(100.0)),
             },
         ];
@@ -336,6 +352,7 @@ mod tests {
             commission_years: "ALL".into(),
             addition_limit: CapacityPerYear(75.0),
             capacity_growth_limit: Some(Dimensionless(0.5)),
+            growth_seed: Some(Dimensionless(1.0)),
             total_capacity_limit: Some(Capacity(100.0)),
         }];
 
@@ -386,6 +403,7 @@ mod tests {
             commission_years: "2025".into(), // Outside milestone years (2010-2020)
             addition_limit: CapacityPerYear(100.0),
             capacity_growth_limit: Some(Dimensionless(0.5)),
+            growth_seed: Some(Dimensionless(1.0)),
             total_capacity_limit: Some(Capacity(100.0)),
         }];
 
@@ -402,36 +420,65 @@ mod tests {
     }
 
     #[rstest]
-    #[case(CapacityPerYear(10.0), None, None)]
-    #[case(CapacityPerYear(0.0), None, None)]
-    #[case(CapacityPerYear(10.0), Some(Dimensionless(0.5)), None)]
-    #[case(CapacityPerYear(10.0), Some(Dimensionless(0.0)), None)]
-    #[case(CapacityPerYear(10.0), None, Some(Capacity(100.0)))]
-    #[case(CapacityPerYear(10.0), None, Some(Capacity(0.0)))]
+    #[case(CapacityPerYear(10.0), None, None, None)]
+    #[case(CapacityPerYear(0.0), None, None, None)]
+    #[case(CapacityPerYear(10.0), Some(Dimensionless(0.5)), None, None)]
+    #[case(CapacityPerYear(10.0), Some(Dimensionless(0.0)), None, None)]
+    #[case(CapacityPerYear(10.0), None, None, Some(Capacity(100.0)))]
+    #[case(CapacityPerYear(10.0), None, None, Some(Capacity(0.0)))]
     fn validate_constraints_valid(
         #[case] addition_limit: CapacityPerYear,
         #[case] capacity_growth_limit: Option<Dimensionless>,
+        #[case] growth_seed: Option<Dimensionless>,
         #[case] total_capacity_limit: Option<Capacity>,
     ) {
-        // Valid: capacity constraints with values >= 0, and capacity_growth_limit and total_capacity_limit as None
-        let valid =
-            validate_raw_constraint(addition_limit, capacity_growth_limit, total_capacity_limit);
+        // Valid: capacity constraints with values >= 0, and capacity_growth_limit and
+        // total_capacity_limit as None
+        let valid = validate_raw_constraint(
+            addition_limit,
+            capacity_growth_limit,
+            growth_seed,
+            total_capacity_limit,
+        );
         valid.unwrap();
     }
 
     #[rstest]
-    #[case(CapacityPerYear(-10.0), None, None, "Invalid value for addition constraint: '-10'; must be non-negative and finite.")]
-    #[case(CapacityPerYear(10.0), Some(Dimensionless(-0.5)), None, "Invalid value for capacity growth constraint: '-0.5'; must be non-negative and finite.")]
-    #[case(CapacityPerYear(10.0), None, Some(Capacity(-100.0)), "Invalid value for total capacity constraint: '-100'; must be non-negative and finite.")]
+    #[case(
+        CapacityPerYear(-10.0),
+        None,
+        None,
+        None,
+        "Invalid value for addition constraint: '-10'; must be non-negative and finite."
+    )]
+    #[case(
+        CapacityPerYear(10.0),
+        Some(Dimensionless(-0.5)),
+        None,
+        None,
+        "Invalid value for capacity growth constraint: '-0.5'; must be non-negative and finite."
+    )]
+    #[case(
+        CapacityPerYear(10.0),
+        None,
+        None,
+        Some(Capacity(-100.0)),
+        "Invalid value for total capacity constraint: '-100'; must be non-negative and finite."
+    )]
     fn validate_constraints_rejects_negative(
         #[case] addition_limit: CapacityPerYear,
         #[case] capacity_growth_limit: Option<Dimensionless>,
+        #[case] growth_seed: Option<Dimensionless>,
         #[case] total_capacity_limit: Option<Capacity>,
         #[case] error_msg: &str,
     ) {
         // Not valid: capacity constraints with negative value
-        let invalid =
-            validate_raw_constraint(addition_limit, capacity_growth_limit, total_capacity_limit);
+        let invalid = validate_raw_constraint(
+            addition_limit,
+            capacity_growth_limit,
+            growth_seed,
+            total_capacity_limit,
+        );
         assert_error!(invalid, error_msg);
     }
 
@@ -440,16 +487,19 @@ mod tests {
         CapacityPerYear(f64::INFINITY),
         None,
         None,
+        None,
         "Invalid value for addition constraint: 'inf'; must be non-negative and finite."
     )]
     #[case(
         CapacityPerYear(10.0),
         Some(Dimensionless(f64::INFINITY)),
         None,
+        None,
         "Invalid value for capacity growth constraint: 'inf'; must be non-negative and finite."
     )]
     #[case(
         CapacityPerYear(10.0),
+        None,
         None,
         Some(Capacity(f64::INFINITY)),
         "Invalid value for total capacity constraint: 'inf'; must be non-negative and finite."
@@ -457,12 +507,17 @@ mod tests {
     fn validate_constraints_rejects_infinite(
         #[case] addition_limit: CapacityPerYear,
         #[case] capacity_growth_limit: Option<Dimensionless>,
+        #[case] growth_seed: Option<Dimensionless>,
         #[case] total_capacity_limit: Option<Capacity>,
         #[case] error_msg: &str,
     ) {
         // Not valid: capacity constraints with infinite value
-        let invalid =
-            validate_raw_constraint(addition_limit, capacity_growth_limit, total_capacity_limit);
+        let invalid = validate_raw_constraint(
+            addition_limit,
+            capacity_growth_limit,
+            growth_seed,
+            total_capacity_limit,
+        );
         assert_error!(invalid, error_msg);
     }
 
@@ -471,16 +526,19 @@ mod tests {
         CapacityPerYear(f64::NAN),
         None,
         None,
+        None,
         "Invalid value for addition constraint: 'NaN'; must be non-negative and finite."
     )]
     #[case(
         CapacityPerYear(10.0),
         Some(Dimensionless(f64::NAN)),
         None,
+        None,
         "Invalid value for capacity growth constraint: 'NaN'; must be non-negative and finite."
     )]
     #[case(
         CapacityPerYear(10.0),
+        None,
         None,
         Some(Capacity(f64::NAN)),
         "Invalid value for total capacity constraint: 'NaN'; must be non-negative and finite."
@@ -488,12 +546,17 @@ mod tests {
     fn validate_constraints_rejects_nan(
         #[case] addition_limit: CapacityPerYear,
         #[case] capacity_growth_limit: Option<Dimensionless>,
+        #[case] growth_seed: Option<Dimensionless>,
         #[case] total_capacity_limit: Option<Capacity>,
         #[case] error_msg: &str,
     ) {
         // Not valid: capacity constraints with NaN value
-        let invalid =
-            validate_raw_constraint(addition_limit, capacity_growth_limit, total_capacity_limit);
+        let invalid = validate_raw_constraint(
+            addition_limit,
+            capacity_growth_limit,
+            growth_seed,
+            total_capacity_limit,
+        );
         assert_error!(invalid, error_msg);
     }
 
@@ -501,10 +564,77 @@ mod tests {
     fn validate_capacity_growth_limit_warning() {
         // Check warning raised if value above 1 provided
         let mut logger = Logger::start();
-        let _ = validate_raw_constraint(CapacityPerYear(10.0), Some(Dimensionless(5.0)), None);
+        let _ =
+            validate_raw_constraint(CapacityPerYear(10.0), Some(Dimensionless(5.0)), None, None);
         assert_eq!(
             logger.pop().unwrap().args(),
             "Interpreting capacity growth constraint '5' as 500%"
         );
+    }
+
+    #[rstest]
+    #[case(CapacityPerYear(10.0), None, None, None)]
+    #[case(CapacityPerYear(10.0), None, Some(Dimensionless(1.0)), None)]
+    #[case(CapacityPerYear(10.0), None, Some(Dimensionless(42.0)), None)]
+    fn validate_growth_seed_valid(
+        #[case] addition_limit: CapacityPerYear,
+        #[case] capacity_growth_limit: Option<Dimensionless>,
+        #[case] growth_seed: Option<Dimensionless>,
+        #[case] total_capacity_limit: Option<Capacity>,
+    ) {
+        // Valid: growth seed with finite values >= 1, or None
+        let valid = validate_raw_constraint(
+            addition_limit,
+            capacity_growth_limit,
+            growth_seed,
+            total_capacity_limit,
+        );
+        valid.unwrap();
+    }
+
+    #[rstest]
+    #[case(
+        CapacityPerYear(10.0),
+        None,
+        Some(Dimensionless(0.9)),
+        None,
+        "Invalid value for growth seed: '0.9'; must be greater than or equal to 1, and finite."
+    )]
+    #[case(
+        CapacityPerYear(10.0),
+        None,
+        Some(Dimensionless(-42.0)),
+        None,
+        "Invalid value for growth seed: '-42'; must be greater than or equal to 1, and finite.",
+    )]
+    #[case(
+        CapacityPerYear(10.0),
+        None,
+        Some(Dimensionless(f64::NAN)),
+        None,
+        "Invalid value for growth seed: 'NaN'; must be greater than or equal to 1, and finite."
+    )]
+    #[case(
+        CapacityPerYear(10.0),
+        None,
+        Some(Dimensionless(f64::INFINITY)),
+        None,
+        "Invalid value for growth seed: 'inf'; must be greater than or equal to 1, and finite."
+    )]
+    fn validate_growth_seed_invvalid(
+        #[case] addition_limit: CapacityPerYear,
+        #[case] capacity_growth_limit: Option<Dimensionless>,
+        #[case] growth_seed: Option<Dimensionless>,
+        #[case] total_capacity_limit: Option<Capacity>,
+        #[case] error_msg: &str,
+    ) {
+        // Invalid: growth seed with values < 1, NaN or inf
+        let invalid = validate_raw_constraint(
+            addition_limit,
+            capacity_growth_limit,
+            growth_seed,
+            total_capacity_limit,
+        );
+        assert_error!(invalid, error_msg);
     }
 }


### PR DESCRIPTION
# Description

This PR enables the option to provide a seed parameter for capacity growth, as per https://github.com/EnergySystemsModellingLab/MUSE2/pull/1424#pullrequestreview-4721746130.

- The csv reader looks for an optional `growth_seed` column
- If present, these values are then stored in a new `growth_seed` field of the `ProcessInvestmentConstraintRaw` struct.
- Simple input validation takes place to check that the values, if not `None`, are greater than or equal to 1, and finite.
  - Tests have been added for this validation
- The schema for `process_investment_constraints.csv` input files has been updated with details of this new parameter

Fixes #1425 

## Type of change

- [ ] Bug fix (non-breaking change to fix an issue)
- [X] New feature (non-breaking change to add functionality)
- [ ] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [X] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`
- [ ] Update release notes for the latest release if this PR adds a new feature or fixes a bug
      present in the previous release

## Further checks

- [X] Code is commented, particularly in hard-to-understand areas
- [X] Tests added that prove fix is effective or that feature works
