### PR TITLE
Remove use of child assets in appraisal

### DIFF
--- a/src/asset.rs
+++ b/src/asset.rs
@@ -643,7 +643,10 @@ impl Asset {
 
     /// Whether this asset has been commissioned
     pub fn is_commissioned(&self) -> bool {
-        matches!(&self.state, AssetState::Commissioned { .. })
+        matches!(
+            &self.state,
+            AssetState::Commissioned { .. } | AssetState::Parent { .. }
+        )
     }
 
     /// Get the commission year for this asset

--- a/src/asset.rs
+++ b/src/asset.rs
@@ -749,11 +749,14 @@ impl Asset {
         self.capacity.set(capacity);
     }
 
-    /// Increase the capacity for this asset (only for Candidate assets)
+    /// Increase the capacity for this asset (only for Candidate and Parent assets)
     pub fn increase_capacity(&mut self, capacity: AssetCapacity) {
         assert!(
-            self.state == AssetState::Candidate,
-            "increase_capacity can only be called on Candidate assets"
+            matches!(
+                self.state,
+                AssetState::Candidate | AssetState::Parent { .. }
+            ),
+            "increase_capacity can only be called on Candidate or Parent assets"
         );
         assert!(
             capacity.total_capacity() > Capacity(0.0),

--- a/src/simulation/investment.rs
+++ b/src/simulation/investment.rs
@@ -348,7 +348,7 @@ fn log_on_equal_appraisal_outputs(
 pub fn select_best_assets(
     model: &Model,
     mut opt_assets: Vec<AssetRef>,
-    investment_limits: HashMap<AssetRef, AssetCapacity>,
+    candidate_investment_limits: HashMap<AssetRef, AssetCapacity>,
     commodity: &Commodity,
     agent: &Agent,
     region_id: &RegionID,
@@ -358,7 +358,7 @@ pub fn select_best_assets(
     writer: &mut DataWriter,
 ) -> Result<Vec<AssetRef>> {
     let objective_type = &agent.objectives[&year];
-    let mut remaining_candidate_capacity = investment_limits;
+    let mut remaining_candidate_capacity = candidate_investment_limits;
 
     // Calculate coefficients for all asset options according to the agent's objective
     let coefficients =
@@ -384,7 +384,7 @@ pub fn select_best_assets(
         let mut seen_groups = HashSet::new();
 
         // Appraise all options
-        let mut outputs_for_opts = Vec::new();
+        let mut outputs = Vec::new();
         for asset in &opt_assets {
             // Skip any assets from groups we've already seen
             if let Some(group_id) = asset.group_id()
@@ -427,24 +427,24 @@ pub fn select_best_assets(
                 &coefficients[&asset],
                 &demand,
             )?;
-            outputs_for_opts.push(output);
+            outputs.push(output);
         }
 
         // Save appraisal results
         writer.write_appraisal_debug_info(
             year,
             &format!("{} {} round {}", commodity.id, agent.id, round),
-            &outputs_for_opts,
+            &outputs,
             &demand,
         )?;
 
         // Sort by investment priority and discard non-feasible options
-        let num_nonfeasible = sort_and_filter_appraisal_outputs(&mut outputs_for_opts);
+        let num_nonfeasible = sort_and_filter_appraisal_outputs(&mut outputs);
 
         // If none of the remaining options are feasible, we terminate the loop. We may still be
         // able to meet the full demands with assets selected so far, so we continue anyway with a
         // warning.
-        if outputs_for_opts.is_empty() {
+        if outputs.is_empty() {
             warn!(
                 "Investment appraisal completed with unmet demand for commodity '{}', region '{}', \
                 year '{}', agent '{}'. {} non-feasible investments were not considered. \
@@ -455,9 +455,9 @@ pub fn select_best_assets(
         }
 
         // Warn if there are multiple equally good assets
-        log_on_equal_appraisal_outputs(&outputs_for_opts, &agent.id, &commodity.id, region_id);
+        log_on_equal_appraisal_outputs(&outputs, &agent.id, &commodity.id, region_id);
 
-        let best_output = outputs_for_opts.into_iter().next().unwrap();
+        let best_output = outputs.into_iter().next().unwrap();
 
         // Log the selected asset
         debug!(

--- a/src/simulation/investment.rs
+++ b/src/simulation/investment.rs
@@ -13,7 +13,7 @@ use anyhow::{Result, ensure};
 use indexmap::IndexMap;
 use itertools::Itertools;
 use log::{debug, warn};
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use strum::IntoEnumIterator;
 
 pub mod appraisal;
@@ -358,7 +358,12 @@ pub fn select_best_assets(
     writer: &mut DataWriter,
 ) -> Result<Vec<AssetRef>> {
     let objective_type = &agent.objectives[&year];
-    let mut remaining_candidate_capacity = candidate_investment_limits;
+
+    // Remaining capacity for candidates and divisible assets
+    let mut remaining_capacities = candidate_investment_limits;
+
+    // Swap child assets for parents representing a single unit
+    let children = replace_child_assets_with_parents(&mut opt_assets, &mut remaining_capacities);
 
     // Calculate coefficients for all asset options according to the agent's objective
     let coefficients =
@@ -379,20 +384,9 @@ pub fn select_best_assets(
             region_id
         );
 
-        // Since all assets with the same `group_id` are identical, we only need to appraise one
-        // from each group.
-        let mut seen_groups = HashSet::new();
-
         // Appraise all options
         let mut outputs = Vec::new();
         for asset in &opt_assets {
-            // Skip any assets from groups we've already seen
-            if let Some(group_id) = asset.group_id()
-                && !seen_groups.insert(group_id)
-            {
-                continue;
-            }
-
             // For candidates, cap the asset's capacity by the current demand-limiting capacity
             // and, where an addition constraint exists, the remaining installable capacity.
             let mut asset = asset.clone();
@@ -407,7 +401,7 @@ pub fn select_best_assets(
                     asset.unit_size(),
                 );
                 let cap = asset.capacity().min(dlc);
-                let max_capacity = remaining_candidate_capacity
+                let max_capacity = remaining_capacities
                     .get(&asset)
                     .copied()
                     .map_or(cap, |remaining| cap.min(remaining));
@@ -471,7 +465,7 @@ pub fn select_best_assets(
         update_assets(
             best_output.asset,
             &mut opt_assets,
-            &mut remaining_candidate_capacity,
+            &mut remaining_capacities,
             &mut best_assets,
         );
 
@@ -489,7 +483,80 @@ pub fn select_best_assets(
         }
     }
 
+    // Convert parent assets back to children
+    replace_parent_assets_with_children(&mut best_assets, children, remaining_capacities);
+
     Ok(best_assets)
+}
+
+/// Replace all child assets with parent assets representing a single unit.
+///
+/// Non-divisible assets are left as is. `remaining_capacities` is updated to include total capacity
+/// for each parent asset.
+///
+/// # Returns
+///
+/// The child assets previously in `assets`.
+fn replace_child_assets_with_parents(
+    assets: &mut Vec<AssetRef>,
+    remaining_capacities: &mut HashMap<AssetRef, AssetCapacity>,
+) -> Vec<AssetRef> {
+    // Extract all child assets
+    let children = assets
+        .extract_if(.., |asset| asset.parent().is_some())
+        .collect_vec();
+
+    let parents = children
+        .iter()
+        .map(|child| child.parent().unwrap())
+        .unique();
+    for parent in parents {
+        // Store remaining capacity
+        remaining_capacities.insert(parent.clone(), parent.capacity());
+
+        // Add parent asset (one unit)
+        assets.push(parent.make_partial_parent(1));
+    }
+
+    children
+}
+
+/// Replace parent assets with their corresponding children.
+///
+/// If only a portion of a parent's capacity was selected, some child assets will be dropped,
+/// starting with those with the highest ID.
+fn replace_parent_assets_with_children(
+    assets: &mut Vec<AssetRef>,
+    mut children: Vec<AssetRef>,
+    mut remaining_capacities: HashMap<AssetRef, AssetCapacity>,
+) {
+    // Drop parent assets. We can figure out which ones were selected from `children` and
+    // `remaining_capacities`.
+    assets.retain(|asset| !asset.is_parent());
+
+    // Sort children in reverse order, so higher IDs come first
+    children.sort_by(|a, b| a.cmp(b).reverse());
+
+    // Drop any surplus children
+    children.retain(|child| {
+        let parent = child.parent().unwrap();
+
+        let Some(remaining) = remaining_capacities.get_mut(parent) else {
+            return true;
+        };
+
+        // Decrease remaining capacity
+        if remaining.n_units() == Some(1) {
+            remaining_capacities.remove(parent);
+        } else {
+            *remaining = *remaining - child.capacity();
+        }
+
+        false
+    });
+
+    // Add child assets back into `assets`
+    assets.extend(children);
 }
 
 /// Check whether there is any remaining demand that is unmet in any time slice
@@ -501,7 +568,7 @@ fn is_any_remaining_demand(demand: &DemandMap, absolute_tolerance: Flow) -> bool
 fn update_assets(
     best_asset: AssetRef,
     opt_assets: &mut Vec<AssetRef>,
-    remaining_candidate_capacity: &mut HashMap<AssetRef, AssetCapacity>,
+    remaining_capacities: &mut HashMap<AssetRef, AssetCapacity>,
     best_assets: &mut Vec<AssetRef>,
 ) {
     match best_asset.state() {
@@ -510,9 +577,9 @@ fn update_assets(
             opt_assets.retain(|asset| *asset != best_asset);
             best_assets.push(best_asset);
         }
-        AssetState::Candidate => {
+        AssetState::Candidate | AssetState::Parent { .. } => {
             // Track remaining capacity for assets that have limits
-            if let Some(remaining_capacity) = remaining_candidate_capacity.get_mut(&best_asset) {
+            if let Some(remaining_capacity) = remaining_capacities.get_mut(&best_asset) {
                 *remaining_capacity = *remaining_capacity - best_asset.capacity();
 
                 // If there's no capacity remaining, remove the asset from the options
@@ -523,7 +590,7 @@ fn update_assets(
                         .unwrap();
 
                     opt_assets.swap_remove(old_idx);
-                    remaining_candidate_capacity.remove(&best_asset);
+                    remaining_capacities.remove(&best_asset);
                 }
             }
 
@@ -538,7 +605,11 @@ fn update_assets(
                 best_assets.push(best_asset);
             }
         }
-        _ => panic!("update_assets should only be called with Commissioned or Candidate assets"),
+        AssetState::Ready { .. } => {
+            panic!(
+                "update_assets should only be called with Commissioned, Parent or Candidate assets"
+            )
+        }
     }
 }
 

--- a/src/simulation/investment/appraisal/costs.rs
+++ b/src/simulation/investment/appraisal/costs.rs
@@ -9,13 +9,17 @@ use crate::units::{MoneyPerCapacity, Year};
 /// - For a candidate asset, this includes both operating and capital costs.
 ///
 /// The return value is the annualised fixed cost expressed as `MoneyPerCapacity`.
-/// If `asset.state()` is neither `Commissioned` nor `Candidate` this function will panic.
+/// If `asset.state()` is not `Commissioned`, `Parent` or `Candidate` this function will panic.
 pub fn annual_fixed_cost(asset: &AssetRef) -> MoneyPerCapacity {
     match asset.state() {
-        AssetState::Commissioned { .. } => annual_fixed_cost_for_existing(asset),
+        AssetState::Commissioned { .. } | AssetState::Parent { .. } => {
+            annual_fixed_cost_for_existing(asset)
+        }
         AssetState::Candidate => annual_fixed_cost_for_candidate(asset),
-        _ => {
-            panic!("annual_fixed_cost should only be called with Commissioned or Candidate assets")
+        AssetState::Ready { .. } => {
+            panic!(
+                "annual_fixed_cost should only be called with Commissioned, Parent or Candidate assets"
+            )
         }
     }
 }

--- a/src/simulation/market.rs
+++ b/src/simulation/market.rs
@@ -193,14 +193,14 @@ pub fn select_assets_for_single_market(
         .collect::<Vec<_>>();
 
         // Calculate investment limits for candidate assets
-        let investment_limits =
+        let candidate_investment_limits =
             collect_investment_limits_for_candidates(&opt_assets, commodity_portion);
 
         // Choose assets from among existing pool and candidates
         let best_assets = select_best_assets(
             model,
             opt_assets,
-            investment_limits,
+            candidate_investment_limits,
             commodity,
             agent,
             region_id,


### PR DESCRIPTION
# Description

We were planning to remove child assets altogether in this engagement (#1123). Appraisal still relies on the use of child assets, however; divisible assets are currently appraised one unit (child asset) at a time. We considered coming up with an approach that would involve appraising multiple units of a divisible asset at once (#1209), but decided against it in favour of the current one-unit-at-a-time approach. However, this still means we need to come up with a way to avoid using child assets here.

This PR removes the use of child assets in the `select_best_assets` function. The function accepts investment options (assets) which may include child assets and returns the selected assets, which will include child assets if any are selected. To avoid more wide-ranging changes, I've kept this API the same, except internally the function now replaces child assets with their corresponding parents at the start and selects the appropriate number of child assets to retain (if any) before returning. This is similar to what we do for dispatch, which also accepts child assets as an input, but converts them to parents internally. This change definitely makes things uglier in the short term, but it's an important step towards #1123. `AssetPool` still stores child assets rather than parents internally, but now that we've removed this last user of child assets, we can swap over to parent assets everywhere and remove the code for converting back and forth between children and parents.

Commissioned divisible assets are somewhat similar to candidate assets, in that the appraisal process allows for selecting only part of the possible total capacity and discarding the rest (except that it's discrete rather than continuous), so I was able to reuse some of the code for candidate assets.

As we still want to appraise divisible assets one unit at a time, we use "partial parents", which are the same as the original parent, except that in this case they have a smaller capacity (we also use partial parents for dispatch). Capacity is not considered when hashing assets though, which is important when they're being used as keys for maps.

Closes #1429.

## Type of change

- [ ] Bug fix (non-breaking change to fix an issue)
- [ ] New feature (non-breaking change to add functionality)
- [x] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [x] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`
- [ ] Update release notes for the latest release if this PR adds a new feature or fixes a bug
      present in the previous release

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
