### PR TITLE
Allow for mothballing part of a divisible asset and remove `AssetState::Parent`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,12 +44,12 @@ dirs = "6.0.0"
 edit = "0.1.5"
 erased-serde = "0.4.10"
 context_manager = "0.1.3"
+map-macro = "0.3.0"
 
 [dev-dependencies]
 assert_cmd = "2.2.2"
 colored = "3.0.0"
 logtest = "2.0.0"
-map-macro = "0.3.0"
 ordered-float = "5.1.0"
 rstest = {version = "0.26.1", default-features = false, features = ["crate-name"]}
 similar = "3.1.0"

--- a/src/asset.rs
+++ b/src/asset.rs
@@ -711,15 +711,8 @@ impl Asset {
         self.capacity.set(capacity);
     }
 
-    /// Increase the capacity for this asset (only for Candidate and Parent assets)
+    /// Increase the capacity for this asset
     pub fn increase_capacity(&mut self, capacity: AssetCapacity) {
-        assert!(
-            matches!(
-                self.state,
-                AssetState::Candidate | AssetState::Parent { .. }
-            ),
-            "increase_capacity can only be called on Candidate or Parent assets"
-        );
         assert!(
             capacity.total_capacity() > Capacity(0.0),
             "Capacity increase must be positive"

--- a/src/asset.rs
+++ b/src/asset.rs
@@ -746,10 +746,12 @@ impl Asset {
         let AssetCapacity::Discrete(n_units, unit_size) = self.capacity() else {
             panic!("Cannot decrement unit count of non-divisible asset");
         };
-        assert!(n_units > 0, "Unit count has dropped below zero");
 
+        let new_n_units = n_units
+            .checked_sub(1)
+            .expect("Unit count has dropped below zero");
         self.capacity
-            .set(AssetCapacity::Discrete(n_units - 1, unit_size));
+            .set(AssetCapacity::Discrete(new_n_units, unit_size));
     }
 
     /// Commission the asset.

--- a/src/asset.rs
+++ b/src/asset.rs
@@ -674,16 +674,6 @@ impl Asset {
         matches!(self.state, AssetState::Parent { .. })
     }
 
-    /// Get the number of children this asset has.
-    ///
-    /// If this asset is not a parent, then `None` is returned.
-    pub fn num_children(&self) -> Option<u32> {
-        match &self.state {
-            AssetState::Parent { .. } => Some(self.capacity().n_units().unwrap()),
-            _ => None,
-        }
-    }
-
     /// Get the agent ID for this asset, if any
     pub fn agent_id(&self) -> Option<&AgentID> {
         match &self.state {
@@ -1495,7 +1485,7 @@ mod tests {
             partial_parent.capacity(),
             AssetCapacity::Discrete(num_units, Capacity(4.0))
         );
-        assert_eq!(partial_parent.num_children(), Some(num_units));
+        assert_eq!(partial_parent.capacity().n_units(), Some(num_units));
         assert_eq!(partial_parent.id(), parent.id());
         assert_eq!(partial_parent.agent_id(), parent.agent_id());
         assert_eq!(Rc::ptr_eq(&partial_parent.0, &parent.0), expect_same_asset);

--- a/src/asset.rs
+++ b/src/asset.rs
@@ -674,6 +674,11 @@ impl Asset {
         matches!(self.state, AssetState::Parent { .. })
     }
 
+    /// Whether this asset is divisible
+    pub fn is_divisible(&self) -> bool {
+        matches!(self.capacity.get(), AssetCapacity::Discrete { .. })
+    }
+
     /// Get the agent ID for this asset, if any
     pub fn agent_id(&self) -> Option<&AgentID> {
         match &self.state {

--- a/src/asset.rs
+++ b/src/asset.rs
@@ -752,28 +752,6 @@ impl Asset {
             .set(AssetCapacity::Discrete(n_units - 1, unit_size));
     }
 
-    /// Decommission this asset
-    fn decommission(&mut self, reason: &str) {
-        let (id, agent_id, kind) = match &self.state {
-            AssetState::Commissioned {
-                id, agent_id, kind, ..
-            } => (*id, agent_id.clone(), kind),
-            _ => panic!("Cannot decommission an asset that hasn't been commissioned"),
-        };
-        debug!(
-            "Decommissioning '{}' asset (ID: {}) for agent '{}' (reason: {})",
-            self.process_id(),
-            id,
-            agent_id,
-            reason
-        );
-
-        // If this is a child asset, we need to decrease the parent's capacity appropriately
-        if let CommissionedType::Child { parent } = kind {
-            parent.decrement_unit_count();
-        }
-    }
-
     /// Commission the asset.
     ///
     /// Only assets with an [`AssetState`] of `Ready` can be commissioned. If the asset's state is
@@ -1108,6 +1086,28 @@ impl AssetRef {
             capacity: Cell::new(AssetCapacity::Discrete(num_units, unit_size)),
             ..Rc::unwrap_or_clone(self.0)
         })
+    }
+
+    /// Decommission this asset
+    fn decommission(self, reason: &str) {
+        let (id, agent_id, kind) = match &self.state {
+            AssetState::Commissioned {
+                id, agent_id, kind, ..
+            } => (*id, agent_id.clone(), kind),
+            _ => panic!("Cannot decommission an asset that hasn't been commissioned"),
+        };
+        debug!(
+            "Decommissioning '{}' asset (ID: {}) for agent '{}' (reason: {})",
+            self.process_id(),
+            id,
+            agent_id,
+            reason
+        );
+
+        // If this is a child asset, we need to decrease the parent's capacity appropriately
+        if let CommissionedType::Child { parent } = kind {
+            parent.decrement_unit_count();
+        }
     }
 }
 

--- a/src/asset.rs
+++ b/src/asset.rs
@@ -15,9 +15,11 @@ use crate::units::{
 use anyhow::{Context, Result, ensure};
 use indexmap::IndexMap;
 use log::debug;
+use map_macro::vec_deque;
 use serde::{Deserialize, Serialize};
 use std::cell::Cell;
 use std::cmp::Ordering;
+use std::collections::VecDeque;
 use std::hash::{Hash, Hasher};
 use std::iter;
 use std::ops::RangeInclusive;
@@ -43,6 +45,13 @@ pub use pool::AssetPool;
     Serialize,
 )]
 pub struct AssetID(u32);
+
+/// Indicates the year and number of units mothballed
+#[derive(PartialEq, Debug, Clone)]
+pub struct MothballEvent {
+    year: u32,
+    num_units: u32,
+}
 
 /// The type of commissioned asset
 #[derive(PartialEq, Debug, Clone)]
@@ -75,8 +84,11 @@ pub enum AssetState {
         id: AssetID,
         /// The ID of the agent that owns the asset
         agent_id: AgentID,
-        /// Year in which the asset was mothballed. None, if it is not mothballed
-        mothballed_year: Option<u32>,
+        /// Years in which all of some of the asset was mothballed.
+        ///
+        /// Invariants: This **must** be sorted by year with older years first and the total number
+        /// of units must not exceed the total for this asset.
+        mothball_events: VecDeque<MothballEvent>,
         /// The type of commissioned asset (non-divisible, parent or child)
         kind: CommissionedType,
     },
@@ -207,7 +219,7 @@ impl Asset {
             AssetState::Commissioned {
                 id: AssetID(0),
                 agent_id,
-                mothballed_year: None,
+                mothball_events: vec_deque![],
                 kind: CommissionedType::NonDivisible,
             },
             process,
@@ -706,17 +718,19 @@ impl Asset {
         self.capacity().total_capacity()
     }
 
-    /// Set the capacity for this asset (only for Candidate or Ready assets)
+    /// Set the capacity of this asset.
+    ///
+    /// Note that this should be done with care!
     pub fn set_capacity(&mut self, capacity: AssetCapacity) {
-        assert!(
-            matches!(self.state, AssetState::Candidate | AssetState::Ready { .. }),
-            "set_capacity can only be called on Candidate or Ready assets"
-        );
         assert!(
             capacity.total_capacity() >= Capacity(0.0),
             "Capacity must be >= 0"
         );
         self.capacity().assert_same_type(capacity);
+        assert!(
+            self.get_num_mothballed_units() <= capacity.n_units().unwrap_or(1),
+            "Cannot set capacity to a smaller number of units than are currently mothballed"
+        );
 
         // As `capacity` is a `Cell`, we don't actually need a `mut` ref to `self`, but allowing for
         // changing the capacity of immutable refs would be potentially dangerous
@@ -746,6 +760,10 @@ impl Asset {
         let AssetCapacity::Discrete(n_units, unit_size) = self.capacity() else {
             panic!("Cannot decrement unit count of non-divisible asset");
         };
+        assert!(
+            !self.has_any_mothballed_units(),
+            "Cannot decrement unit count of asset with mothballed units"
+        );
 
         let new_n_units = n_units
             .checked_sub(1)
@@ -782,7 +800,7 @@ impl Asset {
         self.state = AssetState::Commissioned {
             id,
             agent_id: agent_id.clone(),
-            mothballed_year: None,
+            mothball_events: vec_deque![],
             kind,
         };
     }
@@ -800,57 +818,54 @@ impl Asset {
         };
     }
 
-    /// Set the year this asset was mothballed
-    pub fn mothball(&mut self, year: u32) {
-        let (id, agent_id, kind) = match &self.state {
-            AssetState::Commissioned {
-                id, agent_id, kind, ..
-            } => (*id, agent_id.clone(), kind.clone()),
-            _ => panic!("Cannot mothball an asset that hasn't been commissioned"),
-        };
-        self.state = AssetState::Commissioned {
-            id,
-            agent_id,
-            mothballed_year: Some(year),
-            kind,
-        };
-    }
-
-    /// Remove the mothballed year - presumably because the asset has been used
-    pub fn unmothball(&mut self) {
-        let (id, agent_id, kind) = match &self.state {
-            AssetState::Commissioned {
-                id, agent_id, kind, ..
-            } => (*id, agent_id.clone(), kind.clone()),
-            _ => panic!("Cannot unmothball an asset that hasn't been commissioned"),
-        };
-        self.state = AssetState::Commissioned {
-            id,
-            agent_id,
-            mothballed_year: None,
-            kind,
-        };
-    }
-
-    /// Get the mothballed year for the asset
-    pub fn get_mothballed_year(&self) -> Option<u32> {
+    /// Get the mothball events for this asset, if commissioned
+    fn get_mothball_events(&self) -> Option<&VecDeque<MothballEvent>> {
         match &self.state {
             AssetState::Commissioned {
-                mothballed_year, ..
-            } => *mothballed_year,
+                mothball_events, ..
+            } => Some(mothball_events),
             _ => None,
         }
     }
 
-    /// Whether this asset is currently mothballed
-    pub fn is_mothballed(&self) -> bool {
-        self.get_mothballed_year().is_some()
+    /// Get the mothball events (mutably) for this asset, if commissioned
+    fn get_mothball_events_mut(&mut self) -> Option<&mut VecDeque<MothballEvent>> {
+        match &mut self.state {
+            AssetState::Commissioned {
+                mothball_events, ..
+            } => Some(mothball_events),
+            _ => None,
+        }
+    }
+
+    /// Whether this asset has any units mothballed
+    pub fn has_any_mothballed_units(&self) -> bool {
+        self.get_mothball_events()
+            .is_some_and(|events| !events.is_empty())
+    }
+
+    /// Get the number of units which are mothballed.
+    ///
+    /// For non-commissioned assets, this always returns zero.
+    pub fn get_num_mothballed_units(&self) -> u32 {
+        let Some(events) = self.get_mothball_events() else {
+            return 0;
+        };
+
+        events.iter().map(|event| event.num_units).sum()
+    }
+
+    /// Get the remaining number of units that are not mothballed.
+    ///
+    /// For non-commissioned assets, this always returns the total number of units.
+    pub fn get_num_nonmothballed_units(&self) -> u32 {
+        self.num_units() - self.get_num_mothballed_units()
     }
 
     /// The number of units this asset represents
     ///
     /// If divisible, returns the total number of units, otherwise returns one.
-    fn num_units(&self) -> u32 {
+    pub fn num_units(&self) -> u32 {
         self.capacity().n_units().unwrap_or(1)
     }
 
@@ -977,6 +992,23 @@ pub fn check_capacity_valid_for_asset(capacity: Capacity) -> Result<()> {
     Ok(())
 }
 
+/// Log that the specified number of units has been decommissioned for the given asset
+fn log_decommissioning(asset: &Asset, num_units: u32, reason: &str) {
+    let (id, agent_id) = match &asset.state {
+        AssetState::Commissioned { id, agent_id, .. } => (*id, agent_id.clone()),
+        _ => panic!("Cannot decommission an asset that hasn't been commissioned"),
+    };
+    debug!(
+        "Decommissioning {}/{} units of '{}' asset (ID: {}) for agent '{}' (reason: {})",
+        num_units,
+        asset.num_units(),
+        asset.process_id(),
+        id,
+        agent_id,
+        reason
+    );
+}
+
 /// A wrapper containing a reference-counted [`Asset`].
 ///
 /// [`AssetRef`] implements equality, ordering, and hashing using an [`AssetID`], if available, but
@@ -1046,7 +1078,7 @@ impl AssetRef {
         self.make_mut().state = AssetState::Commissioned {
             id: AssetID(*next_id),
             agent_id,
-            mothballed_year: None,
+            mothball_events: vec_deque![],
             kind: CommissionedType::Parent,
         };
         *next_id += 1;
@@ -1059,17 +1091,20 @@ impl AssetRef {
 
     /// Get an [`AssetRef`] representing a subset of this asset's units.
     ///
-    /// For non-divisible assets, `num_units` must be one.
+    /// For non-divisible assets, `new_num_units` must be one. If some of the asset's units are
+    /// mothballed, these are discarded before non-mothballed units. For example, if an asset has
+    /// seven units of which four are mothballed and we are reducing the number of units to four,
+    /// the new asset will have one mothballed unit.
     ///
     /// # Panics
     ///
-    /// Panics if `num_units` is zero or exceeds the total capacity of this asset.
-    pub fn with_subset_of_units(self, num_units: u32) -> Self {
-        if num_units == self.num_units() {
+    /// Panics if `new_num_units` is zero or exceeds the total capacity of this asset.
+    pub fn with_subset_of_units(self, new_num_units: u32) -> Self {
+        if new_num_units == self.num_units() {
             return self;
         }
 
-        assert!(num_units > 0, "Cannot make an asset with zero units");
+        assert!(new_num_units > 0, "Cannot make an asset with zero units");
 
         let (max_num_units, unit_size) = match self.capacity() {
             AssetCapacity::Discrete(max_num_units, unit_size) => (max_num_units, unit_size),
@@ -1079,37 +1114,143 @@ impl AssetRef {
         };
 
         assert!(
-            num_units <= max_num_units,
+            new_num_units <= max_num_units,
             "Cannot make an asset with more units than original"
         );
 
-        // Make a new Asset with fewer units
-        Self::from(Asset {
-            capacity: Cell::new(AssetCapacity::Discrete(num_units, unit_size)),
-            ..Rc::unwrap_or_clone(self.0)
-        })
+        // Make a new Asset with fewer units. If there are more mothballed units than the new asset
+        // will have, we reduce this number to avoid there being more mothballed units than the new
+        // asset has, which would be a logic error. We discard mothballed before non-mothballed
+        // units.
+        let new_num_mothballed = new_num_units.saturating_sub(self.get_num_nonmothballed_units());
+        let mut asset = self.with_mothballed_units(new_num_mothballed, None);
+        asset
+            .make_mut()
+            .set_capacity(AssetCapacity::Discrete(new_num_units, unit_size));
+        asset
     }
 
     /// Decommission this asset
     fn decommission(self, reason: &str) {
-        let (id, agent_id, kind) = match &self.state {
-            AssetState::Commissioned {
-                id, agent_id, kind, ..
-            } => (*id, agent_id.clone(), kind),
-            _ => panic!("Cannot decommission an asset that hasn't been commissioned"),
-        };
-        debug!(
-            "Decommissioning '{}' asset (ID: {}) for agent '{}' (reason: {})",
-            self.process_id(),
-            id,
-            agent_id,
-            reason
-        );
+        log_decommissioning(&self, self.num_units(), reason);
 
         // If this is a child asset, we need to decrease the parent's capacity appropriately
-        if let CommissionedType::Child { parent } = kind {
+        if let Some(parent) = self.parent() {
             parent.decrement_unit_count();
         }
+    }
+
+    /// Decommission any units that were mothballed at least `mothball_years` ago.
+    ///
+    /// If the asset still has some units remaining, it is returned, else None.
+    fn with_decommission_mothballed(self, year: u32, mothball_years: u32) -> Option<Self> {
+        let events = self
+            .get_mothball_events()
+            .expect("Can only decommission mothballed units in commissioned assets");
+
+        // Mothball events are ordered oldest-first, so this sums the units mothballed longest ago
+        let units_to_remove: u32 = events
+            .iter()
+            .take_while(|event| event.year <= year.saturating_sub(mothball_years))
+            .map(|event| event.num_units)
+            .sum();
+        if units_to_remove == 0 {
+            // Nothing to do. Return self unmodified.
+            return Some(self);
+        }
+
+        let reason = format!(
+            "The asset has not been used for the set mothball years ({mothball_years} years)."
+        );
+        let new_num_units = self.num_units() - units_to_remove;
+        if new_num_units == 0 {
+            self.decommission(&reason);
+            return None;
+        }
+
+        // `with_subset_of_units` discards the oldest mothballed units first, which are exactly the
+        // ones being decommissioned here.
+        log_decommissioning(&self, units_to_remove, &reason);
+        Some(self.with_subset_of_units(new_num_units))
+    }
+
+    /// Return a new [`AssetRef`] with the specified number of units mothballed.
+    ///
+    /// If `num_units` equals the number of already mothballed units, the original asset is
+    /// returned. If additional units may be mothballed, a value must be provided for `year`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if attempting to mothball more units than the asset represents or if attempting to
+    /// change the number of mothballed units for a non-commissioned asset.
+    pub fn with_mothballed_units(mut self, num_units: u32, year: Option<u32>) -> Self {
+        if num_units == 0 {
+            // Small optimisation
+            return self.with_unmothball_all();
+        }
+
+        let num_already_mothballed = self.get_num_mothballed_units();
+        if num_units == num_already_mothballed {
+            // Nothing to do. Return self unmodified.
+            return self;
+        }
+
+        assert!(
+            num_units <= self.num_units(),
+            "Cannot mothball more units than asset represents"
+        );
+
+        // Now that we know we have to modify self, call make_mut().
+        let events = self.make_mut().get_mothball_events_mut().expect(
+            "Cannot change number of mothballed units for an asset that hasn't been commissioned",
+        );
+        if num_units < num_already_mothballed {
+            // Remove mothballing events until only required num of mothballed units remains,
+            // starting with oldest
+            let mut remaining = num_already_mothballed - num_units;
+            while remaining > 0
+                && let Some(event) = events.front_mut()
+            {
+                let to_remove = event.num_units.min(remaining);
+                event.num_units -= to_remove;
+                remaining -= to_remove;
+                if event.num_units == 0 {
+                    events.pop_front();
+                }
+            }
+        } else {
+            let year =
+                year.expect("Cannot increase number of mothballed units without supplying year");
+
+            if let Some(event) = events.back() {
+                // Need to check this as adding events in the past breaks the expected invariant for
+                // `mothball_events`
+                assert!(
+                    event.year <= year,
+                    "Attempting to mothball units in a year in the past"
+                );
+            }
+
+            // Mothball extra units in specified year
+            events.push_back(MothballEvent {
+                year,
+                num_units: num_units - num_already_mothballed,
+            });
+        }
+
+        self
+    }
+
+    /// Returns a new [`AssetRef`] with no mothballed units.
+    ///
+    /// If the asset has no mothballed units, the original asset is returned.
+    pub fn with_unmothball_all(mut self) -> Self {
+        if self.has_any_mothballed_units() {
+            // Only commissioned assets can have mothballed units, so this is safe
+            self.make_mut().get_mothball_events_mut().unwrap().clear();
+        }
+
+        self
     }
 }
 
@@ -1243,6 +1384,7 @@ mod tests {
     };
     use float_cmp::assert_approx_eq;
     use indexmap::indexmap;
+    use itertools::assert_equal;
     use rstest::{fixture, rstest};
     use std::rc::Rc;
 
@@ -1617,5 +1759,213 @@ mod tests {
         // commodity_portion = 0.5 -> limit = 3 * 0.5 = 1.5
         let result = asset.max_installable_capacity(Dimensionless(0.5));
         assert_eq!(result, Some(AssetCapacity::Continuous(Capacity(1.5))));
+    }
+
+    #[rstest]
+    #[case::none(0)]
+    #[case::some(2)]
+    #[case::all(3)]
+    fn mothball_unit_counts(parent_asset: AssetRef, #[case] num_mothballed: u32) {
+        // `parent_asset` is a commissioned parent with 3 units
+        let asset = parent_asset.with_mothballed_units(num_mothballed, Some(2020));
+        assert_eq!(asset.get_num_mothballed_units(), num_mothballed);
+        assert_eq!(asset.get_num_nonmothballed_units(), 3 - num_mothballed);
+        assert_eq!(asset.has_any_mothballed_units(), num_mothballed > 0);
+    }
+
+    #[rstest]
+    fn mothball_counts_non_commissioned(asset: Asset, process: Process) {
+        // Non-commissioned assets never have mothballed units, regardless of state
+        let ready = AssetRef::from(asset);
+        let candidate = AssetRef::from(
+            Asset::new_candidate(process.into(), "GBR".into(), Capacity(1.0), 2020).unwrap(),
+        );
+        for asset in [ready, candidate] {
+            assert!(!asset.has_any_mothballed_units());
+            assert_eq!(asset.get_num_mothballed_units(), 0);
+            assert_eq!(asset.get_num_nonmothballed_units(), asset.num_units());
+        }
+    }
+
+    #[rstest]
+    fn with_mothballed_units_accumulates_events(parent_asset: AssetRef) {
+        // Mothball one unit in 2020
+        let asset = parent_asset.with_mothballed_units(1, Some(2020));
+        assert_equal(
+            asset.get_mothball_events().unwrap().iter(),
+            &[MothballEvent {
+                year: 2020,
+                num_units: 1,
+            }],
+        );
+
+        // Mothball a second unit in 2022: events are retained in chronological order
+        let asset = asset.with_mothballed_units(2, Some(2022));
+        assert_equal(
+            asset.get_mothball_events().unwrap().iter(),
+            &[
+                MothballEvent {
+                    year: 2020,
+                    num_units: 1,
+                },
+                MothballEvent {
+                    year: 2022,
+                    num_units: 1,
+                },
+            ],
+        );
+    }
+
+    #[rstest]
+    fn with_mothballed_units_decrease_removes_oldest_first(parent_asset: AssetRef) {
+        // Mothball 1 unit in 2020, then 2 more (3 total) in 2022
+        let asset = parent_asset
+            .with_mothballed_units(1, Some(2020))
+            .with_mothballed_units(3, Some(2022));
+        assert_equal(
+            asset.get_mothball_events().unwrap().iter(),
+            &[
+                MothballEvent {
+                    year: 2020,
+                    num_units: 1,
+                },
+                MothballEvent {
+                    year: 2022,
+                    num_units: 2,
+                },
+            ],
+        );
+
+        // Reduce to a single mothballed unit: the oldest event is fully removed and the newer
+        // event is partially reduced, leaving exactly one mothballed unit
+        let asset = asset.with_mothballed_units(1, None);
+        assert_eq!(asset.get_num_mothballed_units(), 1);
+        assert_equal(
+            asset.get_mothball_events().unwrap().iter(),
+            &[MothballEvent {
+                year: 2022,
+                num_units: 1,
+            }],
+        );
+    }
+
+    #[rstest]
+    fn with_mothballed_units_noop_returns_same_rc(parent_asset: AssetRef) {
+        let asset = parent_asset.with_mothballed_units(2, Some(2020));
+        // Requesting the same number of mothballed units is a no-op (the year is ignored)
+        let same = asset.clone().with_mothballed_units(2, Some(2099));
+        assert!(Rc::ptr_eq(&asset.0, &same.0));
+    }
+
+    #[rstest]
+    fn with_mothballed_units_zero_unmothballs(parent_asset: AssetRef) {
+        let asset = parent_asset.with_mothballed_units(2, Some(2020));
+        assert!(asset.has_any_mothballed_units());
+
+        let asset = asset.with_mothballed_units(0, None);
+        assert!(!asset.has_any_mothballed_units());
+        assert_eq!(asset.get_num_mothballed_units(), 0);
+    }
+
+    #[rstest]
+    #[should_panic(expected = "Cannot mothball more units than asset represents")]
+    fn with_mothballed_units_panics_for_too_many_units(parent_asset: AssetRef) {
+        parent_asset.with_mothballed_units(4, Some(2020));
+    }
+
+    #[rstest]
+    #[should_panic(
+        expected = "Cannot change number of mothballed units for an asset that hasn't been commissioned"
+    )]
+    fn with_mothballed_units_panics_for_non_commissioned(asset: Asset) {
+        AssetRef::from(asset).with_mothballed_units(1, Some(2020));
+    }
+
+    #[rstest]
+    #[should_panic(expected = "Cannot increase number of mothballed units without supplying year")]
+    fn with_mothballed_units_panics_when_increasing_without_year(parent_asset: AssetRef) {
+        parent_asset.with_mothballed_units(1, None);
+    }
+
+    #[rstest]
+    #[should_panic(expected = "Attempting to mothball units in a year in the past")]
+    fn with_mothballed_units_panics_when_mothballing_in_the_past(parent_asset: AssetRef) {
+        // Mothball a unit in 2020, then attempt to mothball another in an earlier year, which would
+        // break the chronological ordering invariant of the mothball events
+        parent_asset
+            .with_mothballed_units(1, Some(2020))
+            .with_mothballed_units(2, Some(2019));
+    }
+
+    #[rstest]
+    fn with_unmothball_all_clears_events(parent_asset: AssetRef) {
+        let asset = parent_asset.with_mothballed_units(2, Some(2020));
+        let asset = asset.with_unmothball_all();
+        assert!(!asset.has_any_mothballed_units());
+        assert_eq!(asset.get_num_mothballed_units(), 0);
+    }
+
+    #[rstest]
+    fn with_unmothball_all_noop_returns_same_rc(parent_asset: AssetRef) {
+        // `parent_asset` has no mothballed units, so the original Rc is returned unchanged
+        let same = parent_asset.clone().with_unmothball_all();
+        assert!(Rc::ptr_eq(&parent_asset.0, &same.0));
+    }
+
+    #[rstest]
+    fn with_subset_of_units_caps_mothballed(parent_asset: AssetRef) {
+        // Mothball all 3 units
+        let asset = parent_asset.with_mothballed_units(3, Some(2020));
+        assert_eq!(asset.get_num_mothballed_units(), 3);
+
+        // Taking a subset of 2 units caps the mothballed count at the new number of units
+        let subset = asset.with_subset_of_units(2);
+        assert_eq!(subset.num_units(), 2);
+        assert_eq!(subset.get_num_mothballed_units(), 2);
+    }
+
+    #[rstest]
+    #[should_panic(expected = "Cannot decrement unit count of asset with mothballed units")]
+    fn decrement_unit_count_panics_with_mothballed(parent_asset: AssetRef) {
+        let asset = parent_asset.with_mothballed_units(1, Some(2020));
+        asset.decrement_unit_count();
+    }
+
+    #[rstest]
+    fn with_decommission_mothballed_nothing_old_enough(parent_asset: AssetRef) {
+        let asset = parent_asset.with_mothballed_units(1, Some(2020));
+        // Threshold is 2005, so the 2020 event is not old enough: the asset is returned unchanged
+        let result = asset
+            .clone()
+            .with_decommission_mothballed(2025, 20)
+            .unwrap();
+        assert!(Rc::ptr_eq(&asset.0, &result.0));
+    }
+
+    #[rstest]
+    fn with_decommission_mothballed_partial(parent_asset: AssetRef) {
+        // Mothball 1 unit in 2010 and 1 unit in 2020 (leaving 1 unit active)
+        let asset = parent_asset
+            .with_mothballed_units(1, Some(2010))
+            .with_mothballed_units(2, Some(2020));
+
+        // With a threshold of 2015, only the 2010 event is old enough to decommission
+        let result = asset.with_decommission_mothballed(2025, 10).unwrap();
+        assert_eq!(result.num_units(), 2);
+        assert_eq!(result.get_num_mothballed_units(), 1);
+        assert_equal(
+            result.get_mothball_events().unwrap().iter(),
+            &[MothballEvent {
+                year: 2020,
+                num_units: 1,
+            }],
+        );
+    }
+
+    #[rstest]
+    fn with_decommission_mothballed_all(parent_asset: AssetRef) {
+        // All units mothballed long enough ago: the whole asset is decommissioned
+        let asset = parent_asset.with_mothballed_units(3, Some(2010));
+        assert!(asset.with_decommission_mothballed(2025, 10).is_none());
     }
 }

--- a/src/asset.rs
+++ b/src/asset.rs
@@ -1186,7 +1186,7 @@ impl AssetRef {
     pub fn with_mothballed_units(mut self, num_units: u32, year: Option<u32>) -> Self {
         if num_units == 0 {
             // Small optimisation
-            return self.with_unmothball_all();
+            return self.with_no_mothballed_units();
         }
 
         let num_already_mothballed = self.get_num_mothballed_units();
@@ -1244,7 +1244,7 @@ impl AssetRef {
     /// Returns a new [`AssetRef`] with no mothballed units.
     ///
     /// If the asset has no mothballed units, the original asset is returned.
-    pub fn with_unmothball_all(mut self) -> Self {
+    pub fn with_no_mothballed_units(mut self) -> Self {
         if self.has_any_mothballed_units() {
             // Only commissioned assets can have mothballed units, so this is safe
             self.make_mut().get_mothball_events_mut().unwrap().clear();
@@ -1898,17 +1898,17 @@ mod tests {
     }
 
     #[rstest]
-    fn with_unmothball_all_clears_events(parent_asset: AssetRef) {
+    fn with_no_mothballed_units_clears_events(parent_asset: AssetRef) {
         let asset = parent_asset.with_mothballed_units(2, Some(2020));
-        let asset = asset.with_unmothball_all();
+        let asset = asset.with_no_mothballed_units();
         assert!(!asset.has_any_mothballed_units());
         assert_eq!(asset.get_num_mothballed_units(), 0);
     }
 
     #[rstest]
-    fn with_unmothball_all_noop_returns_same_rc(parent_asset: AssetRef) {
+    fn with_no_mothballed_units_noop_returns_same_rc(parent_asset: AssetRef) {
         // `parent_asset` has no mothballed units, so the original Rc is returned unchanged
-        let same = parent_asset.clone().with_unmothball_all();
+        let same = parent_asset.clone().with_no_mothballed_units();
         assert!(Rc::ptr_eq(&parent_asset.0, &same.0));
     }
 

--- a/src/asset.rs
+++ b/src/asset.rs
@@ -867,6 +867,13 @@ impl Asset {
         self.get_mothballed_year().is_some()
     }
 
+    /// The number of units this asset represents
+    ///
+    /// If divisible, returns the total number of units, otherwise returns one.
+    fn num_units(&self) -> u32 {
+        self.capacity().n_units().unwrap_or(1)
+    }
+
     /// Get the unit size for this asset's capacity (if any)
     pub fn unit_size(&self) -> Option<Capacity> {
         match self.capacity() {
@@ -1070,39 +1077,37 @@ impl AssetRef {
         }
     }
 
-    /// Get an [`AssetRef`] representing a subset of this parent's children.
+    /// Get an [`AssetRef`] representing a subset of this asset's units.
+    ///
+    /// For non-divisible assets, `num_units` must be one.
     ///
     /// # Panics
     ///
-    /// Panics if this asset is not a parent asset or `num_units` is zero or exceeds the total
-    /// capacity of this asset.
-    pub fn make_partial_parent(&self, num_units: u32) -> Self {
-        assert!(
-            self.is_parent(),
-            "Cannot make a partial parent from a non-parent asset"
-        );
-        assert!(
-            num_units > 0,
-            "Cannot make a partial parent with zero units"
-        );
+    /// Panics if `num_units` is zero or exceeds the total capacity of this asset.
+    pub fn with_subset_of_units(self, num_units: u32) -> Self {
+        if num_units == self.num_units() {
+            return self;
+        }
+
+        assert!(num_units > 0, "Cannot make an asset with zero units");
 
         let (max_num_units, unit_size) = match self.capacity() {
             AssetCapacity::Discrete(max_num_units, unit_size) => (max_num_units, unit_size),
-            // We know asset capacity type is discrete as this is a parent asset
-            AssetCapacity::Continuous(_) => unreachable!(),
-        };
-        match num_units.cmp(&max_num_units) {
-            // Make a new Asset with fewer units
-            Ordering::Less => Self::from(Asset {
-                capacity: Cell::new(AssetCapacity::Discrete(num_units, unit_size)),
-                ..Asset::clone(self)
-            }),
-            // Same number of units as self
-            Ordering::Equal => self.clone(),
-            Ordering::Greater => {
-                panic!("Cannot make a partial parent with more units than original")
+            AssetCapacity::Continuous(_) => {
+                panic!("Non-divisible assets can only have one unit");
             }
-        }
+        };
+
+        assert!(
+            num_units <= max_num_units,
+            "Cannot make an asset with more units than original"
+        );
+
+        // Make a new Asset with fewer units
+        Self::from(Asset {
+            capacity: Cell::new(AssetCapacity::Discrete(num_units, unit_size)),
+            ..Rc::unwrap_or_clone(self.0)
+        })
     }
 }
 
@@ -1208,7 +1213,7 @@ where
 
         for (parent, child_count) in child_counts {
             // Convert to an object representing the appropriate portion of the parent's capacity
-            out.push(parent.make_partial_parent(child_count));
+            out.push(parent.clone().with_subset_of_units(child_count));
         }
 
         out
@@ -1468,7 +1473,7 @@ mod tests {
     #[rstest]
     #[case::subset_of_children(2, false)]
     #[case::all_children(3, true)]
-    fn make_partial_parent(
+    fn with_subset_of_units(
         parent_asset: AssetRef,
         #[case] num_units: u32,
         #[case] expect_same_asset: bool,
@@ -1476,7 +1481,7 @@ mod tests {
         let parent = parent_asset;
         assert!(parent.is_parent());
 
-        let partial_parent = parent.make_partial_parent(num_units);
+        let partial_parent = parent.clone().with_subset_of_units(num_units);
 
         assert!(partial_parent.is_parent());
         assert_eq!(
@@ -1491,22 +1496,31 @@ mod tests {
     }
 
     #[rstest]
-    #[should_panic(expected = "Cannot make a partial parent from a non-parent asset")]
-    fn make_partial_parent_panics_for_non_parent_asset(asset_divisible: Asset) {
-        let asset = AssetRef::from(asset_divisible);
-        asset.make_partial_parent(1);
+    fn with_subset_of_units_non_divisible_asset(asset: Asset) {
+        let asset = AssetRef::from(asset);
+        assert!(Rc::ptr_eq(
+            &asset.0,
+            &asset.clone().with_subset_of_units(1).0
+        ));
     }
 
     #[rstest]
-    #[should_panic(expected = "Cannot make a partial parent with zero units")]
-    fn make_partial_parent_panics_for_zero_units(parent_asset: AssetRef) {
-        parent_asset.make_partial_parent(0);
+    #[should_panic(expected = "Non-divisible assets can only have one unit")]
+    fn with_subset_of_units_panics_for_non_divisible_asset(asset: Asset) {
+        let asset = AssetRef::from(asset);
+        asset.with_subset_of_units(2);
     }
 
     #[rstest]
-    #[should_panic(expected = "Cannot make a partial parent with more units than original")]
-    fn make_partial_parent_panics_for_too_many_units(parent_asset: AssetRef) {
-        parent_asset.make_partial_parent(4);
+    #[should_panic(expected = "Cannot make an asset with zero units")]
+    fn with_subset_of_units_panics_for_zero_units(parent_asset: AssetRef) {
+        parent_asset.with_subset_of_units(0);
+    }
+
+    #[rstest]
+    #[should_panic(expected = "Cannot make an asset with more units than original")]
+    fn with_subset_of_units_panics_for_too_many_units(parent_asset: AssetRef) {
+        parent_asset.with_subset_of_units(4);
     }
 
     #[rstest]

--- a/src/asset.rs
+++ b/src/asset.rs
@@ -44,6 +44,20 @@ pub use pool::AssetPool;
 )]
 pub struct AssetID(u32);
 
+/// The type of commissioned asset
+#[derive(PartialEq, Debug, Clone)]
+pub enum CommissionedType {
+    /// A non-divisible asset
+    NonDivisible,
+    /// A parent asset
+    Parent,
+    /// A child asset
+    Child {
+        /// The parent of this child
+        parent: AssetRef,
+    },
+}
+
 /// The state of an asset
 ///
 /// New assets are created as either `Ready` or `Candidate` assets. `Ready` assets from the input
@@ -63,10 +77,8 @@ pub enum AssetState {
         agent_id: AgentID,
         /// Year in which the asset was mothballed. None, if it is not mothballed
         mothballed_year: Option<u32>,
-        /// Parent asset, if any.
-        ///
-        /// All divided assets have a parent, which tracks the total capacity across the children.
-        parent: Option<AssetRef>,
+        /// The type of commissioned asset (non-divisible, parent or child)
+        kind: CommissionedType,
     },
     /// The asset is ready for investment, but not yet confirmed
     Ready {
@@ -74,16 +86,6 @@ pub enum AssetState {
         agent_id: AgentID,
         /// The reason why this asset is due to be commissioned
         commission_reason: &'static str,
-    },
-    /// The asset is a parent of other assets.
-    ///
-    /// Parents are used for grouping (commissioned) divided assets, which can be used as an
-    /// optimisation.
-    Parent {
-        /// ID of this parent
-        id: AssetID,
-        /// The ID of the agent which owns this asset's children
-        agent_id: AgentID,
     },
     /// The asset is a candidate for investment but has not yet been selected by an agent
     Candidate,
@@ -206,7 +208,7 @@ impl Asset {
                 id: AssetID(0),
                 agent_id,
                 mothballed_year: None,
-                parent: None,
+                kind: CommissionedType::NonDivisible,
             },
             process,
             region_id,
@@ -627,10 +629,7 @@ impl Asset {
 
     /// Whether this asset has been commissioned
     pub fn is_commissioned(&self) -> bool {
-        matches!(
-            &self.state,
-            AssetState::Commissioned { .. } | AssetState::Parent { .. }
-        )
+        matches!(&self.state, AssetState::Commissioned { .. })
     }
 
     /// Get the commission year for this asset
@@ -656,22 +655,30 @@ impl Asset {
     /// Get the ID for this asset
     pub fn id(&self) -> Option<AssetID> {
         match &self.state {
-            AssetState::Commissioned { id, .. } | AssetState::Parent { id, .. } => Some(*id),
+            AssetState::Commissioned { id, .. } => Some(*id),
+            _ => None,
+        }
+    }
+
+    /// Type of commissioned asset
+    fn commissioned_type(&self) -> Option<&CommissionedType> {
+        match &self.state {
+            AssetState::Commissioned { kind, .. } => Some(kind),
             _ => None,
         }
     }
 
     /// Get the parent asset of this asset, if any
     pub fn parent(&self) -> Option<&AssetRef> {
-        match &self.state {
-            AssetState::Commissioned { parent, .. } => parent.as_ref(),
+        match self.commissioned_type() {
+            Some(CommissionedType::Child { parent }) => Some(parent),
             _ => None,
         }
     }
 
     /// Whether this asset is a parent of divided assets
     pub fn is_parent(&self) -> bool {
-        matches!(self.state, AssetState::Parent { .. })
+        self.commissioned_type() == Some(&CommissionedType::Parent)
     }
 
     /// Whether this asset is divisible
@@ -682,9 +689,9 @@ impl Asset {
     /// Get the agent ID for this asset, if any
     pub fn agent_id(&self) -> Option<&AgentID> {
         match &self.state {
-            AssetState::Commissioned { agent_id, .. }
-            | AssetState::Ready { agent_id, .. }
-            | AssetState::Parent { agent_id, .. } => Some(agent_id),
+            AssetState::Commissioned { agent_id, .. } | AssetState::Ready { agent_id, .. } => {
+                Some(agent_id)
+            }
             AssetState::Candidate => None,
         }
     }
@@ -747,13 +754,10 @@ impl Asset {
 
     /// Decommission this asset
     fn decommission(&mut self, reason: &str) {
-        let (id, agent_id, parent) = match &self.state {
+        let (id, agent_id, kind) = match &self.state {
             AssetState::Commissioned {
-                id,
-                agent_id,
-                parent,
-                ..
-            } => (*id, agent_id.clone(), parent),
+                id, agent_id, kind, ..
+            } => (*id, agent_id.clone(), kind),
             _ => panic!("Cannot decommission an asset that hasn't been commissioned"),
         };
         debug!(
@@ -765,7 +769,7 @@ impl Asset {
         );
 
         // If this is a child asset, we need to decrease the parent's capacity appropriately
-        if let Some(parent) = parent {
+        if let CommissionedType::Child { parent } = kind {
             parent.decrement_unit_count();
         }
     }
@@ -778,8 +782,8 @@ impl Asset {
     /// # Arguments
     ///
     /// * `id` - The ID to give the newly commissioned asset
-    /// * `parent` - The parent asset, if this is a child asset
-    fn commission(&mut self, id: AssetID, parent: Option<AssetRef>) {
+    /// * `kind` - The type of commissioned asset to produce
+    fn commission(&mut self, id: AssetID, kind: CommissionedType) {
         let (agent_id, reason) = match &self.state {
             AssetState::Ready {
                 agent_id,
@@ -799,7 +803,7 @@ impl Asset {
             id,
             agent_id: agent_id.clone(),
             mothballed_year: None,
-            parent,
+            kind,
         };
     }
 
@@ -818,39 +822,33 @@ impl Asset {
 
     /// Set the year this asset was mothballed
     pub fn mothball(&mut self, year: u32) {
-        let (id, agent_id, parent) = match &self.state {
+        let (id, agent_id, kind) = match &self.state {
             AssetState::Commissioned {
-                id,
-                agent_id,
-                parent,
-                ..
-            } => (*id, agent_id.clone(), parent.clone()),
+                id, agent_id, kind, ..
+            } => (*id, agent_id.clone(), kind.clone()),
             _ => panic!("Cannot mothball an asset that hasn't been commissioned"),
         };
         self.state = AssetState::Commissioned {
             id,
             agent_id,
             mothballed_year: Some(year),
-            parent,
+            kind,
         };
     }
 
     /// Remove the mothballed year - presumably because the asset has been used
     pub fn unmothball(&mut self) {
-        let (id, agent_id, parent) = match &self.state {
+        let (id, agent_id, kind) = match &self.state {
             AssetState::Commissioned {
-                id,
-                agent_id,
-                parent,
-                ..
-            } => (*id, agent_id.clone(), parent.clone()),
+                id, agent_id, kind, ..
+            } => (*id, agent_id.clone(), kind.clone()),
             _ => panic!("Cannot unmothball an asset that hasn't been commissioned"),
         };
         self.state = AssetState::Commissioned {
             id,
             agent_id,
             mothballed_year: None,
-            parent,
+            kind,
         };
     }
 
@@ -1022,6 +1020,8 @@ impl AssetRef {
 
     /// Apply a function to each of this asset's children, consuming the asset in the process.
     ///
+    /// Note that the original asset is converted to a commissioned state.
+    ///
     /// If this asset is divisible, the first argument to `f` will be this asset after it has been
     /// converted to a parent and the second will be each child.
     ///
@@ -1056,9 +1056,11 @@ impl AssetRef {
 
         // Turn this asset into a parent
         let agent_id = self.agent_id().unwrap().clone();
-        self.make_mut().state = AssetState::Parent {
-            agent_id,
+        self.make_mut().state = AssetState::Commissioned {
             id: AssetID(*next_id),
+            agent_id,
+            mothballed_year: None,
+            kind: CommissionedType::Parent,
         };
         *next_id += 1;
 
@@ -1409,9 +1411,7 @@ mod tests {
         asset
             .clone()
             .into_for_each_child(&mut 0, |parent, child, _| {
-                assert!(
-                    parent.is_some_and(|parent| matches!(parent.state, AssetState::Parent { .. }))
-                );
+                assert!(parent.is_some_and(|parent| parent.is_commissioned()));
 
                 // Check each child has capacity equal to unit_size
                 assert_eq!(
@@ -1520,7 +1520,7 @@ mod tests {
             2020,
         )
         .unwrap();
-        asset.commission(AssetID(2), None);
+        asset.commission(AssetID(2), CommissionedType::NonDivisible);
         assert!(asset.is_commissioned());
         assert_eq!(asset.id(), Some(AssetID(2)));
     }
@@ -1530,7 +1530,7 @@ mod tests {
     fn commission_wrong_states(process: Process) {
         let mut asset =
             Asset::new_candidate(process.into(), "GBR".into(), Capacity(1.0), 2020).unwrap();
-        asset.commission(AssetID(1), None);
+        asset.commission(AssetID(1), CommissionedType::NonDivisible);
     }
 
     #[test]

--- a/src/asset/pool.rs
+++ b/src/asset/pool.rs
@@ -2,7 +2,6 @@
 use super::{AssetID, AssetRef, AssetState, CommissionedType, UserAsset};
 use itertools::Itertools;
 use log::warn;
-use std::cmp::min;
 
 /// The active pool of [`super::Asset`]s
 #[derive(Default, derive_more::Deref)]
@@ -72,18 +71,13 @@ impl AssetPool {
 
     /// Decommission mothballed assets if mothballed long enough
     pub fn decommission_mothballed(&mut self, year: u32, mothball_years: u32) {
-        self.assets
-            .extract_if(.., |asset| {
-                asset
-                    .get_mothballed_year()
-                    .is_some_and(|myear| myear <= year - min(mothball_years, year))
-            })
-            .for_each(|asset| {
-                asset.decommission(&format!(
-                    "The asset has not been used for the set mothball years ({mothball_years} \
-                        years)."
-                ));
-            });
+        // Empty the Vec and reconstruct it with only the remaining units of the remaining assets
+        // after decommissioning. This sadly means we always allocate a new Vec, but modifying the
+        // Vec in place leads to uglier code and unnecessary deep clones of assets.
+        self.assets = std::mem::take(&mut self.assets)
+            .into_iter()
+            .filter_map(|asset| asset.with_decommission_mothballed(year, mothball_years))
+            .collect();
     }
 
     /// Mothball the specified assets if they are no longer in the active pool and put them back
@@ -101,22 +95,30 @@ impl AssetPool {
     where
         I: IntoIterator<Item = AssetRef>,
     {
-        for mut asset in assets {
-            let in_pool = match asset.state {
-                AssetState::Commissioned { .. } => !self.assets.contains(&asset),
-                _ => panic!("Cannot mothball asset that has not been commissioned"),
-            };
+        for old_asset in assets {
+            let id = old_asset
+                .id()
+                .expect("Cannot mothball asset that has not been commissioned");
 
-            if in_pool {
-                // If not already set, we set the current year as the mothball year,
-                // i.e. the first one the asset was not used.
-                if !asset.is_mothballed() {
-                    asset.make_mut().mothball(year);
-                }
-
-                // And we put it back to the pool, so they can be chosen the next milestone year
-                // if not decommissioned earlier.
-                self.assets.push(asset);
+            // Note that we cannot use a binary search here, as `self.assets` may have become
+            // unsorted by new assets added below
+            if let Some(new_asset) = self
+                .assets
+                .iter_mut()
+                .find(|asset| asset.id().unwrap() == id)
+            {
+                // At least some of the asset's units have made it back into the pool. Increase the
+                // capacity back to what it was before, with the unselected units set as mothballed.
+                let num_mothballed = old_asset
+                    .num_units()
+                    .checked_sub(new_asset.num_units())
+                    .expect("Number of units has increased");
+                *new_asset = old_asset.with_mothballed_units(num_mothballed, Some(year));
+            } else {
+                // Put back into pool, with all units mothballed
+                let num_mothballed = old_asset.num_units();
+                self.assets
+                    .push(old_asset.with_mothballed_units(num_mothballed, Some(year)));
             }
         }
         self.assets.sort();
@@ -193,6 +195,7 @@ impl AssetPool {
 mod tests {
     use super::super::Asset;
     use super::*;
+    use crate::asset::MothballEvent;
     use crate::fixture::{asset, asset_divisible, process, process_parameter_map};
     use crate::process::{Process, ProcessParameter};
     use crate::units::{
@@ -656,7 +659,13 @@ mod tests {
 
         // Only the removed asset should be mothballed (since it's not in active pool)
         assert_eq!(asset_pool.assets.len(), 2); // And should be back into the pool
-        assert_eq!(asset_pool.assets[0].get_mothballed_year(), Some(2025));
+        assert_equal(
+            asset_pool.assets[0].get_mothball_events().unwrap().iter(),
+            &[MothballEvent {
+                year: 2025,
+                num_units: 1,
+            }],
+        );
     }
 
     #[rstest]
@@ -668,13 +677,16 @@ mod tests {
 
         // Make an asset unused for a few years
         let mothball_years: u32 = 10;
-        asset_pool.assets[0]
-            .make_mut()
-            .mothball(2025 - mothball_years);
+        asset_pool.assets[0] = asset_pool[0]
+            .clone()
+            .with_mothballed_units(1, Some(2025 - mothball_years));
 
-        assert_eq!(
-            asset_pool.assets[0].get_mothballed_year(),
-            Some(2025 - mothball_years)
+        assert_equal(
+            asset_pool.assets[0].get_mothball_events().unwrap().iter(),
+            &[MothballEvent {
+                year: 2025 - mothball_years,
+                num_units: 1,
+            }],
         );
 
         // Decommission unused assets
@@ -700,9 +712,21 @@ mod tests {
         // All assets should be mothballed
         assert_eq!(asset_pool.assets.len(), 2);
         assert_eq!(asset_pool.assets[0].id(), all_assets[0].id());
-        assert_eq!(asset_pool.assets[0].get_mothballed_year(), Some(2025));
+        assert_equal(
+            asset_pool.assets[0].get_mothball_events().unwrap().iter(),
+            &[MothballEvent {
+                year: 2025,
+                num_units: 1,
+            }],
+        );
         assert_eq!(asset_pool.assets[1].id(), all_assets[1].id());
-        assert_eq!(asset_pool.assets[1].get_mothballed_year(), Some(2025));
+        assert_equal(
+            asset_pool.assets[1].get_mothball_events().unwrap().iter(),
+            &[MothballEvent {
+                year: 2025,
+                num_units: 1,
+            }],
+        );
     }
 
     #[rstest]
@@ -722,5 +746,86 @@ mod tests {
         // This should panic because the asset was never commissioned
         let mut asset_pool = AssetPool::new();
         asset_pool.mothball_unretained(vec![non_commissioned_asset], 2025);
+    }
+
+    /// A commissioned divisible (parent) asset with three units.
+    #[fixture]
+    fn commissioned_divisible(asset_divisible: Asset) -> AssetRef {
+        let asset = AssetRef::from(asset_divisible);
+        let mut parent = None;
+        asset.into_for_each_child(&mut 0, |maybe_parent, _, _| {
+            if parent.is_none() {
+                parent = maybe_parent.cloned();
+            }
+        });
+        let parent = parent.expect("Divisible asset should create a parent");
+        assert_eq!(parent.num_units(), 3);
+        parent
+    }
+
+    #[rstest]
+    fn asset_pool_mothball_unretained_partial(commissioned_divisible: AssetRef) {
+        // The full asset has three units; only two of them were retained in the pool
+        let full = commissioned_divisible;
+        let retained = full.clone().with_subset_of_units(2);
+
+        let mut asset_pool = AssetPool::new();
+        asset_pool.assets.push(retained);
+
+        asset_pool.mothball_unretained(vec![full], 2025);
+
+        // The asset is restored to its full capacity, with the unretained unit mothballed
+        assert_eq!(asset_pool.assets.len(), 1);
+        let asset = &asset_pool.assets[0];
+        assert_eq!(asset.num_units(), 3);
+        assert_eq!(asset.get_num_mothballed_units(), 1);
+        assert_equal(
+            asset.get_mothball_events().unwrap().iter(),
+            &[MothballEvent {
+                year: 2025,
+                num_units: 1,
+            }],
+        );
+    }
+
+    #[rstest]
+    fn asset_pool_decommission_mothballed_partial(commissioned_divisible: AssetRef) {
+        // Mothball one unit in 2010 and one in 2020, leaving one active
+        let asset = commissioned_divisible
+            .with_mothballed_units(1, Some(2010))
+            .with_mothballed_units(2, Some(2020));
+
+        let mut asset_pool = AssetPool::new();
+        asset_pool.assets.push(asset);
+
+        // Threshold of 2015: only the unit mothballed in 2010 is old enough to decommission
+        asset_pool.decommission_mothballed(2025, 10);
+
+        assert_eq!(asset_pool.assets.len(), 1);
+        let asset = &asset_pool.assets[0];
+        assert_eq!(asset.num_units(), 2);
+        assert_eq!(asset.get_num_mothballed_units(), 1);
+        assert_equal(
+            asset.get_mothball_events().unwrap().iter(),
+            &[MothballEvent {
+                year: 2020,
+                num_units: 1,
+            }],
+        );
+    }
+
+    #[rstest]
+    fn asset_pool_decommission_mothballed_removes_fully_mothballed(
+        commissioned_divisible: AssetRef,
+    ) {
+        // All three units mothballed long enough ago: the whole asset is removed from the pool
+        let asset = commissioned_divisible.with_mothballed_units(3, Some(2010));
+
+        let mut asset_pool = AssetPool::new();
+        asset_pool.assets.push(asset);
+
+        asset_pool.decommission_mothballed(2025, 10);
+
+        assert!(asset_pool.assets.is_empty());
     }
 }

--- a/src/asset/pool.rs
+++ b/src/asset/pool.rs
@@ -1,5 +1,5 @@
 //! Defines a data structure for representing the current active pool of assets.
-use super::{AssetID, AssetRef, AssetState, UserAsset};
+use super::{AssetID, AssetRef, AssetState, CommissionedType, UserAsset};
 use itertools::Itertools;
 use log::warn;
 use std::cmp::min;
@@ -49,9 +49,13 @@ impl AssetPool {
     /// Commission the specified asset or, if divisible, its children
     fn commission(&mut self, asset: AssetRef) {
         asset.into_for_each_child(&mut self.next_id, |parent, mut child, next_id| {
-            child
-                .make_mut()
-                .commission(AssetID(*next_id), parent.cloned());
+            let kind = match parent {
+                Some(parent) => CommissionedType::Child {
+                    parent: parent.clone(),
+                },
+                None => CommissionedType::NonDivisible,
+            };
+            child.make_mut().commission(AssetID(*next_id), kind);
             *next_id += 1;
             self.assets.push(child);
         });
@@ -161,7 +165,7 @@ impl AssetPool {
                 AssetState::Ready { .. } => {
                     self.commission(asset);
                 }
-                _ => panic!(
+                AssetState::Candidate => panic!(
                     "Cannot extend asset pool with asset in state {}. Only assets in \
                     Commissioned or Ready states are allowed.",
                     asset.state

--- a/src/asset/pool.rs
+++ b/src/asset/pool.rs
@@ -65,8 +65,8 @@ impl AssetPool {
     pub fn decommission_old(&mut self, year: u32) {
         self.assets
             .extract_if(.., |asset| asset.max_decommission_year() <= year)
-            .for_each(|mut asset| {
-                asset.make_mut().decommission("end of life");
+            .for_each(|asset| {
+                asset.decommission("end of life");
             });
     }
 
@@ -78,8 +78,8 @@ impl AssetPool {
                     .get_mothballed_year()
                     .is_some_and(|myear| myear <= year - min(mothball_years, year))
             })
-            .for_each(|mut asset| {
-                asset.make_mut().decommission(&format!(
+            .for_each(|asset| {
+                asset.decommission(&format!(
                     "The asset has not been used for the set mothball years ({mothball_years} \
                         years)."
                 ));

--- a/src/output.rs
+++ b/src/output.rs
@@ -643,7 +643,7 @@ impl DataWriter {
                 milestone_year,
                 asset_id: asset.id().unwrap(),
                 capacity: asset.total_capacity(),
-                num_units: asset.num_children(),
+                num_units: asset.capacity().n_units(),
             };
             self.asset_capacities.serialize(row)?;
         }

--- a/src/simulation.rs
+++ b/src/simulation.rs
@@ -165,7 +165,7 @@ pub fn run(model: &Model, output_path: &Path, debug_model: bool) -> Result<()> {
 /// from a run with both existing and candidate assets. If either flows or prices cannot be
 /// calculated, empty maps are returned.
 ///
-/// Mothballed assets are excluded.
+/// Fully mothballed assets or mothballed units thereof are excluded.
 #[context_manager::wrap(DispatchTimer)]
 fn run_dispatch_for_year(
     model: &Model,
@@ -177,13 +177,18 @@ fn run_dispatch_for_year(
     // Sanity check
     debug_assert!(candidates.iter().all(|asset| !asset.is_commissioned()));
 
-    // Exclude mothballed assets
+    // Only include non-mothballed units
     let assets_vec: Vec<AssetRef>;
-    let assets = if assets.iter().any(|asset| asset.is_mothballed()) {
+    let assets = if assets.iter().any(|asset| asset.has_any_mothballed_units()) {
         assets_vec = assets
             .iter()
-            .filter(|asset| !asset.is_mothballed())
             .cloned()
+            .filter_map(|asset| {
+                // Exclude fully mothballed assets entirely. If assets are partially mothballed,
+                // get a new asset without the mothballed units.
+                let num_units = asset.get_num_nonmothballed_units();
+                (num_units > 0).then(|| asset.with_subset_of_units(num_units))
+            })
             .collect();
         &assets_vec
     } else {

--- a/src/simulation/investment.rs
+++ b/src/simulation/investment.rs
@@ -574,51 +574,49 @@ fn update_assets(
     remaining_capacities: &mut HashMap<AssetRef, AssetCapacity>,
     best_assets: &mut Vec<AssetRef>,
 ) {
-    match best_asset.state() {
-        AssetState::Commissioned { .. } => {
-            // Remove this asset from the options
-            opt_assets.retain(|asset| *asset != best_asset);
+    let capacity_accumulates = if best_asset.is_commissioned() {
+        best_asset.is_divisible()
+    } else if best_asset.state() == &AssetState::Candidate {
+        true
+    } else {
+        panic!("Invalid asset type");
+    };
 
-            // As this asset has been selected, it should be unmothballed
-            if best_asset.is_mothballed() {
-                best_asset.make_mut().unmothball();
+    // As this asset has been selected, it should be unmothballed
+    if best_asset.is_mothballed() {
+        best_asset.make_mut().unmothball();
+    }
+
+    if capacity_accumulates {
+        // Track remaining capacity for assets that have limits
+        if let Some(remaining_capacity) = remaining_capacities.get_mut(&best_asset) {
+            *remaining_capacity = *remaining_capacity - best_asset.capacity();
+
+            // If there's no capacity remaining, remove the asset from the options
+            if remaining_capacity.total_capacity() <= Capacity(0.0) {
+                let old_idx = opt_assets
+                    .iter()
+                    .position(|asset| *asset == best_asset)
+                    .unwrap();
+
+                opt_assets.swap_remove(old_idx);
+                remaining_capacities.remove(&best_asset);
             }
+        }
 
+        if let Some(existing_asset) = best_assets.iter_mut().find(|asset| **asset == best_asset) {
+            // If the asset is already in the list of best assets, add the additional required capacity
+            existing_asset
+                .make_mut()
+                .increase_capacity(best_asset.capacity());
+        } else {
+            // Otherwise add it to the list of best assets
             best_assets.push(best_asset);
         }
-        AssetState::Candidate | AssetState::Parent { .. } => {
-            // Track remaining capacity for assets that have limits
-            if let Some(remaining_capacity) = remaining_capacities.get_mut(&best_asset) {
-                *remaining_capacity = *remaining_capacity - best_asset.capacity();
-
-                // If there's no capacity remaining, remove the asset from the options
-                if remaining_capacity.total_capacity() <= Capacity(0.0) {
-                    let old_idx = opt_assets
-                        .iter()
-                        .position(|asset| *asset == best_asset)
-                        .unwrap();
-
-                    opt_assets.swap_remove(old_idx);
-                    remaining_capacities.remove(&best_asset);
-                }
-            }
-
-            if let Some(existing_asset) = best_assets.iter_mut().find(|asset| **asset == best_asset)
-            {
-                // If the asset is already in the list of best assets, add the additional required capacity
-                existing_asset
-                    .make_mut()
-                    .increase_capacity(best_asset.capacity());
-            } else {
-                // Otherwise add it to the list of best assets
-                best_assets.push(best_asset);
-            }
-        }
-        AssetState::Ready { .. } => {
-            panic!(
-                "update_assets should only be called with Commissioned, Parent or Candidate assets"
-            )
-        }
+    } else {
+        // Remove this asset from the options
+        opt_assets.retain(|asset| *asset != best_asset);
+        best_assets.push(best_asset);
     }
 }
 

--- a/src/simulation/investment.rs
+++ b/src/simulation/investment.rs
@@ -569,7 +569,7 @@ fn is_any_remaining_demand(demand: &DemandMap, absolute_tolerance: Flow) -> bool
 
 /// Update capacity of chosen asset, if needed, and update both asset options and chosen assets
 fn update_assets(
-    mut best_asset: AssetRef,
+    best_asset: AssetRef,
     opt_assets: &mut Vec<AssetRef>,
     remaining_capacities: &mut HashMap<AssetRef, AssetCapacity>,
     best_assets: &mut Vec<AssetRef>,
@@ -581,11 +581,6 @@ fn update_assets(
     } else {
         panic!("Invalid asset type");
     };
-
-    // As this asset has been selected, it should be unmothballed
-    if best_asset.is_mothballed() {
-        best_asset.make_mut().unmothball();
-    }
 
     if capacity_accumulates {
         // Track remaining capacity for assets that have limits

--- a/src/simulation/investment.rs
+++ b/src/simulation/investment.rs
@@ -605,13 +605,13 @@ fn update_assets(
                 .make_mut()
                 .increase_capacity(best_asset.capacity());
         } else {
-            // Otherwise add it to the list of best assets
-            best_assets.push(best_asset);
+            // Otherwise add it to the list of best assets. Selected assets are unmothballed.
+            best_assets.push(best_asset.with_no_mothballed_units());
         }
     } else {
-        // Remove this asset from the options
+        // Remove this asset from the options. Selected assets are unmothballed.
         opt_assets.retain(|asset| *asset != best_asset);
-        best_assets.push(best_asset);
+        best_assets.push(best_asset.with_no_mothballed_units());
     }
 }
 

--- a/src/simulation/investment.rs
+++ b/src/simulation/investment.rs
@@ -518,7 +518,7 @@ fn replace_child_assets_with_parents(
         remaining_capacities.insert(parent.clone(), parent.capacity());
 
         // Add parent asset (one unit)
-        assets.push(parent.make_partial_parent(1));
+        assets.push(parent.clone().with_subset_of_units(1));
     }
 
     children

--- a/src/simulation/investment/appraisal/costs.rs
+++ b/src/simulation/investment/appraisal/costs.rs
@@ -9,17 +9,13 @@ use crate::units::{MoneyPerCapacity, Year};
 /// - For a candidate asset, this includes both operating and capital costs.
 ///
 /// The return value is the annualised fixed cost expressed as `MoneyPerCapacity`.
-/// If `asset.state()` is not `Commissioned`, `Parent` or `Candidate` this function will panic.
+/// If `asset.state()` is not `Commissioned` or `Candidate` this function will panic.
 pub fn annual_fixed_cost(asset: &AssetRef) -> MoneyPerCapacity {
     match asset.state() {
-        AssetState::Commissioned { .. } | AssetState::Parent { .. } => {
-            annual_fixed_cost_for_existing(asset)
-        }
+        AssetState::Commissioned { .. } => annual_fixed_cost_for_existing(asset),
         AssetState::Candidate => annual_fixed_cost_for_candidate(asset),
         AssetState::Ready { .. } => {
-            panic!(
-                "annual_fixed_cost should only be called with Commissioned, Parent or Candidate assets"
-            )
+            panic!("annual_fixed_cost should only be called with Commissioned or Candidate assets")
         }
     }
 }

--- a/src/simulation/market.rs
+++ b/src/simulation/market.rs
@@ -405,13 +405,16 @@ fn get_asset_options<'a>(
     year: u32,
     capacity_limit_factor: Dimensionless,
 ) -> impl Iterator<Item = AssetRef> + 'a {
-    // Get existing assets which produce the commodity of interest
+    // Get existing assets which produce the commodity of interest. We discard information about
+    // mothballed units here; it is preserved in the original collection of assets and is fed back
+    // into `AssetPool` later.
     let existing_assets = all_existing_assets
         .iter()
         .filter_agent(&agent.id)
         .filter_region(region_id)
         .filter_primary_producers_of(&commodity.id)
-        .cloned();
+        .cloned()
+        .map(AssetRef::with_unmothball_all);
 
     // Get candidates assets which produce the commodity of interest
     let candidate_assets = get_candidate_assets(

--- a/src/simulation/market.rs
+++ b/src/simulation/market.rs
@@ -414,7 +414,7 @@ fn get_asset_options<'a>(
         .filter_region(region_id)
         .filter_primary_producers_of(&commodity.id)
         .cloned()
-        .map(AssetRef::with_unmothball_all);
+        .map(AssetRef::with_no_mothballed_units);
 
     // Get candidates assets which produce the commodity of interest
     let candidate_assets = get_candidate_assets(

--- a/src/simulation/market.rs
+++ b/src/simulation/market.rs
@@ -413,8 +413,7 @@ fn get_asset_options<'a>(
         .filter_agent(&agent.id)
         .filter_region(region_id)
         .filter_primary_producers_of(&commodity.id)
-        .cloned()
-        .map(AssetRef::with_no_mothballed_units);
+        .cloned();
 
     // Get candidates assets which produce the commodity of interest
     let candidate_assets = get_candidate_assets(

--- a/src/simulation/optimisation.rs
+++ b/src/simulation/optimisation.rs
@@ -211,7 +211,8 @@ fn create_flow_map<'a>(
         let num_children_in_this_run = existing_assets_with_parents
             .get(parent)
             .unwrap()
-            .num_children()
+            .capacity()
+            .n_units()
             .unwrap();
         let n_units = Dimensionless(num_children_in_this_run as f64);
 


### PR DESCRIPTION
# Description

This PR is the last step before we can do #1123 :partying_face:. Once this is merged, it will just be a case of ripping stuff out, which should be easy (and satisfying). I'll try to do this tomorrow and open a PR based on this one, if it's not already merged.

I'm afraid this is a little on the long side: it turns out fixing mothballing for divisible assets was a bigger problem than I thought. Essentially, mothballing was another case where we are using child assets that also needed to be converted over. If we move to representing divisible assets as a single `Asset` object, that means we also need to represent the case where only a subset of an assets units are mothballed.

The first step was to remove the `AssetState::Parent` variant, as part of the plan to turn parent assets into regular commissioned assets. As a stopgap I've added a separate `CommissionedType` field to commissioned assets so we can distinguish non-divisible from parent and child assets, but will be removed altogether along with child assets. Sorry to include it here, but I couldn't see a way around it!

In order to allow for mothballing a subset of an asset's units, we need to track how many units have been mothballed and in what year. For this, I've replaced the `mothball_year` field of `AssetState::Commissioned` with a `mothball_events` queue, which stores this information. I used a `VecDeque` because the queue semantics fit well with this (new events are pushed to the back, old events are popped from the front), but you could equally use a `Vec`. This field is used for tracking mothballing events for all commissioned asset types: non-divisible assets are treated as being comprised of one unit (though in future all assets will be divisible, see #1441). Note that parent assets are not currently mothballed, as child assets, not parent assets, are the ones stored directly in `AssetPool`. Hence, the current code will never be mothballing more than one unit per asset until we do #1123 (though there are tests to verify that it works for more units).

The new API for (un)mothballing assets is via some methods on `AssetRef`: `with_mothballed_units()`, `with_unmothball_all()` etc. These methods consume `self` and return another `AssetRef`. I think this "functional-style" approach works quite nicely here, but another advantage is that we can avoid doing a deep copy of assets unless we actually need to change them. For example, if you call `with_mothballed_units()` with `num_units` set to the number of already mothballed units (or the asset type doesn't support mothballing), you just get the original asset back.

Let me know what you think :smile:.

## Type of change

- [ ] Bug fix (non-breaking change to fix an issue)
- [ ] New feature (non-breaking change to add functionality)
- [x] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [x] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`
- [ ] Update release notes for the latest release if this PR adds a new feature or fixes a bug
      present in the previous release

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
