### PR TITLE
Render default 404 pages correctly in docs

### DIFF
--- a/docs/move_dev_docs.py
+++ b/docs/move_dev_docs.py
@@ -2,6 +2,7 @@
 #
 # A script to move the development docs into a /dev directory
 
+import re
 import shutil
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -9,6 +10,33 @@ from tempfile import TemporaryDirectory
 from release import get_releases
 
 REPO_ROOT = Path(__file__).parent.parent.absolute()
+
+
+def write_root_404(bookdir: Path) -> None:
+    """Generate book/404.html from book/dev/404.html with corrected asset paths."""
+    content = (bookdir / "dev" / "404.html").read_text(encoding="utf-8")
+
+    # Replace base href with the GitHub Pages project root
+    content = re.sub(r'<base\s+href="[^"]*"\s*/?>', '<base href="/MUSE2/">', content)
+
+    # Prefix all relative href/src values with dev/
+    content = re.sub(
+        r'((?:href|src)=")((?!(?:https?:|//|#|/)))',
+        r"\1dev/\2",
+        content,
+    )
+
+    # Fix JS path variables
+    content = content.replace(
+        'const path_to_root = "";', 'const path_to_root = "dev/";'
+    )
+    content = content.replace('var pathToRoot = "";', 'var pathToRoot = "dev/";')
+    content = content.replace(
+        'window.path_to_searchindex_js = "',
+        'window.path_to_searchindex_js = "dev/',
+    )
+
+    (bookdir / "404.html").write_text(content, encoding="utf-8")
 
 
 def move_to_dev() -> None:
@@ -29,6 +57,9 @@ def move_to_dev() -> None:
         content="0; URL=./{get_releases()[0]}/index.html"
     />
 </head>""")
+
+    # Create a fix for the 404 routing
+    write_root_404(bookdir)
 
 
 if __name__ == "__main__":

--- a/docs/move_dev_docs.py
+++ b/docs/move_dev_docs.py
@@ -31,9 +31,10 @@ def write_root_404(bookdir: Path) -> None:
         'const path_to_root = "";', 'const path_to_root = "dev/";'
     )
     content = content.replace('var pathToRoot = "";', 'var pathToRoot = "dev/";')
-    content = content.replace(
-        'window.path_to_searchindex_js = "',
-        'window.path_to_searchindex_js = "dev/',
+    content = re.sub(
+        r'(window\.path_to_searchindex_js\s*=\s*")(?!dev/)',
+        r"\1dev/",
+        content,
     )
 
     (bookdir / "404.html").write_text(content, encoding="utf-8")


### PR DESCRIPTION
# Description

This PR should fix the fact the 404 pages are not displaying at all now (and were not rendering properly before). It will use

It's hard to test locally, the best approach I found was to do the following (order is important!):
1. `mdbook serve -o`
2. `just build-docs all_with_old`
3. Change line 7 in `book/404.html` to `<base href="/">` (it is how it is to be compatible with the GitHub Pages deployment)
4. Navigate to a bad path (ie `http://localhost:3000/dev/bad-path/bad.html`)

Fixes #1390

## Type of change

- [ ] Bug fix (non-breaking change to fix an issue)
- [ ] New feature (non-breaking change to add functionality)
- [ ] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [ ] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`
- [ ] Update release notes for the latest release if this PR adds a new feature or fixes a bug
      present in the previous release

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
