### PR TITLE
Allow for wider tables in docs

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -6,3 +6,4 @@ title = "MUSE2"
 
 [output.html]
 mathjax-support = true
+additional-css = ["theme/custom.css"]

--- a/theme/custom.css
+++ b/theme/custom.css
@@ -1,8 +1,8 @@
 /* Allow tables to break out of the text column and use the full page content area */
-@media only screen and (min-width: 1200px) {
+@media only screen {
     .content main .table-wrapper {
-        /* 150px matches .nav-chapters max-width */
-        --_nav-clearance: 150px;
+        /* 100px matches .nav-chapters max-width */
+        --_nav-clearance: 100px;
         --_table-max: calc(100vw - 2 * (var(--page-padding) + 5px) - 2 * var(--_nav-clearance));
         width: max-content;
         max-width: var(--_table-max);
@@ -14,6 +14,20 @@
     /* mdBook adds sidebar-visible to <html> when the sidebar is open */
     .sidebar-visible .content main .table-wrapper {
         --_table-max: calc(100vw - var(--sidebar-width) - 2 * (var(--page-padding) + 5px) - 2 * var(--_nav-clearance));
+    }
+}
+
+/* mdBook hides nav-wide-wrapper when sidebar is open below 1380px */
+@media only screen and (max-width: 1380px) {
+    .sidebar-visible .content main .table-wrapper {
+        --_nav-clearance: 0px;
+    }
+}
+
+/* mdBook hides nav-wide-wrapper when sidebar is closed below 1080px */
+@media only screen and (max-width: 1080px) {
+    .content main .table-wrapper {
+        --_nav-clearance: 0px;
     }
 }
 

--- a/theme/custom.css
+++ b/theme/custom.css
@@ -16,3 +16,7 @@
         --_table-max: calc(100vw - var(--sidebar-width) - 2 * (var(--page-padding) + 5px) - 2 * var(--_nav-clearance));
     }
 }
+
+.content main .table-wrapper {
+    font-size: 0.85em;
+}

--- a/theme/custom.css
+++ b/theme/custom.css
@@ -1,0 +1,18 @@
+/* Allow tables to break out of the text column and use the full page content area */
+@media only screen and (min-width: 1200px) {
+    .content main .table-wrapper {
+        /* 150px matches .nav-chapters max-width */
+        --_nav-clearance: 150px;
+        --_table-max: calc(100vw - 2 * (var(--page-padding) + 5px) - 2 * var(--_nav-clearance));
+        width: max-content;
+        max-width: var(--_table-max);
+        position: relative;
+        left: 50%;
+        transform: translateX(-50%);
+    }
+
+    /* mdBook adds sidebar-visible to <html> when the sidebar is open */
+    .sidebar-visible .content main .table-wrapper {
+        --_table-max: calc(100vw - var(--sidebar-width) - 2 * (var(--page-padding) + 5px) - 2 * var(--_nav-clearance));
+    }
+}


### PR DESCRIPTION
# Description

This PR allows the tables to be wider than the surrounding text content so that they are less likely to need a horizontal scroll. It also reduces the font size slightly (85% of the surrounding font).

The maximum width of the tables is now the width of screen available before the chapter navigation buttons on the sides.

Fixes #1213 

## Type of change

- [ ] Bug fix (non-breaking change to fix an issue)
- [ ] New feature (non-breaking change to add functionality)
- [ ] Refactoring (non-breaking, non-functional change to improve maintainability)
- [ ] Optimization (non-breaking change to speed up the code)
- [ ] Breaking change (whatever its nature)
- [ ] Documentation (improve or add documentation)

## Key checklist

- [ ] All tests pass: `$ cargo test`
- [ ] The documentation builds and looks OK: `$ cargo doc`
- [ ] Update release notes for the latest release if this PR adds a new feature or fixes a bug
      present in the previous release

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
