### PR TITLE
Fixes for `commodity_balance_epsilon`

### DIFF
--- a/schemas/input/model.yaml
+++ b/schemas/input/model.yaml
@@ -18,7 +18,7 @@ properties:
   commodity_balance_epsilon:
     type: number
     description: Epsilon added to commodity balance lower bounds to force some dispatch by candidate assets
-    default: 0.000001
+    default: 1e-6
     notes: |
       The default value should work. Do not change this value unless you know what you're doing!
   capacity_limit_factor:

--- a/schemas/input/model.yaml
+++ b/schemas/input/model.yaml
@@ -15,6 +15,12 @@ properties:
     default: 0.0001
     notes: |
       The default value should work. Do not change this value unless you know what you're doing!
+  commodity_balance_epsilon:
+    type: number
+    description: Epsilon added to commodity balance lower bounds to force some dispatch by candidate assets
+    default: 0.000001
+    notes: |
+      The default value should work. Do not change this value unless you know what you're doing!
   capacity_limit_factor:
     type: number
     description: Scales the capacity assigned to candidate assets

--- a/src/model/parameters.rs
+++ b/src/model/parameters.rs
@@ -342,8 +342,8 @@ impl ModelParameters {
         // commodity_balance_epsilon
         ensure!(
             self.commodity_balance_epsilon.is_finite()
-                && self.commodity_balance_epsilon > Flow(0.0),
-            "commodity_balance_epsilon must be a finite number greater than zero"
+                && self.commodity_balance_epsilon >= Flow(0.0),
+            "commodity_balance_epsilon must be a finite number greater than or equal to zero"
         );
 
         // value_of_lost_load

--- a/src/model/parameters.rs
+++ b/src/model/parameters.rs
@@ -77,6 +77,10 @@ pub struct ModelParameters {
     ///
     /// Don't change unless you know what you're doing.
     pub candidate_asset_capacity: Capacity,
+    /// The epsilon added to commodity balance lower bounds to force candidate dispatch.
+    ///
+    /// Don't change unless you know what you're doing.
+    pub commodity_balance_epsilon: Flow,
     /// Affects the maximum capacity that can be given to a newly created asset.
     ///
     /// It is the proportion of maximum capacity that could be required across time slices.
@@ -118,6 +122,7 @@ impl Default for ModelParameters {
             // Default values for optional parameters
             allow_dangerous_options: false,
             candidate_asset_capacity: Capacity(1e-4),
+            commodity_balance_epsilon: Flow(1e-6),
             capacity_limit_factor: Dimensionless(0.05),
             value_of_lost_load: MoneyPerFlow(1e9),
             max_ironing_out_iterations: 1,
@@ -333,6 +338,13 @@ impl ModelParameters {
         // candidate_asset_capacity
         check_capacity_valid_for_asset(self.candidate_asset_capacity)
             .context("Invalid value for candidate_asset_capacity")?;
+
+        // commodity_balance_epsilon
+        ensure!(
+            self.commodity_balance_epsilon.is_finite()
+                && self.commodity_balance_epsilon > Flow(0.0),
+            "commodity_balance_epsilon must be a finite number greater than zero"
+        );
 
         // value_of_lost_load
         check_value_of_lost_load(self.value_of_lost_load)?;

--- a/src/simulation/optimisation/constraints.rs
+++ b/src/simulation/optimisation/constraints.rs
@@ -5,12 +5,12 @@ use crate::commodity::{CommodityID, CommodityType};
 use crate::model::Model;
 use crate::region::RegionID;
 use crate::time_slice::{TimeSliceInfo, TimeSliceSelection};
-use crate::units::{Activity, UnitType};
+use crate::units::{Flow, UnitType};
 use highs::RowProblem as Problem;
 use indexmap::IndexMap;
 
 /// Small epsilon to add to the commodity balance constraints for candidate assets
-const COMMODITY_BALANCE_EPSILON_FOR_CANDIDATES: f64 = 1e-6;
+const COMMODITY_BALANCE_EPSILON_FOR_CANDIDATES: Flow = Flow(1e-6);
 
 /// Corresponding variables for a constraint along with the row offset in the solution
 pub struct KeysWithOffset<T> {
@@ -179,33 +179,38 @@ where
                 }
             }
 
-            // If any candidate asset in this region produces this commodity, and has a
-            // nonzero activity limit for this time slice selection, then we add a small epsilon
-            // to the *lower bound* of the balance constraints to force some dispatch.
-            let epsilon = if candidate_assets.iter().any(|a| {
-                a.region_id() == region_id
-                    && a.iter_output_flows()
-                        .any(|flow| &flow.commodity.id == commodity_id)
-                    && a.get_activity_limits_for_selection(&ts_selection).end() > &Activity(0.0)
-            }) {
-                COMMODITY_BALANCE_EPSILON_FOR_CANDIDATES
-            } else {
-                0.0
-            };
+            // Calculate the maximum output this commodity could receive from candidate assets in
+            // this region and time slice selection. This is used to ensure any epsilon we add to
+            // the lower bound is always satisfiable.
+            let max_candidate_output: Flow = candidate_assets
+                .iter()
+                .filter(|a| a.region_id() == region_id)
+                .flat_map(|a| {
+                    a.iter_output_flows()
+                        .filter(|flow| &flow.commodity.id == commodity_id)
+                        .map(|flow| {
+                            flow.coeff * *a.get_activity_limits_for_selection(&ts_selection).end()
+                        })
+                })
+                .sum();
 
-            // For SED commodities, enforce net production >= epsilon, and for SVD commodities
-            // enforce net production >= exogenous demand (with a lower cap of epsilon).
+            // Add a small epsilon to the lower bound to force some dispatch by candidate assets,
+            // so they receive a nonzero shadow price. Capped at the maximum candidate output to
+            // ensure the constraint is always satisfiable.
+            let epsilon = max_candidate_output.min(COMMODITY_BALANCE_EPSILON_FOR_CANDIDATES);
+
+            // For SVD commodities, the lower bound is the exogenous demand (or epsilon if larger).
+            // For SED commodities, the lower bound is just epsilon.
             let min = match commodity.kind {
-                CommodityType::ServiceDemand => commodity.demand
-                    [&(region_id.clone(), year, ts_selection.clone())]
-                    .value()
-                    .max(epsilon),
+                CommodityType::ServiceDemand => {
+                    commodity.demand[&(region_id.clone(), year, ts_selection.clone())].max(epsilon)
+                }
                 _ => epsilon,
             };
 
             // Consume collected terms into a row. `terms.drain(..)` ensures the vector is
             // emptied for the next selection.
-            problem.add_row(min.., terms.drain(..));
+            problem.add_row(min.value().., terms.drain(..));
             keys.push((
                 commodity_id.clone(),
                 region_id.clone(),

--- a/src/simulation/optimisation/constraints.rs
+++ b/src/simulation/optimisation/constraints.rs
@@ -9,9 +9,6 @@ use crate::units::{Flow, UnitType};
 use highs::RowProblem as Problem;
 use indexmap::IndexMap;
 
-/// Small epsilon to add to the commodity balance constraints for candidate assets
-const COMMODITY_BALANCE_EPSILON_FOR_CANDIDATES: Flow = Flow(1e-6);
-
 /// Corresponding variables for a constraint along with the row offset in the solution
 pub struct KeysWithOffset<T> {
     /// Row offset in the solver's row ordering corresponding to the first key in `keys`.
@@ -194,8 +191,8 @@ where
                         })
                 })
                 .sum();
-            let epsilon = if max_candidate_output > COMMODITY_BALANCE_EPSILON_FOR_CANDIDATES {
-                COMMODITY_BALANCE_EPSILON_FOR_CANDIDATES
+            let epsilon = if max_candidate_output > model.parameters.commodity_balance_epsilon {
+                model.parameters.commodity_balance_epsilon
             } else {
                 Flow(0.0)
             };

--- a/src/simulation/optimisation/constraints.rs
+++ b/src/simulation/optimisation/constraints.rs
@@ -179,9 +179,10 @@ where
                 }
             }
 
-            // Calculate the maximum output this commodity could receive from candidate assets in
-            // this region and time slice selection. This is used to ensure any epsilon we add to
-            // the lower bound is always satisfiable.
+            // Add a small epsilon to the lower bound to force some dispatch by candidate assets,
+            // ensuring they receive a nonzero shadow price. Only applied when the total maximum
+            // output from candidates exceeds epsilon, so the balance constraint remains
+            // satisfiable.
             let max_candidate_output: Flow = candidate_assets
                 .iter()
                 .filter(|a| a.region_id() == region_id)
@@ -193,11 +194,11 @@ where
                         })
                 })
                 .sum();
