### PR TITLE
Remove pluralizing 's' from optional plurals

### DIFF
--- a/schemas/input/commodity_levies.yaml
+++ b/schemas/input/commodity_levies.yaml
@@ -27,7 +27,7 @@ fields:
       valid year, respectively.
   - name: time_slice
     type: string
-    description: The time slices(s) to which this entry applies
+    description: The time slice(s) to which this entry applies
     notes: |
       Can be a single time slice (e.g. `winter.day`), a whole season (e.g. `winter`) or `annual`,
       representing the whole year

--- a/schemas/input/demand_slicing.yaml
+++ b/schemas/input/demand_slicing.yaml
@@ -17,7 +17,7 @@ fields:
     notes: A region ID
   - name: time_slice
     type: string
-    description: The time slices(s) to which this entry applies
+    description: The time slice(s) to which this entry applies
     notes: |
       Can be a single time slice (e.g. `winter.day`), a whole season (e.g. `winter`) or `annual`,
       representing the whole year

--- a/schemas/input/process_availabilities.yaml
+++ b/schemas/input/process_availabilities.yaml
@@ -29,7 +29,7 @@ fields:
       valid year, respectively.
   - name: time_slice
     type: string
-    description: The time slices(s) to which this entry applies
+    description: The time slice(s) to which this entry applies
     notes: |
       Can be a single time slice (e.g. `winter.day`), a season (e.g. `winter`) or `annual`. If a
       season or `annual`, this means that limit will apply to the season/year as a whole.


### PR DESCRIPTION
Fixes "slices(s)" -> "slice(s)"