### PR TITLE
Pin versions of `highs` and `highs-sys`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,11 @@ updates:
     groups:
       rust:
         patterns: ["*"]
+    ignore:
+      # These packages are currently pinned, see:
+      #     https://github.com/EnergySystemsModellingLab/MUSE2/issues/1431
+      - dependency-name: highs
+      - dependency-name: highs-sys
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -929,6 +929,7 @@ dependencies = [
  "fern",
  "float-cmp",
  "highs",
+ "highs-sys",
  "human-panic",
  "include_dir",
  "indexmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,9 +24,14 @@ fern = {version = "0.7.1", features = ["chrono", "colored"]}
 chrono = "0.4"
 clap = {version = "4.6.1", features = ["cargo", "derive"]}
 include_dir = "0.7.4"
-# Pinned because latest version leads to different results on different platforms:
+# Pinned because newer versions of `highs-sys` (required by newer version of `highs`) lead to
+# different results on different platforms:
 # https://github.com/EnergySystemsModellingLab/MUSE2/issues/1431
+#
+# As `highs-sys` is a transitive dependency, it can be removed from this file when we are happy to
+# unpin.
 highs = "=2.3.0"
+highs-sys = "=1.12.1"
 indexmap = "2.14.0"
 human-panic = "2.0.8"
 clap-markdown = "0.1.5"


### PR DESCRIPTION
# Description

I already attempted to pin the version of the `highs` crate (see #1431), as the latest version was pulling in a newer version of `highs-sys` which gives different results on different platforms (#1174). While we could just disable the divergent regression tests for macOS, it doesn't seem worth it given that we're hoping to tackle #1174 anyway, which would hopefully fix the underlying problem. 

Even though I explicitly pinned the version of the `highs` crate in `Cargo.toml` to v2.3.0, dependabot still opened a PR to update it to v2.4.0 (#1433), so it seems we also need to specify that we want it ignored in `dependabot.yml`.

The `highs-sys` package is a transitive dependency, which bundles the HiGHS C++ code. Its version will be updated whenever you run `cargo update`, but this causes the same problem (see #1435), so I've also pinned the version of this dependency for now.

## Type of change

- [x] Bug fix (non-breaking change to fix an issue)
- [ ] New feature (non-breaking change to add functionality)
- [ ] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [ ] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`
- [ ] Update release notes for the latest release if this PR adds a new feature or fixes a bug
      present in the previous release

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
