### PR TITLE
Invert insertion/deletion reporting in diff

### DIFF
--- a/tests/regression.rs
+++ b/tests/regression.rs
@@ -85,7 +85,7 @@ fn compare_output_dirs(cur_output_dir1: &Path, test_data_dir: &Path, debug_model
 
     let mut errors = Vec::new();
     for file_name in file_names1 {
-        if let Some(diff) = diff_csv_file(cur_output_dir1, test_data_dir, &file_name) {
+        if let Some(diff) = diff_csv_file(test_data_dir, cur_output_dir1, &file_name) {
             errors.push(format!("{file_name}: output differs\n{diff}"));
         }
     }

--- a/tests/regression.rs
+++ b/tests/regression.rs
@@ -97,11 +97,11 @@ fn compare_output_dirs(cur_output_dir1: &Path, test_data_dir: &Path, debug_model
     );
 }
 
-fn diff_csv_file(output_dir1: &Path, output_dir2: &Path, file_name: &str) -> Option<String> {
-    let lines1 = read_lines(&output_dir1.join(file_name));
-    let lines2 = read_lines(&output_dir2.join(file_name));
+fn diff_csv_file(old_output_dir: &Path, new_output_dir: &Path, file_name: &str) -> Option<String> {
+    let old_lines = read_lines(&old_output_dir.join(file_name));
+    let new_lines = read_lines(&new_output_dir.join(file_name));
 
-    compute_normalised_diff(&lines1, &lines2)
+    compute_normalised_diff(&old_lines, &new_lines)
 }
 
 /// Compute a line diff after replacing tolerance-equivalent rows with a shared canonical row.


### PR DESCRIPTION
# Description

This PR reverses the reporting of inserted/deleted lines in failed regression tests, so that diffs are reported relative to the reference data, rather than to the result produced in the test.

Fixes #1447 

## Type of change

- [X] Bug fix (non-breaking change to fix an issue)
- [ ] New feature (non-breaking change to add functionality)
- [ ] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [X] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`
- [ ] Update release notes for the latest release if this PR adds a new feature or fixes a bug
      present in the previous release

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [X] Tests added that prove fix is effective or that feature works
