### PR TITLE
Rewrite dispatch docs and model overview

### DIFF
--- a/docs/model/README.md
+++ b/docs/model/README.md
@@ -49,7 +49,7 @@ At a high level, the user defines:
 The model operates sequentially across a series of milestone years (MSYs). For the base year,
 existing assets are commissioned and a [dispatch optimisation][dispatch-optimisation] is run to
 establish [commodity prices][prices] for the first investment year. For each subsequent MSY, the
-model performs the following steps.
+model performs the following steps:
 
 ### 1. Decommission end-of-life assets
 

--- a/docs/model/README.md
+++ b/docs/model/README.md
@@ -74,18 +74,26 @@ has remained mothballed for longer than `mothball_years` (defined in
 
 ### 4. Ironing-out loop
 
-Investment and dispatch are repeated iteratively to resolve any price instability introduced by new
-capacity commitments. Each iteration runs the full agent investment pass followed by a full system
-dispatch. The loop terminates when time-slice-weighted market prices have converged within
-`price_tolerance`, or when `max_ironing_out_iterations` is reached (both defined in
-[`model.toml`][model-toml]).
+New capacity commitments can shift commodity prices, which in turn may affect which investments are
+optimal. Investment and dispatch are therefore repeated iteratively until prices stabilise. Each
+iteration runs the full agent investment pass (using prices from the previous iteration's dispatch)
+followed by a full system dispatch. The loop terminates when time-slice-weighted market prices have
+converged within `price_tolerance`, or when `max_ironing_out_iterations` is reached (both defined
+in [`model.toml`][model-toml]).
 
 ### 5. Final dispatch
 
 A full [dispatch optimisation][dispatch-optimisation] is run over the settled asset pool. The
-resulting flows and commodity prices are written to the output files and carried forward as the
-price basis for the next MSY's investment appraisal.
+resulting flows are written to the output files.
+
+### 6. Price calculation
+
+**Shadow prices** and **market prices** are derived from the final dispatch solution for each
+commodity, region, and time slice. These are written to the output files and carried forward as the
+price basis for the next MSY's investment appraisal. See [Commodity Prices][prices] for how each
+price type is calculated.
 
 [investment]: ./investment.md
 [dispatch-optimisation]: ./dispatch_optimisation.md
+[prices]: ./prices.md
 [model-toml]: ../file_formats/input_files.md#model-parameters-modeltoml

--- a/docs/model/README.md
+++ b/docs/model/README.md
@@ -46,93 +46,46 @@ At a high level, the user defines:
 
 ## Framework Overview
 
-The model framework is designed to operate sequentially across several distinct milestone years
-(MSY). For each MSY, it endogenously determines asset decommissioning (both scheduled and
-economically-driven) and guides new capacity investments. The overarching objective is to simulate
-agent decision-making to serve commodity (and service) demand.
+The model operates sequentially across a series of milestone years (MSYs). For the base year,
+existing assets are commissioned and a [dispatch optimisation][dispatch-optimisation] is run to
+establish commodity prices for the first investment year. For each subsequent MSY, the model
+performs the following steps.
 
-A fundamental premise for the investment appraisal is that prices for balanced commodities (Supply
-Equals Demand: SED) from the previous milestone year (\\( \pi_{prevMSY} \\)) are considered reliable
-for economic evaluations. Service demand commodity (SVD) prices from \\( MSY_{prev} \\) may or may
-not be reliable (as defined by the user), guiding the choice of appraisal method for assets
-producing them. It is designed as a recursive dynamic model with imperfect foresight.
+### 1. Decommission end-of-life assets
 
-The workflow is structured as follows:
+Assets whose scheduled decommissioning year has been reached are removed from the active pool.
 
-1. **Dispatch is executed for a calibrated base year.** Dispatch is executed using the formulation
-   shown in [Dispatch Optimisation Formulation]. All existing assets are included, and all candidate
-   assets for the \\( MSY_{next} \\) are included with capacities set to zero. This ensures that all
-   commodity shadow prices are generated for use in the \\(
-   MSY_{next} \\). \\( VoLL \\) load shedding variables should be zero after completion, and if they
-   are non-zero then throw an error as the model is not properly calibrated.
+### 2. Agent investment
 
-2. **Time-travel loop:** Move to the next milestone year (\\( MSY \\)).
+Agents select assets to meet commodity demand for the current MSY. Investment decisions follow a
+pre-computed **investment order** derived from the topology of the commodity graph: markets are
+processed deepest-first (most downstream to most upstream), grouped into **layers** of independent
+markets at the same depth. See [Investment Appraisal][investment] for full details.
 
-   1. **Decommission assets that reached their end of life.** This establishes the existing asset
-      fleet for the current \\( MSY \\) by accounting for initial retirements. \\( ExistingCapacity
-      \\) is the set of existing assets and their capacities available after EOL decommissioning.
+After all markets in each layer are settled, a **partial system dispatch** is run over all assets
+selected so far. This propagates demand upstream: input commodity flows consumed by newly committed
+assets become demand targets for the markets not yet invested in.
 
-   2. **Determine SVD demand profiles and run investment appraisal tools for them.** SVD demand
-      profiles for the \\( MSY \\) are determined from user input data. The [investment appraisal
-      tools] are applied to determine portfolios of existing and new assets to meet demand for each
-      SVD commodity. Prices of input commodities are known from the final dispatch of the previous
-      milestone year. This finalises \\( NewCapacity \\) and \\( AssetChosen \\) for each SVD.
+### 3. Mothballing and decommissioning
 
-   3. **Build System Layer-by-Layer loop: Completes the investment pass for the milestone year,
-      progressively adding commodities layer by layer.** This step determines new asset capacities
-      (\\( NewCapacity \\)) and selects existing assets that remain competitive (\\( AssetChosen
-      \\)). Other existing assets are decommissioned if they are not utilised for \\( MothballYears
-      \\) years (a user-input asset parameter). This inner loop continues until no different SED
-      commodities (that have not been processed using the investment appraisal tools) are added as
-      commodities of interest for this iteration.
+Previously commissioned assets that were not selected for retention are mothballed. Any asset that
+has remained mothballed for longer than `mothball_years` (defined in
+[`model.toml`][model-toml]) is permanently decommissioned.
 
-      1. **Determine the commodities of interest for investment.** In the base year this is all
-         service demand (SVD) commodities. After the base year, the commodities of interest are
-         determined dynamically; they are the set of commodities that are consumed by the assets
-         invested/chosen in the last iteration (layer) of this loop.
+### 4. Ironing-out loop
 
-      2. **Dispatch to determine commodity of interest demand profile.** Dispatch is executed using
-         the formulation shown in [Dispatch Optimisation Formulation], but only including system
-         elements downstream of the commodities of interest. Commodity prices for upstream/unknown
-         inputs/outputs from assets serving the commodities of interest and assets downstream of the
-         commodities of interest with unknown commodity prices (if any) are assumed to take on
-         shadow prices from the previous MSY. Care must be taken to avoid any double-counting of
-         prices and e.g. commodity levies. Demand profiles for commodities of interest are recorded
-         (\\( D[c,r,t] \\)).
+Investment and dispatch are repeated iteratively to resolve any price instability introduced by new
+capacity commitments. Each iteration runs the full agent investment pass followed by a full system
+dispatch. The loop terminates when time-slice-weighted market prices have converged within
+`price_tolerance`, or when `max_ironing_out_iterations` is reached (both defined in
+[`model.toml`][model-toml]).
 
-      3. **Run investment appraisal tools for each commodity of interest.** The [investment
-         appraisal tools] are applied to determine portfolios of existing and new assets to meet
-         demand for each commodity of interest. It is necessary to consider the complete demand
-         profile of each commodity of interest, as even where demand can be served with existing
-         assets in the MSY without new investment, economic decommissioning is still possible.
+### 5. Final dispatch
 
-      4. **Finalise new capacity and retained assets that produce the commodities of interest.** \\(
-         NewCapacity \\) and \\( AssetChosen \\) are finalised for the layer.
+A full [dispatch optimisation][dispatch-optimisation] is run over the settled asset pool. The
+resulting flows and commodity prices are written to the output files and carried forward as the
+price basis for the next MSY's investment appraisal.
 
-      5. **Check if there are SED commodities that the investment appraisal tools have not been run
-         for.** If yes, move to next layer of the layering loop at step 2(c). If no, **layering loop
-         ends**, break and continue at step 2(d).
-
-   4. **Ironing-out loop**, with iteration limit \\( k_{max} \\). For each \\( k \\):
-
-      1. Execute dispatch as per [Dispatch Optimisation Formulation] with the complete system, with
-         all candidate assets for the \\( MSY_{next} \\) included with capacities set to zero to
-         generate prices for the \\( MSY_{next} \\).
-
-      2. Check if load-weighted average prices for any SED commodity has changed (or changed more
-         than a tolerance) since the last loop (also, possibly check if the 95th percentile of price
-         has changed more than a tolerance). If yes, continue at 2(d)iii. If no, this MSY is
-         complete, and if further MSY exist continue time-travel loop from step 2, or if no further
-         MSY exist then go to step 3.
-
-      3. If \\( k = k_{max} \\) break with a warning telling the user that this loop did not
-         converge, identifying out-of-balance commodities. If further MSY exist continue time-travel
-         loop from step 2, or if no further MSY exist then go to step 3.
-
-      4. Re-run investment appraisal tools for the assets and commodities that are contributing to
-         the price instability.
-
-3. **Outer loop ends when no further milestone years exist.**
-
-[investment appraisal tools]: ./investment.md#metric-calculation
-[Dispatch Optimisation Formulation]: ./dispatch_optimisation.md
+[investment]: ./investment.md
+[dispatch-optimisation]: ./dispatch_optimisation.md
+[model-toml]: ../file_formats/input_files.md#model-parameters-modeltoml

--- a/docs/model/README.md
+++ b/docs/model/README.md
@@ -48,8 +48,8 @@ At a high level, the user defines:
 
 The model operates sequentially across a series of milestone years (MSYs). For the base year,
 existing assets are commissioned and a [dispatch optimisation][dispatch-optimisation] is run to
-establish commodity prices for the first investment year. For each subsequent MSY, the model
-performs the following steps.
+establish [commodity prices][prices] for the first investment year. For each subsequent MSY, the
+model performs the following steps.
 
 ### 1. Decommission end-of-life assets
 
@@ -88,4 +88,5 @@ price basis for the next MSY's investment appraisal.
 
 [investment]: ./investment.md
 [dispatch-optimisation]: ./dispatch_optimisation.md
+[prices]: ./prices.md
 [model-toml]: ../file_formats/input_files.md#model-parameters-modeltoml

--- a/docs/model/README.md
+++ b/docs/model/README.md
@@ -74,26 +74,18 @@ has remained mothballed for longer than `mothball_years` (defined in
 
 ### 4. Ironing-out loop
 
-New capacity commitments can shift commodity prices, which in turn may affect which investments are
-optimal. Investment and dispatch are therefore repeated iteratively until prices stabilise. Each
-iteration runs the full agent investment pass (using prices from the previous iteration's dispatch)
-followed by a full system dispatch. The loop terminates when time-slice-weighted market prices have
-converged within `price_tolerance`, or when `max_ironing_out_iterations` is reached (both defined
-in [`model.toml`][model-toml]).
+Investment and dispatch are repeated iteratively to resolve any price instability introduced by new
+capacity commitments. Each iteration runs the full agent investment pass followed by a full system
+dispatch. The loop terminates when time-slice-weighted market prices have converged within
+`price_tolerance`, or when `max_ironing_out_iterations` is reached (both defined in
+[`model.toml`][model-toml]).
 
 ### 5. Final dispatch
 
 A full [dispatch optimisation][dispatch-optimisation] is run over the settled asset pool. The
-resulting flows are written to the output files.
-
-### 6. Price calculation
-
-**Shadow prices** and **market prices** are derived from the final dispatch solution for each
-commodity, region, and time slice. These are written to the output files and carried forward as the
-price basis for the next MSY's investment appraisal. See [Commodity Prices][prices] for how each
-price type is calculated.
+resulting flows and commodity prices are written to the output files and carried forward as the
+price basis for the next MSY's investment appraisal.
 
 [investment]: ./investment.md
 [dispatch-optimisation]: ./dispatch_optimisation.md
-[prices]: ./prices.md
 [model-toml]: ../file_formats/input_files.md#model-parameters-modeltoml

--- a/docs/model/dispatch_optimisation.md
+++ b/docs/model/dispatch_optimisation.md
@@ -1,7 +1,7 @@
 # Dispatch Optimisation
 
 This section describes the formulation of the dispatch optimisation model in MUSE2. For a given
-milestone year (MSY) and region, the dispatch model calculates the least-cost operation of the
+milestone year (MSY), the dispatch model calculates the least-cost operation of the
 energy system assets to satisfy commodity demands. It is solved as a Linear Programme (LP) using the
 HiGHS solver.
 

--- a/docs/model/dispatch_optimisation.md
+++ b/docs/model/dispatch_optimisation.md
@@ -25,7 +25,7 @@ groupings at different levels (e.g. a single time slice, a season, or the entire
 
 The dispatch model determines the following variables:
 
-- \\( act_{a, t} \ge 0 \\): Activity level of asset \\( a \\) during time slice \\( t \\) (in units
+- \\( Activity_{a, t} \ge 0 \\): Activity level of asset \\( a \\) during time slice \\( t \\) (in units
 of activity, e.g. PJ/year or MW).
 
 ## Objective Function
@@ -33,17 +33,17 @@ of activity, e.g. PJ/year or MW).
 The objective is to minimise the total operating cost of the energy system:
 
 \\[
-  \text{Minimise } \sum_{a \in \mathbf{A}} \sum_{t \in \mathbf{T}} act_{a, t} \cdot
-  c_{\mathrm{act}}(a, t)
+  \text{Minimise } \sum_{a \in \mathbf{A}} \sum_{t \in \mathbf{T}} Activity_{a, t} \cdot
+  Cost_{\mathrm{Activity}}(a, t)
 \\]
 
-### Activity Cost Coefficient \\( c_{\mathrm{act}}(a, t) \\)
+### Activity Cost Coefficient \\( Cost_{\mathrm{Activity}}(a, t) \\)
 
 The cost per unit of activity for asset \\( a \\) in time slice \\( t \\) is composed of variable
 operating costs, flow costs, and levies:
 
 \\[
-  c\_{\mathrm{act}}(a, t) = \text{VariableOpex}\_a +
+  Cost\_{\mathrm{Activity}}(a, t) = \text{VariableOpex}\_a +
   \sum\_{f \in \text{Flows}\_a} |f\_{\mathrm{coeff}}| \cdot
   \left( f\_{\mathrm{cost}} + \mathrm{levy}\_f(t) \right)
 \\]
@@ -62,20 +62,20 @@ in time slice \\( t \\).
 For each asset \\( a \\) and every time slice selection \\( S \\):
 
 \\[
-  avail\_{\mathrm{LB}}(a, S) \cdot \Delta\_S \cdot cap\_a \cdot \text{cap2act}\_a \le
-  \sum\_{t \in S} act\_{a, t} \le
-  avail\_{\mathrm{UB}}(a, S) \cdot \Delta\_S \cdot cap\_a \cdot \text{cap2act}\_a
+  Avail\_{\mathrm{LB}}(a, S) \cdot \Delta\_S \cdot Capacity\_a \cdot \text{cap2act}\_a \le
+  \sum\_{t \in S} Activity\_{a, t} \le
+  Avail\_{\mathrm{UB}}(a, S) \cdot \Delta\_S \cdot Capacity\_a \cdot \text{cap2act}\_a
 \\]
 
 where:
 
-- \\( cap_a \\) is the fixed installed capacity of the asset.
+- \\( Capacity_a \\) is the fixed installed capacity of the asset.
 - \\( \text{cap2act}_a \\) is the conversion factor from capacity to activity units.
 - \\( \Delta_S = \sum_{t \in S} \Delta_t \\) is the total duration of selection \\( S \\) as a
 fraction of the year.
-- \\( avail_{\mathrm{LB}}(a, S) \\) and \\( avail_{\mathrm{UB}}(a, S) \\) are the lower and upper
-availability fractions from `process_activity_limits.csv`, defaulting to \\( 0 \\) and \\( 1 \\)
-respectively for any selection not explicitly defined.
+- \\( Avail_{\mathrm{LB}}(a, S) \\) and \\( Avail_{\mathrm{UB}}(a, S) \\) are the
+lower and upper availability fractions from `process_activity_limits.csv`, defaulting to
+\\( 0 \\) and \\( 1 \\) respectively for any selection not explicitly defined.
 
 ### Commodity Balance Constraints
 
@@ -86,7 +86,7 @@ demands:
 
 \\[
   \sum_{a \in \mathbf{A}(r)} f_{\mathrm{coeff}}(a, c) \cdot
-  \sum_{t \in S} act_{a, t} \ge \text{Bound}_{c, r, S}
+  \sum_{t \in S} Activity_{a, t} \ge \text{Bound}_{c, r, S}
 \\]
 
 where:
@@ -158,15 +158,15 @@ To help debug and pinpoint the exact source of failure, MUSE2 employs a diagnost
 spawns a second, diagnostic dispatch run. In this run, a set of slack variables representing unmet
 demand, \\( UnmetD_{c, r, t} \ge 0 \\), is added to the commodity balance constraints:
    \\[
-     \sum_{a \in \mathbf{A}(r)} f_{\mathrm{coeff}}(a, c) \cdot \sum_{t \in S} act_{a, t} +
+     \sum_{a \in \mathbf{A}(r)} f_{\mathrm{coeff}}(a, c) \cdot \sum_{t \in S} Activity_{a, t} +
       \sum_{t \in S} UnmetD_{c, r, t} \ge \text{Bound}_{c, r, S}
    \\]
 3. **Objective Penalty:** To ensure the solver only leaves demand unmet if it is physically
 impossible to satisfy it, these variables are heavily penalised in the diagnostic objective function
 using the `value_of_lost_load` parameter (\\( \mathrm{VoLL} \\)):
    \\[
-     \text{Minimise } \sum\_{a \in \mathbf{A}} \sum\_{t \in \mathbf{T}} act\_{a, t} \cdot
-      c\_{\mathrm{act}}(a, t) +
+     \text{Minimise } \sum\_{a \in \mathbf{A}} \sum\_{t \in \mathbf{T}} Activity\_{a, t} \cdot
+      Cost\_{\mathrm{Activity}}(a, t) +
     \mathrm{VoLL} \cdot \sum\_{c, r, t} UnmetD\_{c, r, t}
    \\]
 4. **Isolating Shortfalls:** The addition of \\( UnmetD_{c, r, t} \\) guarantees that the LP remains

--- a/docs/model/dispatch_optimisation.md
+++ b/docs/model/dispatch_optimisation.md
@@ -11,7 +11,7 @@ The energy system is defined using the following sets:
 
 - \\( r \in \mathbf{R} \\): Regions. Represents distinct geographical areas.
 - \\( t \in \mathbf{T} \\): Time Slices. Discrete operational sub-periods within a year.
-- \\( S \in \mathbf{S} \\): Time Slice Selections. Collections of time slices representing temporal
+- \\( s \in \mathbf{S} \\): Time Slice Selections. Collections of time slices representing temporal
 groupings at different levels (e.g. a single time slice, a season, or the entire year).
 - \\( a \in \mathbf{A} \\): Assets. All commissioned production, consumption, or conversion technologies.
 - \\( c \in \mathbf{C} \\): Commodities. All energy carriers, emissions, or materials, partitioned into:
@@ -25,83 +25,83 @@ groupings at different levels (e.g. a single time slice, a season, or the entire
 
 The dispatch model determines the following variables:
 
-- \\( Activity_{a, t} \ge 0 \\): Activity level of asset \\( a \\) during time slice \\( t \\) (in units
-of activity, e.g. PJ/year or MW).
+- \\( \mathrm{Activity}_{a, t} \ge 0 \\): Activity level of asset \\( a \\) during time slice
+\\( t \\) (in units of activity, e.g. PJ/year or MW).
 
 ## Objective Function
 
 The objective is to minimise the total operating cost of the energy system:
 
 \\[
-  \text{Minimise } \sum_{a \in \mathbf{A}} \sum_{t \in \mathbf{T}} Activity_{a, t} \cdot
-  Cost_{\mathrm{Activity}}(a, t)
+  \text{Minimise } \sum\_{a \in \mathbf{A}} \sum\_{t \in \mathbf{T}} \mathrm{Activity}\_{a, t} \cdot
+  \mathrm{Cost}\_{\mathrm{Activity},a,t}
 \\]
 
-### Activity Cost Coefficient \\( Cost_{\mathrm{Activity}}(a, t) \\)
+### Activity Cost Coefficient \\( \mathrm{Cost}_{\mathrm{Activity},a,t} \\)
 
 The cost per unit of activity for asset \\( a \\) in time slice \\( t \\) is composed of variable
 operating costs, flow costs, and levies:
 
 \\[
-  Cost\_{\mathrm{Activity}}(a, t) = \text{VariableOpex}\_a +
-  \sum\_{f \in \text{Flows}\_a} |f\_{\mathrm{coeff}}| \cdot
-  \left( f\_{\mathrm{cost}} + \mathrm{levy}\_f(t) \right)
+  \mathrm{Cost}\_{\mathrm{Activity},a,t} = \mathrm{VariableOpex}\_a +
+  \sum\_{f \in \mathrm{Flows}\_a} |f\_{\mathrm{coeff}}| \cdot
+  \left( f\_{\mathrm{cost}} + \mathrm{Levy}\_{f,t} \right)
 \\]
 
-- **VariableOpex**: The non-fuel variable O&M cost of the process.
+- \\( \mathrm{VariableOpex} \\): The non-fuel variable O&M cost of the process.
 - \\( f_{\mathrm{coeff}} \\): The flow coefficient for a commodity flow associated with the asset
 (positive for output/production, negative for input/consumption).
 - \\( f_{\mathrm{cost}} \\): The cost per unit of commodity flow.
-- \\( \mathrm{levy}_f(t) \\): The regional levy (or subsidy, if negative) per unit of commodity flow
+- \\( \mathrm{Levy}_{f,t} \\): The regional levy (or subsidy, if negative) per unit of commodity flow
 in time slice \\( t \\).
 
 ## Constraints
 
 ### Asset Activity Limits
 
-For each asset \\( a \\) and every time slice selection \\( S \\):
+For each asset \\( a \\) and every time slice selection \\( s \\):
 
 \\[
-  Avail\_{\mathrm{LB}}(a, S) \cdot \Delta\_S \cdot Capacity\_a \cdot \text{cap2act}\_a \le
-  \sum\_{t \in S} Activity\_{a, t} \le
-  Avail\_{\mathrm{UB}}(a, S) \cdot \Delta\_S \cdot Capacity\_a \cdot \text{cap2act}\_a
+  \mathrm{Avail}\_{\mathrm{LB},a,s} \cdot \Delta\_s \cdot \mathrm{Capacity}\_a \cdot \mathrm{cap2act}\_a
+  \le \sum\_{t \in s} \mathrm{Activity}\_{a, t} \le
+  \mathrm{Avail}\_{\mathrm{UB},a,s} \cdot \Delta\_s \cdot \mathrm{Capacity}\_a \cdot \mathrm{cap2act}\_a
 \\]
 
 where:
 
-- \\( Capacity_a \\) is the fixed installed capacity of the asset.
-- \\( \text{cap2act}_a \\) is the conversion factor from capacity to activity units.
-- \\( \Delta_S = \sum_{t \in S} \Delta_t \\) is the total duration of selection \\( S \\) as a
+- \\( \mathrm{Capacity}_a \\) is the fixed installed capacity of the asset.
+- \\( \mathrm{cap2act}_a \\) is the conversion factor from capacity to activity units.
+- \\( \Delta_s = \sum_{t \in s} \Delta_t \\) is the total duration of selection \\( s \\) as a
 fraction of the year.
-- \\( Avail_{\mathrm{LB}}(a, S) \\) and \\( Avail_{\mathrm{UB}}(a, S) \\) are the
+- \\( \mathrm{Avail}\_{\mathrm{LB},a,s} \\) and \\( \mathrm{Avail}\_{\mathrm{UB},a,s} \\) are the
 lower and upper availability fractions from `process_activity_limits.csv`, defaulting to
 \\( 0 \\) and \\( 1 \\) respectively for any selection not explicitly defined.
 
 ### Commodity Balance Constraints
 
 For each balanced commodity \\( c \in \mathbf{C}^{\mathrm{SED}} \cup \mathbf{C}^{\mathrm{SVD}} \\)
-in region \\( r \\) and time slice selection \\( S \\) at the commodity's temporal resolution
+in region \\( r \\) and time slice selection \\( s \\) at the commodity's temporal resolution
 (`time_slice_level`), the sum of production across all assets minus consumption must satisfy
 demands:
 
 \\[
-  \sum_{a \in \mathbf{A}(r)} f_{\mathrm{coeff}}(a, c) \cdot
-  \sum_{t \in S} Activity_{a, t} \ge \text{Bound}_{c, r, S}
+  \sum_{a \in \mathbf{A}\_r} f_{\mathrm{coeff},a,c} \cdot
+  \sum_{t \in s} \mathrm{Activity}_{a, t} \ge \mathrm{Bound}\_{c, r, s}
 \\]
 
 where:
 
-- \\( f_{\mathrm{coeff}}(a, c) \\) is the flow coefficient of commodity \\( c \\) for asset
+- \\( f_{\mathrm{coeff},a,c} \\) is the flow coefficient of commodity \\( c \\) for asset
 \\( a \\) (positive for outputs, negative for inputs).
-- \\( \text{Bound}\_{c, r, S} \\) is the constraint lower bound:
-  - For **Service Demand** (`SVD`): \\( \text{Demand}\_{c,r,S} \\)
+- \\( \mathrm{Bound}\_{c, r, s} \\) is the constraint lower bound:
+  - For **Service Demand** (`SVD`): \\( \mathrm{Demand}\_{c, r, s} \\)
   - For **Supply-Equals-Demand** (`SED`): \\( 0 \\)
 
 ## Shadow Prices
 
 The dual values (shadow prices) of the commodity balance constraints represent the marginal cost of
 satisfying an additional unit of demand for that commodity in region \\( r \\) during selection
- \\( S \\). These shadow prices are critical outputs of the dispatch model and are used to seed and
+ \\( s \\). These shadow prices are critical outputs of the dispatch model and are used to seed and
  guide investment appraisal in subsequent steps.
 
 ---
@@ -126,12 +126,12 @@ commodity, a small epsilon is added to the lower bound of commodity balance cons
 candidate assets are present:
 
 \\[
-  \text{Bound}\_{c, r, S} = \begin{cases}
-    \max\left( \text{Demand}\_{c, r, S}\, \epsilon \right) &
-      \text{if } c \in \mathbf{C}^{\mathrm{SVD}} \text{ and candidate assets serve } (c, r, S) \\\\
+  \mathrm{Bound}\_{c, r, s} = \begin{cases}
+    \max\left( \mathrm{Demand}\_{c, r, s}\, \epsilon \right) &
+      \text{if } c \in \mathbf{C}^{\mathrm{SVD}} \text{ and candidate assets serve } (c, r, s) \\\\
     \epsilon &
-      \text{if } c \in \mathbf{C}^{\mathrm{SED}} \text{ and candidate assets serve } (c, r, S) \\\\
-    \text{Demand}\_{c, r, S} &
+      \text{if } c \in \mathbf{C}^{\mathrm{SED}} \text{ and candidate assets serve } (c, r, s) \\\\
+    \mathrm{Demand}\_{c, r, s} &
       \text{if } c \in \mathbf{C}^{\mathrm{SVD}} \\\\
     0 &
       \text{if } c \in \mathbf{C}^{\mathrm{SED}}
@@ -156,22 +156,23 @@ To help debug and pinpoint the exact source of failure, MUSE2 employs a diagnost
 (without unmet demand variables).
 2. **Diagnostic Re-Run:** If the solver reports that the problem is infeasible, MUSE2 automatically
 spawns a second, diagnostic dispatch run. In this run, a set of slack variables representing unmet
-demand, \\( UnmetD_{c, r, t} \ge 0 \\), is added to the commodity balance constraints:
+demand, \\( \mathrm{UnmetD}\_{c, r, t} \ge 0 \\), is added to the commodity balance constraints:
    \\[
-     \sum_{a \in \mathbf{A}(r)} f_{\mathrm{coeff}}(a, c) \cdot \sum_{t \in S} Activity_{a, t} +
-      \sum_{t \in S} UnmetD_{c, r, t} \ge \text{Bound}_{c, r, S}
+     \sum_{a \in \mathbf{A}\_r} f\_{\mathrm{coeff},a,c} \cdot \sum\_{t \in s}
+     \mathrm{Activity}\_{a, t} +
+     \sum\_{t \in s} \mathrm{UnmetD}\_{c, r, t} \ge \mathrm{Bound}\_{c, r, s}
    \\]
 3. **Objective Penalty:** To ensure the solver only leaves demand unmet if it is physically
 impossible to satisfy it, these variables are heavily penalised in the diagnostic objective function
 using the `value_of_lost_load` parameter (\\( \mathrm{VoLL} \\)):
    \\[
-     \text{Minimise } \sum\_{a \in \mathbf{A}} \sum\_{t \in \mathbf{T}} Activity\_{a, t} \cdot
-      Cost\_{\mathrm{Activity}}(a, t) +
-    \mathrm{VoLL} \cdot \sum\_{c, r, t} UnmetD\_{c, r, t}
+     \text{Minimise } \sum\_{a \in \mathbf{A}} \sum\_{t \in \mathbf{T}} \mathrm{Activity}\_{a, t} \cdot
+      \mathrm{Cost}\_{\mathrm{Activity},a,t} +
+    \mathrm{VoLL} \cdot \sum\_{c, r, t} \mathrm{UnmetD}\_{c, r, t}
    \\]
-4. **Isolating Shortfalls:** The addition of \\( UnmetD_{c, r, t} \\) guarantees that the LP remains
-mathematically feasible. When solved, any time slice, region, or commodity with a shortfall
-will have \\( UnmetD_{c, r, t} > 0 \\).
+4. **Isolating Shortfalls:** The addition of \\( \mathrm{UnmetD}\_{c, r, t} \\) guarantees that the
+LP remains mathematically feasible. When solved, any time slice, region, or commodity with a
+shortfall will have \\( \mathrm{UnmetD}_{c, r, t} > 0 \\).
 5. **Error Reporting:** MUSE2 scans the solution, identifies all balanced markets \\( (c, r) \\)
 where unmet demand occurred, outputs detailed diagnostic CSV files, and aborts the simulation with
 an error identifying the exact out-of-balance markets.

--- a/docs/model/dispatch_optimisation.md
+++ b/docs/model/dispatch_optimisation.md
@@ -1,426 +1,177 @@
-# Dispatch Optimisation Formulation
+# Dispatch Optimisation
 
-<!-- We sometimes need a space after an underscore to make equations render properly -->
-<!-- markdownlint-disable MD037 -->
+This section describes the formulation of the dispatch optimisation model in MUSE2. For a given
+milestone year (MSY) and region, the dispatch model calculates the least-cost operation of the
+energy system assets to satisfy commodity demands. It is solved as a Linear Programme (LP) using the
+HiGHS solver.
 
-This dispatch optimisation model calculates the least-cost operation of the energy system for a
-given configuration of assets and capacities, subject to demands and constraints. It is the core
-engine used for each dispatch run referenced in the overall MUSE2 workflow. A key general
-assumption is that SVD commodities represent final demands only and are not consumed as inputs by
-any asset.
+## Sets and Indices
 
-## General Sets
+The energy system is defined using the following sets:
 
-These define the fundamental categories used to define the energy system.
+- \\( r \in \mathbf{R} \\): Regions. Represents distinct geographical areas.
+- \\( t \in \mathbf{T} \\): Time Slices. Discrete operational sub-periods within a year.
+- \\( S \in \mathbf{S} \\): Time Slice Selections. Collections of time slices representing temporal
+groupings at different levels (e.g. a single time slice, a season, or the entire year).
+- \\( a \in \mathbf{A} \\): Assets. All commissioned production, consumption, or conversion technologies.
+- \\( c \in \mathbf{C} \\): Commodities. All energy carriers, emissions, or materials, partitioned into:
+  - \\( \mathbf{C}^{\mathrm{SVD}} \\): Service Demand commodities (representing final end-use demands).
+  - \\( \mathbf{C}^{\mathrm{SED}} \\): Supply-Equals-Demand commodities (intermediate carrier flows
+  like electricity or hydrogen).
+  - \\( \mathbf{C}^{\mathrm{OTH}} \\): Other commodities (e.g. emissions or tracked flows not
+  subject to supply-demand balancing).
 
-- \\( \mathbf{R} \\): Set of Regions (indexed by \\( r \\)). Represents distinct geographical or
-  modelling areas.
+## Decision Variables
 
-- \\( \mathbf{T} \\): Set of Time Slices (indexed by \\( t \\)). Discrete operational periods within
-  a year.
+The dispatch model determines the following variables:
 
-- \\( \mathbf{H} \\): Set of Seasons (indexed by \\( h \\)). Collections of time slices.
+- \\( act_{a, t} \ge 0 \\): Activity level of asset \\( a \\) during time slice \\( t \\) (in units
+of activity, e.g. PJ/year or MW).
 
-- \\( \mathbf{A} \\): Set of All Assets (indexed by \\( a \\)). All existing and candidate
-  production, consumption, or conversion technologies.
+## Objective Function
 
-- \\( \mathbf{A}^{flex} \subseteq \mathbf{A} \\): Subset of Flexible Assets (variable input/output
-  ratios).
-
-- \\( \mathbf{A}^{std} = \mathbf{A} \setminus \mathbf{A}^{flex} \\): Subset of Standard Assets
-  (fixed input/output coefficients).
-
-- \\( \mathbf{C} \\): Set of Commodities (indexed by \\( c \\)). All energy carriers, materials, or
-  tracked flows. Partitioned into:
-
-  - \\( \mathbf{C}^{\mathrm{SVD}} \\): Supply-Driven Commodities (final demands; not consumed by
-    assets).
-
-  - \\( \mathbf{C}^{\mathrm{SED}} \\): Supply-Equals-Demand Commodities (intermediate system flows
-    like grid electricity).
-
-  - \\( \mathbf{C}^{\mathrm{OTH}} \\): Other Tracked Flows (e.g., losses, raw emissions).
-
-- \\( \mathbf{C}^{VoLL} \subseteq \mathbf{C}^{\mathrm{SVD}} \cup \mathbf{C}^{\mathrm{SED}} \\):
-  Subset of commodities where unserved demand is modelled with a penalty.
-
-- \\( \mathbf{P} \\): Set of External Pools/Markets (indexed by \\( p \\)).
-
-- \\( \mathbf{S} \\): Set of Scopes (indexed by \\( s \\)). Sets of \\( (r,t) \\) pairs for policy
-  application.
-
-## A. Core Model (Standard Assets: \\( a \in \mathbf{A}^{std} \\))
-
-**Purpose:** Defines the operation of assets with fixed, predefined input-output relationships.
-
-### A.1. Parameters (for \\( a \in \mathbf{A}^{std} \\) or global)
-
-- \\( duration[t] \\): Duration of time slice \\( t \\) as a fraction of the year (\\( \in (0,1]
-  \\)). Represents the portion of the year covered by this slice.
-
-- \\( season\\_ slice[h,t] \\): Binary indicator; \\( 1 \\) if time slice \\( t \\) is in season \\(
-  h \\), \\( 0 \\) otherwise. Facilitates seasonal aggregation.
-
-- \\( balance\\_ level[c,r] \\): Defines the temporal resolution ('timeslice', 'seasonal', 'annual')
-  at which the supply-demand balance for commodity \\( c \\) in region \\( r \\) must be enforced.
-
-- \\( demand[r,c] \\): Total annual exogenously specified demand (\\( \ge 0 \\)) for commodity \\( c
-  \in \mathbf{C}^{\mathrm{SVD}} \\) in region \\( r \\). This is the final demand to be met.
-
-- \\( timeslice\\_ share[c,t] \\): Fraction (\\( \in [0,1] \\)) of the annual \\( demand[r,c] \\)
-  for \\( c \in \mathbf{C}^{\mathrm{SVD}} \\) that occurs during time slice \\( t \\). (\\(
-  \sum_{t}timeslice\\_ share[c,t]=1 \\)). Defines the demand profile.
-
-- \\( capacity[a,r] \\): Installed operational capacity (\\( \ge 0 \\)) of asset \\( a \\) in region
-  \\( r \\) (e.g., MW for power plants). This value is an input to each dispatch run.
-
-- \\( cap2act[a] \\): Conversion factor (\\( >0 \\)) from asset capacity units to activity units,
-  ensuring consistency between capacity (e.g., MW) and activity (e.g., MWh produced in a slice)
-  considering \\( duration[t] \\).
-
-- \\( avail_{UB}[a,r,t], avail_{LB}[a,r,t], avail_{EQ}[a,r,t] \\): Availability factors (\\( \in
-  [0,1] \\)) for asset \\( a \\) in time slice \\( t \\). \\( UB \\) is maximum availability, \\( LB
-  \\) is minimum operational level, \\( EQ \\) specifies exact operation if required.
-
-- \\( cost_{var}[a,r,t] \\): Variable operating cost (\\( \ge 0 \\)) per unit of activity for asset
-  \\( a \\) (e.g., non-fuel O&M).
-
-- \\( input_{coeff}[a,c] \\): Units (\\( \ge 0 \\)) of commodity \\( c \in
-  (\mathbf{C}^{\mathrm{SED}} \cup \mathbf{C}^{\mathrm{OTH}}) \\) consumed by asset \\( a \\) per
-  unit of its activity. (By assumption, \\( input_{coeff}[a,c]=0 \\) if \\( c \in
-  \mathbf{C}^{\mathrm{SVD}} \\)).
-
-- \\( output_{coeff}[a,c] \\): Units (\\( \ge 0 \\)) of commodity \\( c \in \mathbf{C} \\) produced
-  by asset \\( a \\) per unit of its activity.
-
-- \\( cost_{input}[a,c] \\): Specific cost (\\( \ge 0 \\)) per unit of input commodity \\( c \\)
-  consumed by asset \\( a \\). Useful if \\( c \\) attracts a levy/incentive \\( only \\) if it is
-  consumed by this type of asset.
-
-- \\( cost_{output}[a,c] \\): Specific cost (if positive) or revenue (if negative) per unit of
-  output commodity \\( c \\) produced by asset \\( a \\). Useful if levy/incentive applies \\( only
-  \\) when the commodity is produced by this type of asset.
-
-- \\( VoLL[c,r] \\): Value of Lost Load. A very high penalty cost applied per unit of unserved
-  demand for \\( c \in \mathbf{C}^{VoLL} \\) in region \\( r \\).
-
-### A.2. Decision Variables
-
-These are the quantities the dispatch optimisation model determines.
-
-- \\( act[a,r,t]\ge0 \\): Activity level of asset \\( a \\) in region \\( r \\) during time slice
-  \\( t \\). This is the primary operational decision for each asset.
-
-- \\( UnmetD[c,r,t]\ge0 \\): Unserved demand for commodity \\( c \in \mathbf{C}^{VoLL} \\) in region
-  \\( r \\) during time slice \\( t \\). This variable allows the model to find a solution even if
-  capacity is insufficient.
-
-### A.3. Objective Contribution (for standard assets \\( a \in \mathbf{A}^{std} \\))
-
-This term represents the sum of operational costs associated with standard assets, forming a
-component of the overall system cost that the model seeks to minimise.
+The objective is to minimise the total operating cost of the energy system:
 
 \\[
-  \sum_{a\in \mathbf{A}^{std}}\sum_{r,t} act[a,r,t]
-  \Biggl(
-    cost_{var}[a,r,t] +
-    \sum_{c \notin \mathbf{C}^{\mathrm{SVD}}} cost_{input}[a,c]\\,input_{coeff}[a,c] +
-    \sum_{c \in \mathbf{C}} cost_{output}[a,c]\\,output_{coeff}[a,c]
-  \Biggr)
+  \text{Minimise } \sum_{a \in \mathbf{A}} \sum_{t \in \mathbf{T}} act_{a, t} \cdot
+  c_{\mathrm{act}}(a, t)
 \\]
 
-### A.4. Constraints (Capacity & Availability for standard assets \\( a \in \mathbf{A}^{std} \\))
+### Activity Cost Coefficient \\( c_{\mathrm{act}}(a, t) \\)
 
-These constraints ensure that each standard asset's operation respects its physical capacity and
-time-varying availability limits. For all \\( a \in \mathbf{A}^{std}, r, t \\):
-
-- Asset activity \\( act[a,r,t] \\) is constrained by its available capacity, considering its
-  minimum operational level (lower bound, LB) and maximum availability (upper bound, UB):
-
-    \\[
-      \begin{aligned}
-        capacity[a,r]\\,cap2act[a]\\,avail_{LB}[a,t]\\,duration[t] &\le act[a,r,t] \\\\
-        act[a,r,t] &\le capacity[a,r]\\,cap2act[a]\\,avail_{UB}[a,t]\\,duration[t]
-      \end{aligned}
-    \\]
-
-- If an exact operational level is mandated (e.g., for some renewables based on forecast, or fixed
-  generation profiles for specific assets):
-
-  \\[ act[a,r,t] = capacity[a,r]\\,cap2act[a]\\,avail_{EQ}[a,t]\\,duration[t] \\]
-
-## B. Flexible Assets (\\( a \in \mathbf{A}^{flex} \\))
-
-**Purpose:** This section defines the operational characteristics of flexible assets, which can
-adjust their input consumption mix and/or output product shares, governed by an overall process
-efficiency. The generic activity variable \\( act[a,r,t] \\) (linked to the asset's physical \\(
-capacity[a,r] \\)) is connected to the scale of this flexible conversion process via a reference
-output parameter. It is assumed that SVD commodities cannot be efficiency-constrained or auxiliary
-inputs to these assets.
-
-### B.1. Asset-Specific Sets (Defined for each flexible asset \\( a \in \mathbf{A}^{flex} \\))
-
-These sets categorize the commodities involved in the flexible asset's operation.
-
-- \\( \mathbf{C}^{eff\\_ in}_a \subseteq (\mathbf{C}^{\mathrm{SED}} \cup \mathbf{C}^{\mathrm{OTH}})
-  \\): Set of input commodities for asset \\( a \\) whose combined energy or mass content is subject
-  to the main process efficiency \\( \eta[a] \\).
-
-- \\( \mathbf{C}^{eff\\_ out}_a \subseteq \mathbf{C} \\): Set of main output commodities from asset
-  \\( a \\) whose combined energy or mass content is determined by \\( \eta[a] \\) and the processed
-  inputs.
-
-- \\( \mathbf{C}^{aux\\_ in}_a \subseteq (\mathbf{C}^{\mathrm{SED}} \cup \mathbf{C}^{\mathrm{OTH}})
-  \\): Set of auxiliary input commodities for asset \\( a \\) (e.g., water, catalysts) whose
-  consumption is typically proportional to the main activity \\( act[a,r,t] \\) but which are not
-  part of the primary energy/mass balance for the efficiency calculation.
-
-- \\( \mathbf{C}^{aux\\_ out}_a \subseteq \mathbf{C} \\): Set of auxiliary output commodities for
-  asset \\( a \\) (e.g., specific emissions, waste streams) whose production is typically
-  proportional to \\( act[a,r,t] \\) but which are not counted in the efficiency calculation for the
-  primary products.
-
-### B.2. Parameters (for \\( a \in \mathbf{A}^{flex} \\))
-
-These parameters define the technical and economic behavior of flexible assets.
-
-- \\( \eta[a] \\): The overall process efficiency (\\( \in (0,1] \\)) of flexible asset \\( a \\),
-  relating total common units of outputs in \\( \mathbf{C}^{eff\\_out}_a \\) to inputs in \\(
-  \mathbf{C}^{eff\\_in}_a \\).
-
-- \\( factor_{CU}[c] \\): A commodity-specific factor to convert its native physical units (e.g.,
-  tonnes, m³) to a common unit (e.g., MWh of energy content, or tonnes of mass if it's a mass
-  balance) used for consistent efficiency and input/output share calculations.
-
-- \\( RefEffOutPerAct[a] \\): Reference Total Efficiency-constrained Output per unit of Activity.
-  This crucial parameter defines the total quantity of efficiency-constrained outputs (summed in
-  common units using \\( factor_{CU}[c] \\)) that are produced when asset \\( a \\) operates at one
-  unit of its generic activity level \\( act[a,r,t] \\).
-
-- \\( minInputShare[a,c] \\) (for \\( c \in \mathbf{C}^{eff\\_ in}_a \\)): Minimum fractional share
-  of input commodity \\( c \\) (in common units) relative to the total efficiency-constrained input
-  (in common units).
-
-- \\( maxInputShare[a,c] \\) (for \\( c \in \mathbf{C}^{eff\\_ in}_a \\)): Maximum fractional share
-  for input \\( c \\).
-
-- \\( minOutputShare[a,c] \\) (for \\( c \in \mathbf{C}^{eff\\_ out}_a \\)): Minimum fractional
-  share of output commodity \\( c \\) (in common units) relative to the total efficiency-constrained
-  output.
-
-- \\( maxOutputShare[a,c] \\) (for \\( c \in \mathbf{C}^{eff\\_ out}_a \\)): Maximum fractional
-  share for output \\( c \\).
-
-- \\( coeff_{aux\\_ in}[a,c] \\) (for \\( c \in \mathbf{C}^{aux\\_ in}_a \\)): Quantity of auxiliary
-  input \\( c \\) consumed per unit of \\( act[a,r,t] \\).
-
-- \\( coeff_{aux\\_ out}[a,c] \\) (for \\( c \in \mathbf{C}^{aux\\_ out}_a \\)): Quantity of
-  auxiliary output \\( c \\) produced per unit of \\( act[a,r,t] \\).
-
-### B.3. Decision Variables (for \\( a \in \mathbf{A}^{flex} \\))
-
-These variables represent the operational choices for flexible assets.
-
-- \\( act[a,r,t]\ge0 \\): Generic activity level of flexible asset \\( a \\) (linked to its \\(
-  capacity[a,r] \\)).
-
-- \\( InputSpec[a,c,r,t]\ge0 \quad \forall c \in \mathbf{C}^{eff\\_ in}\_a \\): Actual amount of
-  efficiency-constrained input commodity \\( c \\) consumed by asset \\( a \\) in region \\( r \\),
-  time \\( t \\) (in its native physical units).
-
-- \\( OutputSpec[a,c,r,t]\ge0 \quad \forall c \in \mathbf{C}^{eff\\_ out}\_a \\): Actual amount of
-  efficiency-constrained output commodity \\( c \\) produced by asset \\( a \\) in region \\( r \\),
-  time \\( t \\) (in its native physical units).
-
-### B.4. Objective Contribution (for \\( a \in \mathbf{A}^{flex} \\))
-
-The cost contribution from flexible assets includes costs related to their generic activity,
-specific costs for efficiency-constrained inputs and outputs (if defined separately from system
-commodity values), and costs/revenues for auxiliary inputs and outputs.
+The cost per unit of activity for asset \\( a \\) in time slice \\( t \\) is composed of variable
+operating costs, flow costs, and levies:
 
 \\[
-  \begin{aligned}
-    &act[a,r,t] \cdot cost\_{var}[a,r,t] \\\\
-    &+ \sum\_{c \in \mathbf{C}^{eff\\_ in}\_a} InputSpec[a,c,r,t] \cdot cost\_{input}[a,c] \\\\
-    &+ \sum\_{c \in \mathbf{C}^{eff\\_ out}\_a} OutputSpec[a,c,r,t] \cdot cost\_{output}[a,c] \\\\
-    &+ \sum\_{c \in \mathbf{C}^{aux\\_ in}\_a} (act[a,r,t] \cdot coeff\_{aux\\_ in}[a,c])
-      \cdot cost\_{input}[a,c] \\\\
-    &+ \sum\_{c \in \mathbf{C}^{aux\\_ out}\_a} (act[a,r,t] \cdot coeff\_{aux\\_ out}[a,c])
-      \cdot cost\_{output}[a,c] \\\\
-  \end{aligned}
+  c\_{\mathrm{act}}(a, t) = \text{VariableOpex}\_a +
+  \sum\_{f \in \text{Flows}\_a} |f\_{\mathrm{coeff}}| \cdot
+  \left( f\_{\mathrm{cost}} + \mathrm{levy}\_f(t) \right)
 \\]
 
-### B.5. Constraints (for \\( a \in \mathbf{A}^{flex}, r \in \mathbf{R}, t \in \mathbf{T} \\))
+- **VariableOpex**: The non-fuel variable O&M cost of the process.
+- \\( f_{\mathrm{coeff}} \\): The flow coefficient for a commodity flow associated with the asset
+(positive for output/production, negative for input/consumption).
+- \\( f_{\mathrm{cost}} \\): The cost per unit of commodity flow.
+- \\( \mathrm{levy}_f(t) \\): The regional levy (or subsidy, if negative) per unit of commodity flow
+in time slice \\( t \\).
 
-These rules govern the internal operation and conversion process of flexible assets. Let \\(
-ActualTotalEffOutputCU[a,r,t] = RefEffOutPerAct[a] \cdot act[a,r,t] \\) (This is the total
-efficiency-constrained output in common units). Let \\( ActualTotalEffInputCU[a,r,t] =
-(RefEffOutPerAct[a] / \eta[a]) \cdot act[a,r,t] \\) (This is the total efficiency-constrained input
-in common units, derived from the output and efficiency).
+## Constraints
 
-- **Capacity & Availability:** Standard capacity and availability constraints (as in A.4) apply to
-  the generic activity variable \\( act[a,r,t] \\) of the flexible asset.
+### Asset Activity Limits
 
-- **Total Efficiency-Constrained Input Definition:** The sum of all specific efficiency-constrained
-  inputs, when converted to common units by \\( factor_{CU}[c] \\), must equal the total
-  efficiency-constrained input derived from \\( act[a,r,t] \\) and the asset's efficiency:
-
-  \\[
-    \sum\_{c \in \mathbf{C}^{eff\\_ in}\_a} InputSpec[a,c,r,t] \cdot factor\_{CU}[c]
-      = ActualTotalEffInputCU[a,r,t]
-  \\]
-
-- **Total Efficiency-Constrained Output Definition:** Similarly, the sum of all specific main
-  outputs (in common units) must equal the total defined by \\( act[a,r,t] \\) and the reference
-  output parameter:
-
-  \\[
-    \sum\_{c \in \mathbf{C}^{eff\\_out}\_a} OutputSpec[a,c,r,t] \cdot factor\_{CU}[c]
-      = ActualTotalEffOutputCU[a,r,t]
-  \\]
-
-- **Input Share Constraints** (for each \\( c \in \mathbf{C}^{eff\\_in}_a \\)): Ensure that each
-  individual efficiency-constrained input (in common units) stays within its defined minimum (\\(
-  minInputShare[a,c] \\)) and maximum (\\( maxInputShare[a,c] \\)) fractional share of the \\(
-  ActualTotalEffInputCU[a,r,t] \\).
-
-  \\[
-    \begin{aligned}
-      InputSpec[a,c,r,t] \cdot factor\_{CU}[c]
-        &\ge minInputShare[a,c] \cdot ActualTotalEffInputCU[a,r,t] \\\\
-      InputSpec[a,c,r,t] \cdot factor\_{CU}[c]
-        &\le maxInputShare[a,c] \cdot ActualTotalEffInputCU[a,r,t]
-    \end{aligned}
-  \\]
-
-- **Output Share Constraints** (for each \\( c \in \mathbf{C}^{eff\\_out}_a \\)): Ensure that each
-  individual efficiency-constrained output (in common units) stays within its defined minimum (\\(
-  minOutputShare[a,c] \\)) and maximum (\\( maxOutputShare[a,c] \\)) fractional share of the \\(
-  ActualTotalEffOutputCU[a,r,t] \\).
-
-  \\[
-    \begin{aligned}
-      OutputSpec[a,c,r,t] \cdot factor\_{CU}[c]
-        &\ge minOutputShare[a,c] \cdot ActualTotalEffOutputCU[a,r,t] \\\\
-      OutputSpec[a,c,r,t] \cdot factor\_{CU}[c]
-        &\le maxOutputShare[a,c] \cdot ActualTotalEffOutputCU[a,r,t]
-    \end{aligned}
-  \\]
-
-## C. Full Model Construction
-
-> Note: This section includes references to many features that are not described elsewhere in this
-> document or implemented yet (e.g. region-to-region trade), but these are included for
-> completeness. This represents the roadmap for future MUSE2 development.
-
-This section describes how all preceding components are integrated to form the complete dispatch
-optimisation problem.
-
-### C.1. Objective Function
-
-The overall objective is to minimise the total system cost, which is the sum of all operational
-costs from assets (standard and flexible), financial impacts from policy scopes (taxes minus
-credits), costs of inter-regional trade, costs of pool-based trade, and importantly, the high
-economic penalties associated with any unserved demand for critical commodities:
+For each asset \\( a \\) and every time slice selection \\( S \\):
 
 \\[
-  \begin{aligned}
-    \text{Minimise: } &(\text{Core Asset Operational Costs from A.3 and B.4}) \\\\
-    &+ \sum_{c \in \mathbf{C}^{VoLL},r,t} UnmetD[c,r,t] \cdot VoLL[c,r]
-    \quad \text{(Penalty for Unserved Demand)}
-  \end{aligned}
+  avail\_{\mathrm{LB}}(a, S) \cdot \Delta\_S \cdot cap\_a \cdot \text{cap2act}\_a \le
+  \sum\_{t \in S} act\_{a, t} \le
+  avail\_{\mathrm{UB}}(a, S) \cdot \Delta\_S \cdot cap\_a \cdot \text{cap2act}\_a
 \\]
 
-Note that the unmet demand variables (\\( UnmetD[c,r,t] \\)) are normally not included in the
-optimisation and are currently only used to diagnose the source of errors when running the model.
+where:
 
-### C.2. Constraints
+- \\( cap_a \\) is the fixed installed capacity of the asset.
+- \\( \text{cap2act}_a \\) is the conversion factor from capacity to activity units.
+- \\( \Delta_S = \sum_{t \in S} \Delta_t \\) is the total duration of selection \\( S \\) as a
+fraction of the year.
+- \\( avail_{\mathrm{LB}}(a, S) \\) and \\( avail_{\mathrm{UB}}(a, S) \\) are the lower and upper
+availability fractions from `process_activity_limits.csv`, defaulting to \\( 0 \\) and \\( 1 \\)
+respectively for any selection not explicitly defined.
 
-The complete set of constraints that the optimisation must satisfy includes:
+### Commodity Balance Constraints
 
-- Capacity & Availability constraints for all assets \\( a \in \mathbf{A} \\)
-  (as per [A.4] and [B.5])
-
-- [Flexible Asset operational constraints][B.5]
-
-[A.4]: #a4-constraints-capacity--availability-for-standard-assets--a-in-mathbfastd-
-[B.5]: #b5-constraints-for--a-in-mathbfaflex-r-in-mathbfr-t-in-mathbft-
-
-#### Demand Satisfaction for \\( c\in \mathbf{C}^{\mathrm{SVD}} \\)
-
-These constraints ensure that exogenously defined final demands for SVDs are met in each region \\(
-r \\) and time slice \\( t \\), or any shortfall is explicitly accounted for.
-
-For all \\( r,t,c \in \mathbf{C}^{\mathrm{SVD}} \\): Let \\( TotalSystemProduction_{SVD}[c,r,t] \\)
-be the sum of all production of \\( c \\) from standard assets (\\( output_{coeff}[a,c]\\,act[a,r,t]
-\\)) and flexible assets (the relevant \\( OutputSpec[a,c,r,t] \\) if \\( c \in
-\mathbf{C}\_a^{eff\\_out} \\), or \\( act[a,r,t] \cdot coeff\_{aux\\_out}[a,c] \\) if \\( c \in
-\mathbf{C}^{aux\\_out}\_a \\)).
-
-Let \\( NetImports_{SVD}[c,r,t] \\) be net imports of \\( c \\) from R2R and Pool trade if SVDs are
-tradeable. If \\( c \in \mathbf{C}^{VoLL} \\) (meaning unserved demand for this SVD is permitted at
-a penalty):
+For each balanced commodity \\( c \in \mathbf{C}^{\mathrm{SED}} \cup \mathbf{C}^{\mathrm{SVD}} \\)
+in region \\( r \\) and time slice selection \\( S \\) at the commodity's temporal resolution
+(`time_slice_level`), the sum of production across all assets minus consumption must satisfy
+demands:
 
 \\[
-  TotalSystemProduction_{SVD}[c,r,t] + NetImports_{SVD}[c,r,t] + UnmetD[c,r,t]
-    \ge demand[r,c] \times timeslice\\_ share[c,t]
+  \sum_{a \in \mathbf{A}(r)} f_{\mathrm{coeff}}(a, c) \cdot
+  \sum_{t \in S} act_{a, t} \ge \text{Bound}_{c, r, S}
 \\]
 
-Else (if SVD \\( c \\) must be strictly met and is not included in \\( \mathbf{C}^{VoLL} \\)):
+where:
+
+- \\( f_{\mathrm{coeff}}(a, c) \\) is the flow coefficient of commodity \\( c \\) for asset
+\\( a \\) (positive for outputs, negative for inputs).
+- \\( \text{Bound}\_{c, r, S} \\) is the constraint lower bound:
+  - For **Service Demand** (`SVD`): \\( \text{Demand}\_{c,r,S} \\)
+  - For **Supply-Equals-Demand** (`SED`): \\( 0 \\)
+
+## Shadow Prices
+
+The dual values (shadow prices) of the commodity balance constraints represent the marginal cost of
+satisfying an additional unit of demand for that commodity in region \\( r \\) during selection
+ \\( S \\). These shadow prices are critical outputs of the dispatch model and are used to seed and
+ guide investment appraisal in subsequent steps.
+
+---
+
+## Candidate Dispatch Run
+
+After the primary dispatch run, MUSE2 performs a second dispatch run that includes
+**candidate assets** — technologies not yet commissioned but available for investment — alongside
+the existing assets. The purpose of this run is to obtain shadow prices for commodities that are
+not consumed or produced in the primary dispatch solution.
+
+In the primary dispatch, a commodity balance constraint will only have a non-zero shadow price if
+the corresponding constraint is binding (i.e. supply exactly meets demand). For a commodity that is
+neither produced nor consumed by any active asset, the constraint is trivially satisfied and its
+dual value is zero. This gives no signal to the investment model about the potential value of new
+capacity for that commodity.
+
+By including candidate assets in the second run, MUSE2 ensures that every commodity served by at
+least one candidate process has a balance constraint that can be binding, yielding a meaningful
+shadow price. To guarantee a non-zero shadow price even when there is no existing demand for the
+commodity, a small epsilon is added to the lower bound of commodity balance constraints where
+candidate assets are present:
 
 \\[
-  TotalSystemProduction_{SVD}[c,r,t] + NetImports_{SVD}[c,r,t]
-    \ge demand[r,c] \times timeslice\\_ share[c,t]
+  \text{Bound}\_{c, r, S} = \begin{cases}
+    \max\left( \text{Demand}\_{c, r, S}\, \epsilon \right) &
+      \text{if } c \in \mathbf{C}^{\mathrm{SVD}} \text{ and candidate assets serve } (c, r, S) \\\\
+    \epsilon &
+      \text{if } c \in \mathbf{C}^{\mathrm{SED}} \text{ and candidate assets serve } (c, r, S) \\\\
+    \text{Demand}\_{c, r, S} &
+      \text{if } c \in \mathbf{C}^{\mathrm{SVD}} \\\\
+    0 &
+      \text{if } c \in \mathbf{C}^{\mathrm{SED}}
+  \end{cases}
 \\]
 
-#### Commodity Balance for \\( c\in \mathbf{C}^{\mathrm{SED}} \\)
+where \\( \epsilon \\) is the `commodity_balance_epsilon` parameter. The shadow prices from this
+candidate dispatch run are then used to seed and guide investment appraisal in subsequent steps.
 
-These constraints ensure that for all intermediate SED commodities, total supply equals total demand
-within each region \\( r \\) and for each balancing period defined by \\( balance\\_ level[c,r] \\)
-(e.g., timeslice, seasonal, annual).
+---
 
-For a timeslice balance (\\( \forall r,t,c \in \mathbf{C}^{\mathrm{SED}} \\)):
+## Diagnosing Infeasible Models
 
-Total Inflows (Local Production by all assets + Imports from other regions and pools + Unserved SED
-if \\( c \in \mathbf{C}^{VoLL} \\)) = Total Outflows (Local Consumption by all assets + Exports to
-other regions).
+In practice, a dispatch optimisation run can fail if the problem is **infeasible** — typically
+because the installed asset capacity in the region is insufficient to meet the required exogenous or
+intermediate commodity demands.
 
-\\[
-  \begin{aligned}
-    &\sum\_{a \in \mathbf{A}^{std}} output_{coeff}[a,c]\\,act[a,r,t]
-      && \text{(Std Asset Production)} \\\\
-    &+ \sum\_{a \in \mathbf{A}^{flex}}
-      \left(
-        \begin{cases}
-          OutputSpec[a,c,r,t] & \text{if } c \in \mathbf{C}^{eff\\_out}\_a \\\\
-          act[a,r,t] \cdot coeff\_{aux\\_out}[a,c] & \text{if } c \in \mathbf{C}^{aux\\_out}\_a \\\\
-          0 & \text{otherwise}
-        \end{cases}
-      \right)
-      && \text{(Flex Asset Production)} \\\\
-    &-\sum\_{a \in \mathbf{A}^{std}} input\_{coeff}[a,c]\\,act[a,r,t]
-      && \text{(Std Asset Consumption)} \\\\
-    &- \sum\_{a \in \mathbf{A}^{flex}}
-      \left(
-        \begin{cases}
-          InputSpec[a,c,r,t] & \text{if } c \in \mathbf{C}^{eff\\_in}\_a \\\\
-          act[a,r,t] \cdot coeff\_{aux\\_in}[a,c] & \text{if } c \in \mathbf{C}^{aux\\_in}\_a \\\\
-          0 & \text{otherwise}
-        \end{cases}
-      \right)
-      && \text{(Flex Asset Consumption)} \\\\
-    &+ \sum\_{r'\neq r, c \in \mathbf{C}^R} ship\_{R2R}[r',r,c,t](1 - loss\_{R2R}[r',r,c,t])
-      && \text{(R2R Imports)} \\\\
-    &+ \sum\_{p, c \in \mathbf{C}^P} ship\_{pool}[p,r,c,t](1 - loss\_{pool}[p,r,c,t])
-      && \text{(Pool Imports)} \\\\
-    &- \sum\_{r'\neq r, c \in \mathbf{C}^R} ship\_{R2R}[r,r',c,t]
-      && \text{(R2R Exports)} \\\\
-    &+ \mathbb{I}(c \in \mathbf{C}^{VoLL}) \cdot UnmetD[c,r,t]
-      && \text{(Unserved SED, if modelled)} \\\\
-    &\ge 0
-  \end{aligned}
-\\]
+To help debug and pinpoint the exact source of failure, MUSE2 employs a diagnostic mechanism using
+**unmet demand variables**:
 
-(where \\( \mathbb{I}(c \in \mathbf{C}^{VoLL}) \\) is an indicator function, \\( 1 \\) if \\( c \\)
-is in \\( \mathbf{C}^{VoLL} \\), \\( 0 \\) otherwise. Note that SVDs are not consumed by assets, so
-\\( input_{coeff}[a,c] \\) and related terms for SVDs on the consumption side are zero).
+1. **First-Pass Run:** MUSE2 first attempts to solve the dispatch model in its standard form
+(without unmet demand variables).
+2. **Diagnostic Re-Run:** If the solver reports that the problem is infeasible, MUSE2 automatically
+spawns a second, diagnostic dispatch run. In this run, a set of slack variables representing unmet
+demand, \\( UnmetD_{c, r, t} \ge 0 \\), is added to the commodity balance constraints:
+   \\[
+     \sum_{a \in \mathbf{A}(r)} f_{\mathrm{coeff}}(a, c) \cdot \sum_{t \in S} act_{a, t} +
+      \sum_{t \in S} UnmetD_{c, r, t} \ge \text{Bound}_{c, r, S}
+   \\]
+3. **Objective Penalty:** To ensure the solver only leaves demand unmet if it is physically
+impossible to satisfy it, these variables are heavily penalised in the diagnostic objective function
+using the `value_of_lost_load` parameter (\\( \mathrm{VoLL} \\)):
+   \\[
+     \text{Minimise } \sum\_{a \in \mathbf{A}} \sum\_{t \in \mathbf{T}} act\_{a, t} \cdot
+      c\_{\mathrm{act}}(a, t) +
+    \mathrm{VoLL} \cdot \sum\_{c, r, t} UnmetD\_{c, r, t}
+   \\]
+4. **Isolating Shortfalls:** The addition of \\( UnmetD_{c, r, t} \\) guarantees that the LP remains
+mathematically feasible. When solved, any time slice, region, or commodity with a shortfall
+will have \\( UnmetD_{c, r, t} > 0 \\).
+5. **Error Reporting:** MUSE2 scans the solution, identifies all balanced markets \\( (c, r) \\)
+where unmet demand occurred, outputs detailed diagnostic CSV files, and aborts the simulation with
+an error identifying the exact out-of-balance markets.

--- a/docs/model/dispatch_optimisation.md
+++ b/docs/model/dispatch_optimisation.md
@@ -162,7 +162,7 @@ demand, \\( \mathrm{UnmetD}\_{c, r, t} \ge 0 \\), is added to the commodity bala
      \mathrm{Activity}\_{a, t} +
      \sum\_{t \in s} \mathrm{UnmetD}\_{c, r, t} \ge \mathrm{Bound}\_{c, r, s}
    \\]
-3. **Objective Penalty:** To ensure the solver only leaves demand unmet if it is physically
+3. **Objective Penalty:** To ensure the solver only leaves demand unmet if it is mathematically
 impossible to satisfy it, these variables are heavily penalised in the diagnostic objective function
 using the `value_of_lost_load` parameter (\\( \mathrm{VoLL} \\)):
    \\[

--- a/docs/model/dispatch_optimisation.md
+++ b/docs/model/dispatch_optimisation.md
@@ -23,10 +23,16 @@ groupings at different levels (e.g. a single time slice, a season, or the entire
 
 ## Decision Variables
 
-The dispatch model determines the following variables:
+The dispatch model determines the activity level of all assets \\( a \in \mathbf{A} \\) in all time
+slices \\( t \in \mathbf{T}\\):
 
-- \\( \mathrm{Activity}_{a, t} \ge 0 \\): Activity level of asset \\( a \\) during time slice
-\\( t \\) (in units of activity, e.g. PJ/year or MW).
+\\[
+  \mathrm{Activity}_{a, t} \ge 0 \text{ for all } a \in \mathbf{A}, t \in \mathbf{T}
+\\]
+
+Activity is a dimensionless quantity representing the level of operation of the asset. It is
+multiplied by flow coefficients to give the corresponding commodity flows in the units of that
+commodity (e.g. PJ of energy for an energy flow).
 
 ## Objective Function
 

--- a/docs/model/investment.md
+++ b/docs/model/investment.md
@@ -20,10 +20,13 @@ investment in electricity generation would happen before investment in gas produ
 This ordering ensures that when an upstream market is being invested in, the
 demand created by already-committed downstream assets is already known.
 
-After each commodity market is settled, a [partial system dispatch](#partial-system-dispatch) is
-run over all assets selected so far. This quantifies the input commodity flows consumed by newly
-committed assets — for example, a gas generator committed during electricity market investment will
-consume gas, creating demand that the gas market investment must subsequently meet.
+Markets are processed in **layers**: a layer is a set of commodity markets that are independent of
+one another (i.e. at the same depth in the commodity graph and with no dependencies between them).
+All markets within a layer are settled before moving to the next layer. After each layer is
+settled, a single [partial system dispatch](#partial-system-dispatch) is run over all assets
+selected so far. This quantifies the input commodity flows consumed by newly committed assets —
+for example, a gas generator committed during electricity market investment will consume gas,
+creating demand that the gas market investment must subsequently meet.
 
 Only commodities of type `ServiceDemand` and `SupplyEqualsDemand` are subject to
 investment decisions. Other commodity types (e.g. `OTH`) are excluded.
@@ -431,9 +434,9 @@ available options.
 
 ## Partial System Dispatch
 
-After each commodity market is settled during the investment loop, a **partial system dispatch** is
-run over all assets selected so far. This is a standard [dispatch optimisation][dispatch-optimisation]
-solve, with three key modifications described below.
+After each layer of commodity markets is settled during the investment loop, a **partial system
+dispatch** is run over all assets selected so far. This is a standard
+[dispatch optimisation][dispatch-optimisation] solve, with three key modifications described below.
 
 ### Market subset
 

--- a/docs/model/investment.md
+++ b/docs/model/investment.md
@@ -85,23 +85,23 @@ For each commodity market, agents consider two categories of supply option:
 The annualised fixed cost (AFC) per unit of capacity differs between the two categories:
 
 - **Existing assets**: AFC comprises only the fixed operations and maintenance (O&M) cost
-(\\( \text{FOM} \\)):
+(\\( \mathrm{FOM} \\)):
   \\[
-    \text{AFC}_\text{existing} = \text{FOM}
+    \mathrm{AFC}_{\mathrm{existing}} = \mathrm{FOM}
   \\]
 
 - **Candidate assets**: AFC includes annualised capital expenditure plus fixed O&M:
   \\[
-    \text{AFC}_\text{candidate} = \text{CAPEX} \times \text{CRF} + \text{FOM}
+    \mathrm{AFC}_{\mathrm{candidate}} = \mathrm{CAPEX} \times \mathrm{CRF} + \mathrm{FOM}
   \\]
 
   where the Capital Recovery Factor (CRF) annualises the upfront capital cost over the asset's
   lifetime \\( L \\) at discount rate \\( d \\):
   \\[
-    \text{CRF} = \frac{d \cdot (1 + d)^L}{(1 + d)^L - 1}
+    \mathrm{CRF} = \frac{d \cdot (1 + d)^L}{(1 + d)^L - 1}
   \\]
 
-  If \\( d = 0 \\), then \\( \text{CRF} = 1/L \\).
+  If \\( d = 0 \\), then \\( \mathrm{CRF} = 1/L \\).
 
 ## Asset Capacity
 
@@ -135,8 +135,8 @@ capacity can be installed in a single investment round (subject to further
   total remaining demand if the asset operated at its maximum annual rate:
 
   \\[
-    \text{TrialCapacity} = \frac{\sum_t \text{Demand}_t}{\text{MaxAnnualSupplyPerCapacity}}
-    \times \text{CapacityLimitFactor}
+    \mathrm{TrialCapacity} = \frac{\sum_t \mathrm{Demand}_t}{\mathrm{MaxAnnualSupplyPerCapacity}}
+    \times \mathrm{CapacityLimitFactor}
   \\]
 
   `capacity_limit_factor` (set in [`model.toml`][model-toml], must be > 0 and <= 1) controls the
@@ -150,8 +150,8 @@ In each investment round, a candidate's trial capacity is further capped by the
 across all time-slice selections:
 
 \\[
-  \text{DLC} = \max_{\text{selection}} \frac{\sum_{t \in \text{selection}} \text{Demand}\_t}
-    {\text{MaxSupplyPerCapacity}_\text{selection}}
+  \mathrm{DLC} = \max_{\mathrm{selection}} \frac{\sum_{t \in \mathrm{selection}} \mathrm{Demand}\_t}
+    {\mathrm{MaxSupplyPerCapacity}_{\mathrm{selection}}}
 \\]
 
 Selections where the asset has zero maximum supply are excluded. The cap prevents over-investment
@@ -164,12 +164,12 @@ Processes may have an `addition_limit` (see
 maximum new capacity that can be built per year. The installable capacity limit for a given MSY is:
 
 \\[
-  \text{MaxInstallableCapacity} = \text{AdditionLimit} \times \Delta_\text{MSY}
-    \times \text{AgentPortion}
+  \mathrm{MaxInstallableCapacity} = \mathrm{AdditionLimit} \times \Delta_{\mathrm{MSY}}
+    \times \mathrm{AgentPortion}
 \\]
 
-where \\( \Delta_\text{MSY} \\) is the number of years since the previous MSY and
-\\( \text{AgentPortion} \\) is the fraction of the commodity market for which this agent is
+where \\( \Delta_{\mathrm{MSY}} \\) is the number of years since the previous MSY and
+\\( \mathrm{AgentPortion} \\) is the fraction of the commodity market for which this agent is
 responsible.
 
 If the remaining installable capacity is exhausted, the candidate is excluded from further
@@ -185,27 +185,27 @@ optimal activity profile given the current remaining demand.
 The mini dispatch optimisation implicitly frames each time slice as a choice: the asset can either
 produce the commodity of interest, or it can be treated as procured from an alternative source at
 the **fallback price** \\( \phi_{c,r,t} \\). Each unit of activity produces
-\\( f_{c,\text{primary}} \\) units of output, displacing that quantity from the fallback source.
+\\( f_{c,\mathrm{primary}} \\) units of output, displacing that quantity from the fallback source.
 The optimiser therefore dispatches the asset whenever doing so is cheaper than procuring from
 elsewhere.
 
 This is captured by the activity coefficient \\( \alpha_t \\), which combines two components:
 
 \\[
-  \text{NetOperatingCost}_t = \text{OperatingCost}(t) - \text{RevenueFromFlows}(\lambda, t)
+  \mathrm{NetOperatingCost}_t = \mathrm{OperatingCost}(t) - \mathrm{RevenueFromFlows}(\lambda, t)
 \\]
 
 \\[
-  \text{FallbackCost} = \phi_{c,r,t} \cdot f_{c,\text{primary}}
+  \mathrm{FallbackCost} = \phi_{c,r,t} \cdot f_{c,\mathrm{primary}}
 \\]
 
 \\[
-  \alpha_t = \text{FallbackCost} - \text{NetOperatingCost}_t + \varepsilon
+  \alpha_t = \mathrm{FallbackCost} - \mathrm{NetOperatingCost}_t + \varepsilon
 \\]
 
-where \\( \text{RevenueFromFlows} \\) is the sum of all commodity flow revenues and costs (positive
-for outputs, negative for inputs) valued at shadow prices, \\( \text{OperatingCost} \\) is the
-variable operating cost plus levies and flow costs, \\( f_{c,\text{primary}} \\) is the primary
+where \\( \mathrm{RevenueFromFlows} \\) is the sum of all commodity flow revenues and costs (positive
+for outputs, negative for inputs) valued at shadow prices, \\( \mathrm{OperatingCost} \\) is the
+variable operating cost plus levies and flow costs, \\( f_{c,\mathrm{primary}} \\) is the primary
 output flow coefficient, and \\( \varepsilon \\) is a small positive constant added to ensure that
 break-even assets are still dispatched.
 
@@ -218,7 +218,7 @@ alternative source at the fallback price.
 The asset dispatches when \\( \alpha_t > 0 \\), i.e. when:
 
 \\[
-  \text{NetOperatingCost}_t < \text{FallbackCost}
+  \mathrm{NetOperatingCost}_t < \mathrm{FallbackCost}
 \\]
 
 \\( \phi_{c,r,t} \\) is calculated according to the strategy defined by `fallback_pricing_strategy`
@@ -238,7 +238,7 @@ The optimisation maximises the total net revenue across all time slices, subject
 constraints:
 
 \\[
-  \max \sum_t \alpha_t \cdot \text{Activity}_t
+  \max \sum_t \alpha_t \cdot \mathrm{Activity}_t
 \\]
 
 ## Metric Calculation
@@ -252,14 +252,14 @@ The market cost \\( \mu_t \\) is calculated differently depending on the objecti
 
 - **LCOX**: the net cost of operating, excluding revenues from the primary output commodity:
   \\[
-    \mu_t^\text{LCOX} = \text{OperatingCost}(t) -
-      \text{RevenueFromNonPrimaryFlows}(\pi, t)
+    \mu_t^{\mathrm{LCOX}} = \mathrm{OperatingCost}(t) -
+      \mathrm{RevenueFromNonPrimaryFlows}(\pi, t)
   \\]
 
 - **NPV**: the net cost of operating, including all commodity flows (so negative values represent
   profit):
   \\[
-    \mu_t^\text{NPV} = \text{OperatingCost}(t) - \text{RevenueFromFlows}(\pi, t)
+    \mu_t^{\mathrm{NPV}} = \mathrm{OperatingCost}(t) - \mathrm{RevenueFromFlows}(\pi, t)
   \\]
 
 ### LCOX metric (`objective_type = "lcox"`)
@@ -268,8 +268,9 @@ The LCOX metric is calculated as the total annualised cost divided by total annu
 the above defined market costs which *exclude* the primary output commodity:
 
 \\[
-  \text{LCOXMetric} = \frac{\text{AFC} \times \text{cap} + \sum_t \text{Activity}_t \times \mu_t^\text{LCOX}}
-    {\sum_t \text{Activity}_t}
+  \mathrm{LCOXMetric} = \frac{\mathrm{AFC} \times \mathrm{Capacity} + \sum_t \mathrm{Activity}_t
+  \times \mu_t^{\mathrm{LCOX}}}
+    {\sum_t \mathrm{Activity}_t}
 \\]
 
 Lower values indicate lower-cost investments.
@@ -280,8 +281,8 @@ The NPV metric is based on the Specific Net Annualised Surplus (SNAS). This the 
 unit of activity, using market costs that *include* the primary output commodity:
 
 \\[
-  \text{SNAS} = \frac{-\left(\text{AFC} \times \text{cap} + \sum_t \text{Activity}_t \times
-    \mu_t^\text{NPV}\right)}{\sum_t \text{Activity}_t}
+  \mathrm{SNAS} = \frac{-\left(\mathrm{AFC} \times \mathrm{Capacity} + \sum_t \mathrm{Activity}_t \times
+    \mu_t^{\mathrm{NPV}}\right)}{\sum_t \mathrm{Activity}_t}
 \\]
 
 Higher values indicate more profitable investments.
@@ -346,10 +347,11 @@ plant, evaluated across two time slices: \\( t_0 \\) (peak) and \\( t_1 \\) (off
 | Electricity output | \\( +1.0 \\) MWh/MWh activity | Primary output |
 | Heat output | \\( +0.5 \\) MWh/MWh activity | By-product |
 | Natural gas input | \\( -2.5 \\) MWh/MWh activity | Fuel |
-| \\( \text{OperatingCost} \\) | £5/MWh activity | Constant across time slices |
+| \\( \mathrm{OperatingCost} \\) | £5/MWh activity | Constant across time slices |
 <!-- markdownlint-enable MD013 -->
 
-All per-flow costs (\\( cost_\text{input} \\), \\( cost_\text{output} \\)) are zero.
+All per-flow costs (\\( \mathrm{cost}\_{\mathrm{input}} \\),
+\\( \mathrm{cost}\_{\mathrm{output}} \\)) are zero.
 
 #### Fixed costs and capacity
 
@@ -382,11 +384,12 @@ Activity coefficients use shadow prices:
 = \text{£}{-10}\text{/MWh}
 \\]
 
-The optimiser maximises \\( 10 \cdot act_{t_0} + (-10) \cdot act_{t_1} \\), so it prefers to
-dispatch during \\( t_0 \\) and minimise activity during \\( t_1 \\), subject to demand and
-availability constraints.
+The optimiser maximises \\( 10 \cdot \mathrm{Activity}_{t_0} + (-10) \cdot \mathrm{Activity}_{t_1} \\),
+so it prefers to dispatch during \\( t_0 \\) and minimise activity during \\( t_1 \\), subject to
+demand and availability constraints.
 
-Suppose the optimiser determines \\( act_{t_0} = 80 \\) MWh and \\( act_{t_1} = 20 \\) MWh.
+Suppose the optimiser determines \\( \mathrm{Activity}_{t_0} = 80 \\) MWh and
+\\( \mathrm{Activity}_{t_1} = 20 \\) MWh.
 
 ### LCOX Metric
 
@@ -394,15 +397,15 @@ Suppose the optimiser determines \\( act_{t_0} = 80 \\) MWh and \\( act_{t_1} = 
 
 \\[
 \begin{aligned}
-\mu_{t_0}^\text{LCOX} &= 5 + (2.5 \times 35) - (0.5 \times 25) = \text{£80/MWh} \\\\
-\mu_{t_1}^\text{LCOX} &= 5 + (2.5 \times 25) - (0.5 \times 15) = \text{£60/MWh}
+\mu_{t_0}^{\mathrm{LCOX}} &= 5 + (2.5 \times 35) - (0.5 \times 25) = \text{£80/MWh} \\\\
+\mu_{t_1}^{\mathrm{LCOX}} &= 5 + (2.5 \times 25) - (0.5 \times 15) = \text{£60/MWh}
 \end{aligned}
 \\]
 
 **Cost Index:**
 \\[
 \begin{aligned}
-\text{CostIndex} &= \frac{(1{,}000 \times 100) + (80 \times 80) + (20 \times 60)}{80 + 20} \\\\
+\mathrm{CostIndex} &= \frac{(1{,}000 \times 100) + (80 \times 80) + (20 \times 60)}{80 + 20} \\\\
 &= \text{£1,076/MWh}
 \end{aligned}
 \\]
@@ -413,16 +416,16 @@ Suppose the optimiser determines \\( act_{t_0} = 80 \\) MWh and \\( act_{t_1} = 
 
 \\[
 \begin{aligned}
-\mu_{t_0}^\text{NPV} &= 5 - (1.0 \times 90) - (0.5 \times 25) + (2.5 \times 35)
+\mu_{t_0}^{\mathrm{NPV}} &= 5 - (1.0 \times 90) - (0.5 \times 25) + (2.5 \times 35)
 = \text{£}{-10}\text{/MWh} \\\\
-\mu_{t_1}^\text{NPV} &= 5 - (1.0 \times 50) - (0.5 \times 15) + (2.5 \times 25) = \text{£10/MWh}
+\mu_{t_1}^{\mathrm{NPV}} &= 5 - (1.0 \times 50) - (0.5 \times 15) + (2.5 \times 25) = \text{£10/MWh}
 \end{aligned}
 \\]
 
 **SNAS:**
 \\[
 \begin{aligned}
-\text{SNAS} &= \frac{-\left[(1{,}000 \times 100) + (80 \times (-10)) + (20 \times 10)\right]}
+\mathrm{SNAS} &= \frac{-\left[(1{,}000 \times 100) + (80 \times (-10)) + (20 \times 10)\right]}
 {80 + 20} \\\\
 &= \text{£}{-994}\text{/MWh}
 \end{aligned}
@@ -460,18 +463,17 @@ markets have been invested in.
 ### Capacity flexibility in circularities
 
 When markets form a cycle, the partial dispatch after each market in the cycle uses **flexible
-capacity variables** for all newly committed assets in the cycle. Rather
-than fixing the capacity of these assets at their committed value, the solver may adjust capacity
-within the bounds:
+capacity variables** for all newly committed assets in the cycle. Rather than fixing the capacity of
+these assets at their committed value, the solver may adjust capacity within the bounds:
 
 \\[
-  \bigl[(1 - \text{capacity\_margin}) \cdot cap_a, \space
-        (1 + \text{capacity\_margin}) \cdot cap_a\bigr]
+  \bigl[(1 - \mathrm{capacity\_margin}) \cdot \mathrm{Capacity}_a, \space
+        (1 + \mathrm{capacity\_margin}) \cdot \mathrm{Capacity}_a\bigr]
 \\]
 
-where \\( cap_a \\) is the committed capacity of asset \\( a \\). The upper bound is additionally
-capped by the asset's `MaxInstallableCapacity`. This allows the dispatch to absorb small demand
-shifts caused by subsequent markets in the cycle.
+where \\( \mathrm{Capacity}\_a \\) is the committed capacity of asset \\( a \\). The upper bound is
+additionally capped by the asset's `MaxInstallableCapacity`. This allows the dispatch to absorb
+small demand shifts caused by subsequent markets in the cycle.
 
 Each flexible capacity variable enters the dispatch objective with a cost coefficient equal to the
 asset's AFC (annualised capital cost plus fixed O&M).

--- a/docs/model/investment.md
+++ b/docs/model/investment.md
@@ -20,10 +20,10 @@ investment in electricity generation would happen before investment in gas produ
 This ordering ensures that when an upstream market is being invested in, the
 demand created by already-committed downstream assets is already known.
 
-After each commodity market is settled, a dispatch is run over all assets selected so far. This
-quantifies the input commodity flows consumed by newly committed assets — for example, a gas
-generator committed during electricity market investment will consume gas, creating demand that
-the gas market investment must subsequently meet.
+After each commodity market is settled, a [partial system dispatch](#partial-system-dispatch) is
+run over all assets selected so far. This quantifies the input commodity flows consumed by newly
+committed assets — for example, a gas generator committed during electricity market investment will
+consume gas, creating demand that the gas market investment must subsequently meet.
 
 Only commodities of type `ServiceDemand` and `SupplyEqualsDemand` are subject to
 investment decisions. Other commodity types (e.g. `OTH`) are excluded.
@@ -35,11 +35,11 @@ investment decisions. Other commodity types (e.g. `OTH`) are excluded.
 
 When commodity markets form a cycle (e.g. electricity → hydrogen → electricity), the markets in
 the cycle are resolved in sequence within one pass. After each market in the cycle is visited, a
-dispatch is run to rebalance demand. Newly committed assets within the cycle are given limited
-capacity flexibility, controlled by the `capacity_margin` parameter (defined in
-[`model.toml`][model-toml]), to absorb small demand shifts caused by later markets in the cycle.
-If these shifts exceed `capacity_margin`, the simulation terminates with an error, and the user
-should increase this parameter.
+[partial system dispatch](#partial-system-dispatch) is run to rebalance demand. Newly committed
+assets within the cycle are given limited capacity flexibility, controlled by the `capacity_margin`
+parameter (defined in [`model.toml`][model-toml]), to absorb small demand shifts caused by later
+markets in the cycle. If these shifts exceed `capacity_margin`, the simulation terminates with an
+error, and the user should increase this parameter.
 
 ## Commodity Prices Used in Appraisal
 
@@ -429,8 +429,67 @@ The negative SNAS indicates that at current market prices, this asset does not g
 over its annualised costs. It would still be selected if it has the highest SNAS among all
 available options.
 
+## Partial System Dispatch
+
+After each commodity market is settled during the investment loop, a **partial system dispatch** is
+run over all assets selected so far. This is a standard [dispatch optimisation][dispatch-optimisation]
+solve, with three key modifications described below.
+
+### Market subset
+
+Only the commodity markets visited so far — i.e. the current market and all those settled in
+earlier investment rounds — are subject to commodity balance constraints. Markets that are upstream
+of the current investment frontier are not yet constrained, because no assets have been committed
+to serve them yet.
+
+### Input prices for upstream commodities
+
+Because upstream markets are unconstrained, their commodities have no balance constraints and
+therefore no shadow prices in this dispatch. Without any signal on the cost of upstream inputs,
+those inputs would appear free to the solver.
+
+To avoid this, the shadow prices \\( \lambda_{c,r,t} \\) from the previous MSY (see
+[Commodity Prices Used in Appraisal](#commodity-prices-used-in-appraisal)) are passed as explicit
+cost penalties on any input flows corresponding to upstream, unconstrained commodities. This ensures
+the dispatch correctly accounts for the cost of consuming upstream resources, even before those
+markets have been invested in.
+
+### Capacity flexibility in circularities
+
+When markets form a cycle, the partial dispatch after each market in the cycle uses **flexible
+capacity variables** for all newly committed assets in the cycle. Rather
+than fixing the capacity of these assets at their committed value, the solver may adjust capacity
+within the bounds:
+
+\\[
+  \bigl[(1 - \text{capacity\_margin}) \cdot cap_a, \space
+        (1 + \text{capacity\_margin}) \cdot cap_a\bigr]
+\\]
+
+where \\( cap_a \\) is the committed capacity of asset \\( a \\). The upper bound is additionally
+capped by the asset's `MaxInstallableCapacity`. This allows the dispatch to absorb small demand
+shifts caused by subsequent markets in the cycle.
+
+Each flexible capacity variable enters the dispatch objective with a cost coefficient equal to the
+asset's AFC (annualised capital cost plus fixed O&M).
+
+If the demand shift for a previously settled market in the cycle exceeds what the flexible capacity
+can accommodate, the simulation terminates with an error. The user should increase the
+`capacity_margin` parameter (defined in [`model.toml`][model-toml]) in this case.
+
+### Using the partial dispatch result
+
+The flow map from the partial dispatch is used to update the **net demand** seen by each upstream
+market. For each newly committed asset, its input commodity flows are added to the demand for the
+corresponding upstream markets, and its primary output flows reduce the remaining demand for the
+current market. Only primary output flows are counted against demand; secondary outputs do not
+affect the demand targets of other commodity markets. These updated demands then drive the next
+investment decisions as the process moves along the investment order, with each market's committed
+assets shaping the demand seen by those upstream.
+
 [framework-overview]: index.html#framework-overview
 [prices]: ./prices.md
 [model-toml]: ../file_formats/input_files.md#model-parameters-modeltoml
 [processes-csv]: ../file_formats/input_files.md#processescsv
 [process-investment-constraints-csv]: ../file_formats/input_files.md#process_investment_constraintscsv
+[dispatch-optimisation]: ./dispatch_optimisation.md

--- a/docs/model/prices.md
+++ b/docs/model/prices.md
@@ -35,13 +35,14 @@ shared between outputs according to output flow coefficients.
 The generic activity cost comprises all operating expenditures, input purchases, and flow costs/levies
 not associated with specific SED/SVD outputs:
 \\[
-\text{GenericActivityCost} = \text{VariableOpex} + \text{InputPurchases} + \sum \text{GenericFlowCosts}
+\mathrm{GenericActivityCost} = \mathrm{VariableOpex} + \mathrm{InputPurchases} + \sum \mathrm{GenericFlowCosts}
 \\]
 
 This is shared equally over all SED/SVD outputs in proportion to their output coefficients to
 compute a generic cost per unit of output flow:
 \\[
-\text{GenericCostPerOutput} = \frac{\text{GenericActivityCost}}{\sum_{c \in \text{SED, SVD}} \text{OutputCoefficient}_c}
+\mathrm{GenericCostPerOutput} = \frac{\mathrm{GenericActivityCost}}{\sum_{c \in \mathrm{SED,\,SVD}}
+\mathrm{OutputCoefficient}_c}
 \\]
 
 #### Marginal Cost
@@ -49,7 +50,7 @@ compute a generic cost per unit of output flow:
 The marginal cost of an output commodity \\( c \\) is the sum of the generic cost per output and any
 commodity-specific costs (e.g., production levies, flow costs):
 \\[
-\text{MarginalCost}_c = \text{GenericCostPerOutput} + \text{SpecificCostPerOutput}_c
+\mathrm{MarginalCost}_c = \mathrm{GenericCostPerOutput} + \mathrm{SpecificCostPerOutput}_c
 \\]
 
 #### Full Cost
@@ -58,23 +59,23 @@ The full cost includes the marginal cost plus annualised capital and fixed opera
 
 Annualised capital costs are calculated using the [Capital Recovery Factor] (CRF):
 \\[
-\text{AnnualCapitalCostPerCapacity} = \text{TotalCapitalCostPerCapacity} \times \text{CRF}
+\mathrm{AnnualCapitalCostPerCapacity} = \mathrm{TotalCapitalCostPerCapacity} \times \mathrm{CRF}
 \\]
 
 The annualised fixed cost (AFC) is:
 \\[
-\text{AFC} = (\text{AnnualCapitalCostPerCapacity} + \text{AnnualFixedOpex}) \times \text{TotalCapacity}
+\mathrm{AFC} = (\mathrm{AnnualCapitalCostPerCapacity} + \mathrm{AnnualFixedOpex}) \times \mathrm{TotalCapacity}
 \\]
 
 This is divided by annual activity to get a cost per unit of activity:
 \\[
-\text{AnnualFixedCostPerActivity} = \frac{\text{AFC}}{\text{AnnualActivity}}
+\mathrm{AnnualFixedCostPerActivity} = \frac{\mathrm{AFC}}{\mathrm{AnnualActivity}}
 \\]
 
 This is divided again by the sum of SED/SVD output coefficients to get a cost per unit output:
 \\[
-\text{AnnualFixedCostPerOutput} = \frac{\text{AnnualFixedCostPerActivity}}{\sum_{c \in \text{SED,
-SVD}} \text{OutputCoefficient}_c}
+\mathrm{AnnualFixedCostPerOutput} =
+\frac{\mathrm{AnnualFixedCostPerActivity}}{\sum_{c \in \mathrm{SED,\,SVD}} \mathrm{OutputCoefficient}_c}
 \\]
 
 > Note: this only works if all output commodities are measured in the same energy units (e.g. PJ).
@@ -82,7 +83,7 @@ SVD}} \text{OutputCoefficient}_c}
 
 The final full cost of output commodity \\( c \\) is:
 \\[
-\text{FullCost}_c = \text{MarginalCost}_c + \text{AnnualFixedCostPerOutput}
+\mathrm{FullCost}_c = \mathrm{MarginalCost}_c + \mathrm{AnnualFixedCostPerOutput}
 \\]
 
 ### Candidate asset fallback
@@ -146,7 +147,7 @@ dispatch results).
 The asset incurs a CO₂ levy (0.04/unit) and a variable operating cost of 2.0:
 
 \\[
-\text{MarginalCost}_{\text{GASPRD}} = ( 5.113 \times 0.04) + 2.0 = 2.20452
+\mathrm{MarginalCost}_{\mathrm{GASPRD}} = ( 5.113 \times 0.04) + 2.0 = 2.20452
 \\]
 
 #### Full Cost
@@ -156,24 +157,24 @@ and a total capital cost of 10 per unit capacity:
 
 \\[
 \begin{aligned}
-\text{CRF} &= 0.11016807219 \\\\
-\text{AnnualFixedCostPerCapacity} &= (10 \times 0.11016807219 + 0.3) = 1.4016807219
+\mathrm{CRF} &= 0.11016807219 \\\\
+\mathrm{AnnualFixedCostPerCapacity} &= (10 \times 0.11016807219 + 0.3) = 1.4016807219
 \end{aligned}
 \\]
 
 Accounting for annual utilisation:
 \\[
-\text{AnnualFixedCostPerActivity} = \frac{1.4016807219}{0.20786471743} = 6.7432354044
+\mathrm{AnnualFixedCostPerActivity} = \frac{1.4016807219}{0.20786471743} = 6.7432354044
 \\]
 
 Accounting for the output coefficient:
 \\[
-\text{AnnualFixedCostPerOutput} = \frac{6.7432354044}{1} = 6.7432354044
+\mathrm{AnnualFixedCostPerOutput} = \frac{6.7432354044}{1} = 6.7432354044
 \\]
 
 The full cost is:
 \\[
-\text{FullCost}_{\text{GASPRD}} = 2.20452 + 6.7432354044 = 8.9477554044
+\mathrm{FullCost}_{\mathrm{GASPRD}} = 2.20452 + 6.7432354044 = 8.9477554044
 \\]
 
 ### GASNAT
@@ -190,9 +191,9 @@ The asset incurs a CO₂ levy (0.04/unit), a variable operating cost of 0.5 and 
 
 \\[
 \begin{aligned}
-\text{CO2Levy} &= 2.5565 \times 0.04 = 0.10226 \\\\
-\text{InputPurchases} &= 8.9477554044 \times 1.05 = 9.39514317462 \\\\
-\text{MarginalCost}_{\text{GASNAT}} &= 0.10226 + 0.5 + 9.39514317462 = 9.99740317462
+\mathrm{CO2Levy} &= 2.5565 \times 0.04 = 0.10226 \\\\
+\mathrm{InputPurchases} &= 8.9477554044 \times 1.05 = 9.39514317462 \\\\
+\mathrm{MarginalCost}_{\mathrm{GASNAT}} &= 0.10226 + 0.5 + 9.39514317462 = 9.99740317462
 \end{aligned}
 \\]
 
@@ -203,24 +204,24 @@ and a total capital cost of 7 per unit capacity:
 
 \\[
 \begin{aligned}
-\text{CRF} &= 0.11016807219 \\\\
-\text{AnnualFixedCostPerCapacity} &= (7 \times 0.11016807219 + 0.21) = 0.98117650533
+\mathrm{CRF} &= 0.11016807219 \\\\
+\mathrm{AnnualFixedCostPerCapacity} &= (7 \times 0.11016807219 + 0.21) = 0.98117650533
 \end{aligned}
 \\]
 
 Accounting for annual utilisation:
 \\[
-\text{AnnualFixedCostPerActivity} = \frac{0.98117650533}{0.2094885671} = 4.6836756722
+\mathrm{AnnualFixedCostPerActivity} = \frac{0.98117650533}{0.2094885671} = 4.6836756722
 \\]
 
 Accounting for the output coefficient:
 \\[
-\text{AnnualFixedCostPerOutput} = \frac{4.6836756722}{1} = 4.6836756722
+\mathrm{AnnualFixedCostPerOutput} = \frac{4.6836756722}{1} = 4.6836756722
 \\]
 
 The full cost is:
 \\[
-\text{FullCost}_{\text{GASNAT}} = 9.99740317462 + 4.6836756722 = 14.6810788468
+\mathrm{FullCost}_{\mathrm{GASNAT}} = 9.99740317462 + 4.6836756722 = 14.6810788468
 \\]
 
 This example illustrates the sequential nature of price calculation: the GASPRD price is

--- a/src/simulation/optimisation/constraints.rs
+++ b/src/simulation/optimisation/constraints.rs
@@ -115,7 +115,7 @@ where
 /// commodity-balance constraint added to `problem` and `keys` lists the
 /// `(commodity, region, time_selection)` entries in the same order as the rows.
 ///
-#[doc = concat!("[1]: ", crate::docs_url!("model/dispatch_optimisation.html#commodity-balance-for--cin-mathbfcmathrmsed-"))]
+#[doc = concat!("[1]: ", crate::docs_url!("model/dispatch_optimisation.html#commodity-balance-constraints"))]
 fn add_commodity_balance_constraints<'a, I>(
     problem: &mut Problem,
     variables: &VariableMap,
@@ -252,7 +252,7 @@ fn candidate_balance_epsilon(
 /// (upper and lower bounds) are added per selection; in that case the same key is
 /// stored twice to match the solver ordering.
 ///
-#[doc = concat!("[1]: ", crate::docs_url!("model/dispatch_optimisation.html#a4-constraints-capacity--availability-for-standard-assets--a-in-mathbfastd-"))]
+#[doc = concat!("[1]: ", crate::docs_url!("model/dispatch_optimisation.html#asset-activity-limits"))]
 fn add_activity_constraints<'a, I>(
     problem: &mut Problem,
     variables: &VariableMap,


### PR DESCRIPTION
# Description

Rewritten the dispatch docs from scratch to bring it in line with what we actually do. Removes a lot from the original that doesn't apply or is out of date:
- flexible assets
- trade
- pools and scopes
- a lot of the terminology didn't match up with parameter names and the code

The new documentation is way more concise and should be a lot easier to read.

Also updated the model overview, and added a section to the investment docs describing partial system dispatch. Also more consistent use of `\mathrm`

Fixes #382 
Fixes #383 

## Type of change

- [ ] Bug fix (non-breaking change to fix an issue)
- [ ] New feature (non-breaking change to add functionality)
- [ ] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [x] Documentation (improve or add documentation)

## Key checklist

- [ ] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`
- [ ] Update release notes for the latest release if this PR adds a new feature or fixes a bug
      present in the previous release

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