-
-            // Add a small epsilon to the lower bound to force some dispatch by candidate assets,
-            // so they receive a nonzero shadow price. Capped at the maximum candidate output to
-            // ensure the constraint is always satisfiable.
-            let epsilon = max_candidate_output.min(COMMODITY_BALANCE_EPSILON_FOR_CANDIDATES);
+            let epsilon = if max_candidate_output > COMMODITY_BALANCE_EPSILON_FOR_CANDIDATES {
+                COMMODITY_BALANCE_EPSILON_FOR_CANDIDATES
+            } else {
+                Flow(0.0)
+            };
 
             // For SVD commodities, the lower bound is the exogenous demand (or epsilon if larger).
             // For SED commodities, the lower bound is just epsilon.

--- a/src/simulation/optimisation/constraints.rs
+++ b/src/simulation/optimisation/constraints.rs
@@ -182,7 +182,7 @@ where
             // satisfiable.
             let max_candidate_output: Flow = candidate_assets
                 .iter()
-                .filter(|a| a.region_id() == region_id)
+                .filter_region(region_id)
                 .flat_map(|a| {
                     let max_activity = *a.get_activity_limits_for_selection(&ts_selection).end();
                     a.iter_output_flows()

--- a/src/simulation/optimisation/constraints.rs
+++ b/src/simulation/optimisation/constraints.rs
@@ -177,24 +177,14 @@ where
             }
 
             // Add a small epsilon to the lower bound to force some dispatch by candidate assets,
-            // ensuring they receive a nonzero shadow price. Only applied when the total maximum
-            // output from candidates exceeds epsilon, so the balance constraint remains
-            // satisfiable.
-            let max_candidate_output: Flow = candidate_assets
-                .iter()
-                .filter_region(region_id)
-                .flat_map(|a| {
-                    let max_activity = *a.get_activity_limits_for_selection(&ts_selection).end();
-                    a.iter_output_flows()
-                        .filter(|flow| &flow.commodity.id == commodity_id)
-                        .map(move |flow| flow.coeff * max_activity)
-                })
-                .sum();
-            let epsilon = if max_candidate_output > model.parameters.commodity_balance_epsilon {
-                model.parameters.commodity_balance_epsilon
-            } else {
-                Flow(0.0)
-            };
+            // ensuring they receive a nonzero shadow price.
+            let epsilon = candidate_balance_epsilon(
+                candidate_assets,
+                region_id,
+                commodity_id,
+                &ts_selection,
+                model.parameters.commodity_balance_epsilon,
+            );
 
             // For SVD commodities, the lower bound is the exogenous demand (or epsilon if larger).
             // For SED commodities, the lower bound is just epsilon.
@@ -217,6 +207,36 @@ where
     }
 
     CommodityBalanceKeys { offset, keys }
