### PR TITLE
Fix broken links in docs

### DIFF
--- a/.github/workflows/check-docs.yml
+++ b/.github/workflows/check-docs.yml
@@ -13,6 +13,14 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v7
+        with:
+          fetch-tags: true
+          fetch-depth: 0
+      - name: Set user name and email for git
+        run: |
+          # Needed so we can apply patches
+          git config --global user.name "GitHub Actions"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
       - uses: ./.github/actions/generate-docs
         with:
           build: all_with_old

--- a/.github/workflows/check-docs.yml
+++ b/.github/workflows/check-docs.yml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/generate-docs
+        with:
+          build: all_with_old
 
       - name: Link Checker
         id: lychee

--- a/.github/workflows/check-docs.yml
+++ b/.github/workflows/check-docs.yml
@@ -13,20 +13,10 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v7
-        with:
-          fetch-tags: true
-          fetch-depth: 0
-      - name: Set user name and email for git
-        run: |
-          # Needed so we can apply patches
-          git config --global user.name "GitHub Actions"
-          git config --global user.email "github-actions[bot]@users.noreply.github.com"
       - uses: ./.github/actions/generate-docs
-        with:
-          build: all_with_old
 
       - name: Link Checker
         id: lychee
         uses: lycheeverse/lychee-action@v2
         with:
-          args: "--verbose --no-progress --accept 200,203,503 --exclude-path ^target/ --exclude-path ^docs/ --exclude-path ^book/404.html$ './**/*.md' './**/*.html'"
+          args: "--verbose --no-progress --accept 200,203,503 --root-dir book --exclude-path ^target/ --exclude-path ^docs/ './**/*.md' './**/*.html'"

--- a/docs/api/muse2/README.md
+++ b/docs/api/muse2/README.md
@@ -4,6 +4,6 @@ This is a placeholder file for the MUSE2 API documentation. This content will be
 output of [`rustdoc`] when run by GitHub Actions.
 
 To view the latest version of the API documentation online, [see
-here](https://energysystemsmodellinglab.github.io/MUSE2/api/muse2/).
+here](https://energysystemsmodellinglab.github.io/MUSE2/dev/api/muse2/index.html).
 
 [`rustdoc`]: https://doc.rust-lang.org/rustdoc/what-is-rustdoc.html

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,10 +11,10 @@ macro_rules! docs_url {
         docs_url!("")
     };
     ($suffix:literal) => {
-        docs_url!(env!("CARGO_PKG_VERSION"), $suffix)
+        docs_url!(concat!("v", env!("CARGO_PKG_VERSION")), $suffix)
     };
     ($version:expr, $suffix:literal) => {
-        concat!(env!("CARGO_PKG_HOMEPAGE"), "/v", $version, "/", $suffix)
+        concat!(env!("CARGO_PKG_HOMEPAGE"), "/", $version, "/", $suffix)
     };
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,13 +11,10 @@ macro_rules! docs_url {
         docs_url!("")
     };
     ($suffix:literal) => {
-        concat!(
-            env!("CARGO_PKG_HOMEPAGE"),
-            "/v",
-            env!("CARGO_PKG_VERSION"),
-            "/",
-            $suffix
-        )
+        docs_url!(env!("CARGO_PKG_VERSION"), $suffix)
+    };
+    ($version:expr, $suffix:literal) => {
+        concat!(env!("CARGO_PKG_HOMEPAGE"), "/v", $version, "/", $suffix)
     };
 }
 

--- a/src/simulation/prices.rs
+++ b/src/simulation/prices.rs
@@ -1,6 +1,6 @@
 //! Code for calculating commodity prices used by the simulation.
 //!
-#![doc = concat!("See <", crate::docs_url!("/model/prices.html"), ">")]
+#![doc = concat!("See <", crate::docs_url!("dev", "model/prices.html"), ">")]
 use crate::asset::AssetRef;
 use crate::commodity::{CommodityID, CommodityMap, CommodityType, PricingStrategy};
 use crate::model::Model;


### PR DESCRIPTION
# Description

There are some broken links in the docs. Some are causing PR failures, but they don't necessarily line up with the broken links in the deployed docs. This PR will address these broken links.

~~_Opening in draft_ because the CI workflow needs to be updated so the link checker is actually checking against the equivalent of the deployed docs.~~ **Edit:** Ignoring broken links in old versions of the docs. These would be very difficult to continue to keep up to date. One problem is that this means the most recent release will include some broken links.

Fixes #1408 

## Type of change

- [ ] Bug fix (non-breaking change to fix an issue)
- [ ] New feature (non-breaking change to add functionality)
- [ ] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [ ] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`
- [ ] Update release notes for the latest release if this PR adds a new feature or fixes a bug
      present in the previous release

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