+}
+
+/// Calculate the epsilon to add to the lower bound of a commodity balance constraint, to force
+/// some dispatch by candidate assets so they receive a nonzero shadow price.
+///
+/// Returns `epsilon` if the total maximum output from candidate assets in `region_id` for
+/// `commodity_id` in `ts_selection` exceeds `epsilon`, otherwise returns zero (to avoid making
+/// the balance constraint infeasible).
+fn candidate_balance_epsilon(
+    candidate_assets: &[AssetRef],
+    region_id: &RegionID,
+    commodity_id: &CommodityID,
+    ts_selection: &TimeSliceSelection,
+    epsilon: Flow,
+) -> Flow {
+    let max_candidate_output: Flow = candidate_assets
+        .iter()
+        .filter_region(region_id)
+        .flat_map(|a| {
+            let max_activity = *a.get_activity_limits_for_selection(ts_selection).end();
+            a.iter_output_flows()
+                .filter(|flow| &flow.commodity.id == commodity_id)
+                .map(move |flow| flow.coeff * max_activity)
+        })
+        .sum();
+    if max_candidate_output > epsilon {
+        epsilon
+    } else {
+        Flow(0.0)
+    }
 }
 
 /// Add constraints on the activity of different assets.

--- a/src/simulation/optimisation/constraints.rs
+++ b/src/simulation/optimisation/constraints.rs
@@ -329,3 +329,53 @@ where
 
     ActivityKeys { offset, keys }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::commodity::Commodity;
+    use crate::fixture::{asset, process, process_flows_map, svd_commodity};
+    use crate::process::Process;
+    use crate::process::{FlowType, ProcessFlow};
+    use crate::time_slice::TimeSliceSelection;
+    use crate::units::{FlowPerActivity, MoneyPerFlow};
+    use indexmap::indexmap;
+    use rstest::rstest;
+    use std::rc::Rc;
+
+    #[rstest]
+    // Max candidate output (2.0) < epsilon (10.0) → zero (guard prevents infeasibility)
+    #[case(10.0, 0.0)]
+    // Max candidate output (2.0) > epsilon (1.0) → epsilon returned
+    #[case(1.0, 1.0)]
+    fn candidate_balance_epsilon_works(
+        #[case] epsilon: f64,
+        #[case] expected: f64,
+        svd_commodity: Commodity,
+        mut process: Process,
+    ) {
+        let commodity_rc = Rc::new(svd_commodity);
+
+        // Add an output flow for the commodity to the process. With capacity 2.0, cap2act 1.0,
+        // and full availability over a single annual time slice, max_candidate_output = 2.0.
+        let flow = ProcessFlow {
+            commodity: Rc::clone(&commodity_rc),
+            coeff: FlowPerActivity(1.0),
+            kind: FlowType::Fixed,
+            cost: MoneyPerFlow(0.0),
+        };
+        process.flows = process_flows_map(
+            process.regions.clone(),
+            Rc::new(indexmap! { commodity_rc.id.clone() => flow }),
+        );
+
+        let result = candidate_balance_epsilon(
+            &[AssetRef::from(asset(process))],
+            &"GBR".into(),
+            &commodity_rc.id,
+            &TimeSliceSelection::Annual,
+            Flow(epsilon),
+        );
+        assert_eq!(result, Flow(expected));
+    }
+}

--- a/src/simulation/optimisation/constraints.rs
+++ b/src/simulation/optimisation/constraints.rs
@@ -184,11 +184,10 @@ where
                 .iter()
                 .filter(|a| a.region_id() == region_id)
                 .flat_map(|a| {
+                    let max_activity = *a.get_activity_limits_for_selection(&ts_selection).end();
                     a.iter_output_flows()
                         .filter(|flow| &flow.commodity.id == commodity_id)
-                        .map(|flow| {
-                            flow.coeff * *a.get_activity_limits_for_selection(&ts_selection).end()
-                        })
+                        .map(move |flow| flow.coeff * max_activity)
                 })
                 .sum();
             let epsilon = if max_candidate_output > model.parameters.commodity_balance_epsilon {


### PR DESCRIPTION
# Description

This is a follow on from #1387 to fix some issues:
- There was a potential pitfall for models with low activity coefficients, as the epsilon was added so long as activity > 0, but if activity is low then max production by the candidates may be lower than epsilon, in which case dispatch could fail. I've fixed this by calculating the max potential activity from candidates, and only applying the epsilon if this value exceeds epsilon. This was causing the issue in #1401. This does now mean that we get a shadow price of zero for `RSHEAT` in summer, but better that than the model failing.
- I've also made `commodity_balance_epsilon` a configurable model parameter, rather than a hardcoded constant. It also uses the `Flow` type rather than `f64`.

Fixes #1401 

## Type of change

- [ ] Bug fix (non-breaking change to fix an issue)
- [ ] New feature (non-breaking change to add functionality)
- [ ] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [ ] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`
- [ ] Update release notes for the latest release if this PR adds a new feature or fixes a bug
      present in the previous release

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
